### PR TITLE
fix host test, no file, and save updates

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -34,9 +34,20 @@ pub fn get_hosts_path() -> PathBuf {
 pub fn parse_hosts_yml() -> Result<BTreeMap<String, Host>, Box<dyn std::error::Error>> {
     let path = get_hosts_path();
     log::debug!("Parsing {:?}", path);
-    let file = File::open(path)?;
-    let reader = BufReader::new(file);
-    let hosts: Result<BTreeMap<String, Host>, serde_yaml::Error> = serde_yaml::from_reader(reader);
+    let hosts = match path.is_file() {
+        true => {
+            let file = File::open(path)?;
+            let reader = BufReader::new(file);
+            let hosts: Result<BTreeMap<String, Host>, serde_yaml::Error> =
+                serde_yaml::from_reader(reader);
+            hosts
+        }
+        false => {
+            log::info!("No hosts, file creating {:?}", path);
+            File::create(path)?;
+            Ok(BTreeMap::new())
+        }
+    };
     Ok(hosts?)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,26 +160,26 @@ async fn main() {
             save,
         } => {
             log::info!("Configuring host {name}");
-            // Fix misleading error message when either host and app are missing
-            let url = url.clone().expect("Host URL must be specified");
-            let host = match Host::get_known(name) {
-                Some(host) => host,
-                None => match app {
+            let host = match app.is_some() && url.is_some() {
+                false => match Host::get_known(&name) {
+                    Some(host) => host,
                     None => {
-                        log::error!("Application must be specified for new host configurations");
+                        log::error!(
+                            "Application and URL must be specified for new host configurations"
+                        );
                         return;
                     }
-                    Some(app) => Host::new(
-                        url,
-                        app.clone(),
-                        auth.clone(),
-                        accept_invalid_certs.clone(),
-                        apikey.clone(),
-                        cloud_id.clone(),
-                        username.clone(),
-                        password.clone(),
-                    ),
                 },
+                true => Host::new(
+                    url.clone().unwrap(),
+                    app.clone().unwrap(),
+                    auth.clone(),
+                    accept_invalid_certs.clone(),
+                    apikey.clone(),
+                    cloud_id.clone(),
+                    username.clone(),
+                    password.clone(),
+                ),
             };
 
             let valid_connection = match host.test().await {
@@ -193,7 +193,7 @@ async fn main() {
                 Err(e) => {
                     log::error!("Host connection: FAILED ❌ {}", &e);
                     log::debug!("{:?}", e);
-                    log::warn!("Check your certificates!");
+                    log::warn!("Check your URL and certificates!");
                     false
                 }
             };


### PR DESCRIPTION
The `host test` was broken in the last commit, always requiring a URL.

The panic for not having a file is fixed, it now creates one on first run.

Saving an existing host now properly overwrites existing config.