### PR TITLE
Add initial Logstash diagnostic compatibility

### DIFF
--- a/assets/elasticsearch/component_template/esdiag@ls-mappings.json
+++ b/assets/elasticsearch/component_template/esdiag@ls-mappings.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "template": {
+    "mappings": {
+      "_routing": {
+        "required": false
+      },
+      "date_detection": false,
+      "numeric_detection": false,
+      "dynamic_date_formats": [
+        "strict_date_optional_time",
+        "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"
+      ],
+      "_source": {
+        "excludes": [],
+        "includes": [],
+        "mode": "synthetic"
+      },
+      "dynamic": true,
+      "dynamic_templates": [
+        {
+          "strings_as_keywords": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "match_mapping_type": "string"
+          }
+        },
+        {
+          "long_metrics": {
+            "mapping": {
+              "index": false,
+              "type": "long"
+            },
+            "match_mapping_type": "long"
+          }
+        },
+        {
+          "float_metrics": {
+            "mapping": {
+              "index": false,
+              "type": "float"
+            },
+            "match_mapping_type": "double"
+          }
+        },
+        {
+          "double_metrics": {
+            "mapping": {
+              "index": false,
+              "type": "double"
+            }
+          }
+        }
+      ],
+      "properties": {
+        "data_stream": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "constant_keyword",
+              "value": "metrics"
+            },
+            "namespace": {
+              "type": "constant_keyword",
+              "value": "esdiag"
+            }
+          }
+        }
+      }
+    }
+  },
+  "_meta": {
+    "managed": false,
+    "description": "Default metadat mapping for esdiag Logstash templates"
+  }
+}

--- a/assets/elasticsearch/component_template/esdiag@ls-metadata.json
+++ b/assets/elasticsearch/component_template/esdiag@ls-metadata.json
@@ -1,0 +1,52 @@
+{
+  "template": {
+    "mappings": {
+      "dynamic_date_formats": [
+        "strict_date_optional_time",
+        "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"
+      ],
+      "properties": {
+        "diagnostic": {
+          "type": "object",
+          "properties": {
+            "node": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "inputs": {
+              "type": "match_only_text"
+            },
+            "runner": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "collection_date": {
+              "format": "strict_date_optional_time||epoch_millis",
+              "index": true,
+              "ignore_malformed": false,
+              "store": false,
+              "type": "date",
+              "doc_values": true
+            },
+            "uuid": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "event": {
+          "type": "object",
+          "properties": {
+            "ingested": {
+              "type": "date"
+            }
+          }
+        }
+      }
+    }
+  },
+  "_meta": {
+    "managed": false,
+    "description": "Common mappings for the esdiag metadata"
+  }
+}

--- a/assets/elasticsearch/component_template/esdiag@mappings.json
+++ b/assets/elasticsearch/component_template/esdiag@mappings.json
@@ -142,10 +142,6 @@
         "data_stream": {
           "type": "object",
           "properties": {
-            "type": {
-              "type": "constant_keyword",
-              "value": "metrics"
-            },
             "namespace": {
               "type": "constant_keyword",
               "value": "esdiag"

--- a/assets/elasticsearch/index_template/metrics-logstash.json
+++ b/assets/elasticsearch/index_template/metrics-logstash.json
@@ -1,0 +1,44 @@
+{
+  "index_patterns": ["settings-logstash*-esdiag*"],
+  "composed_of": [
+    "esdiag@ls-mappings",
+    "esdiag@ls-metadata",
+    "esdiag@settings"
+  ],
+  "allow_auto_create": true,
+  "data_stream": {
+    "hidden": false,
+    "allow_custom_routing": false
+  },
+  "priority": 300,
+  "template": {
+    "mappings": {
+      "numeric_detection": false,
+      "dynamic": true,
+      "dynamic_templates": [
+        {
+          "strings_as_keywords": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "match_mapping_type": "string"
+          }
+        }
+      ],
+      "properties": {
+        "data_stream": {
+          "type": "object",
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword"
+            },
+            "type": {
+              "type": "constant_keyword",
+              "value": "settings"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/elasticsearch/index_template/settings-logstash.json
+++ b/assets/elasticsearch/index_template/settings-logstash.json
@@ -1,0 +1,44 @@
+{
+  "index_patterns": ["metrics-logstash*-esdiag*"],
+  "composed_of": [
+    "esdiag@ls-mappings",
+    "esdiag@ls-metadata",
+    "esdiag@settings"
+  ],
+  "allow_auto_create": true,
+  "data_stream": {
+    "hidden": false,
+    "allow_custom_routing": false
+  },
+  "priority": 300,
+  "template": {
+    "mappings": {
+      "numeric_detection": false,
+      "dynamic": true,
+      "dynamic_templates": [
+        {
+          "strings_as_keywords": {
+            "mapping": {
+              "type": "keyword"
+            },
+            "match_mapping_type": "string"
+          }
+        }
+      ],
+      "properties": {
+        "data_stream": {
+          "type": "object",
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword"
+            },
+            "type": {
+              "type": "constant_keyword",
+              "value": "metrics"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -2,6 +2,8 @@
 pub mod diagnostic;
 /// Elasticsearch data types and structures
 pub mod elasticsearch;
+/// Logstash data types and structures
+pub mod logstash;
 /// Classify an input string as a type of univeral resource identifier (URI)
 pub mod uri;
 

--- a/src/data/diagnostic.rs
+++ b/src/data/diagnostic.rs
@@ -2,8 +2,12 @@
 pub mod data_set;
 /// Trait for receiving data from a source
 pub mod data_source;
+/// Data stream naming
+pub mod data_stream_name;
 /// Modern diagnostic bundle manifest file
 pub mod diagnostic_manifest;
+/// Diagnostic metada doc
+pub mod doc;
 /// Elastic Cloud Kubernetes diagnostic bundle
 pub mod eck;
 /// Elasticsearch diagnostic bundle
@@ -16,7 +20,10 @@ pub mod logstash;
 pub mod manifest;
 
 pub use data_set::DataSet;
+pub use data_source::DataSource;
+pub use data_stream_name::DataStreamName;
 pub use diagnostic_manifest::DiagnosticManifest;
+pub use doc::DiagnosticDoc;
 pub use manifest::Manifest;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::str::FromStr;

--- a/src/data/diagnostic/data_stream_name.rs
+++ b/src/data/diagnostic/data_stream_name.rs
@@ -1,0 +1,25 @@
+use serde::Serialize;
+
+#[derive(Clone, Serialize)]
+pub struct DataStreamName {
+    dataset: String,
+    namespace: String,
+    r#type: String,
+}
+
+impl From<&str> for DataStreamName {
+    fn from(name: &str) -> Self {
+        let terms: Vec<&str> = name.split('-').collect();
+        DataStreamName {
+            r#type: terms[0].to_string(),
+            dataset: terms[1].to_string(),
+            namespace: terms[2].to_string(),
+        }
+    }
+}
+
+impl ToString for DataStreamName {
+    fn to_string(&self) -> String {
+        format!("{}-{}-{}", self.r#type, self.dataset, self.namespace)
+    }
+}

--- a/src/data/diagnostic/diagnostic_manifest.rs
+++ b/src/data/diagnostic/diagnostic_manifest.rs
@@ -1,4 +1,4 @@
-use super::{data_source::DataSource, DiagPath, Manifest, Product};
+use super::{DataSource, DiagPath, Manifest, Product};
 use crate::data::{diagnostic::DataSet, Uri};
 use color_eyre::eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
@@ -16,6 +16,17 @@ pub struct DiagnosticManifest {
     pub collection_date: String,
     /// ECK diagnostic bunldes can contain multiple stack diagnostics
     pub included_diagnostics: Option<Vec<DiagPath>>,
+    /// Name for human-readable IDs
+    pub name: Option<String>,
+}
+
+impl DiagnosticManifest {
+    pub fn with_name(self, name: String) -> Self {
+        Self {
+            name: Some(name),
+            ..self
+        }
+    }
 }
 
 impl DataSource for DiagnosticManifest {
@@ -50,6 +61,7 @@ impl From<Manifest> for DiagnosticManifest {
                 .map(|v| v.original_value.map(|v| v.to_string()).unwrap_or_default()),
             collection_date: manifest.collection_date,
             included_diagnostics: manifest.included_diagnostics,
+            name: None,
         }
     }
 }

--- a/src/data/diagnostic/doc.rs
+++ b/src/data/diagnostic/doc.rs
@@ -1,0 +1,81 @@
+use super::DiagnosticManifest;
+use chrono::{DateTime, SecondsFormat, TimeZone, Utc};
+use color_eyre::eyre::Result;
+use serde::Serialize;
+use uuid::Uuid;
+
+#[derive(Clone, Serialize)]
+pub struct DiagnosticDoc {
+    pub collection_date: i64,
+    pub runner: String,
+    pub id: String,
+    pub uuid: String,
+    pub version: Option<String>,
+}
+
+impl DiagnosticDoc {
+    pub fn new(
+        collection_date: i64,
+        id: String,
+        runner: String,
+        uuid: String,
+        version: Option<String>,
+    ) -> Self {
+        DiagnosticDoc {
+            collection_date,
+            runner,
+            id,
+            uuid,
+            version,
+        }
+    }
+}
+
+impl TryFrom<DiagnosticManifest> for DiagnosticDoc {
+    type Error = color_eyre::eyre::Report;
+
+    fn try_from(manifest: DiagnosticManifest) -> Result<Self> {
+        let collection_date = {
+            if let Ok(date) = DateTime::parse_from_rfc3339(&manifest.collection_date) {
+                date.timestamp_millis()
+            } else if let Ok(date) =
+                DateTime::parse_from_str(&manifest.collection_date, "%Y-%m-%dT%H:%M:%S%.3f%z")
+            {
+                date.timestamp_millis()
+            } else {
+                log::warn!(
+                    "Failed to parse collection date: {}",
+                    manifest.collection_date
+                );
+                chrono::Utc::now().timestamp_millis()
+            }
+        };
+
+        let collection_date_string = Utc
+            .timestamp_millis_opt(collection_date)
+            .map(|dt| dt.to_rfc3339_opts(SecondsFormat::Secs, true))
+            .unwrap();
+
+        let uuid = Uuid::new_v4().to_string();
+        // Human readable ID
+        let id = format!(
+            "{}@{}#{}",
+            manifest.name.expect("Diagnostic name not found"),
+            collection_date_string,
+            uuid.chars().take(4).collect::<String>()
+        );
+
+        let runner = match &manifest.runner {
+            Some(runner) => runner.clone(),
+            None => "Unknown".to_string(),
+        };
+
+        Ok(DiagnosticDoc::new(
+            collection_date,
+            id,
+            runner,
+            uuid,
+            manifest.version,
+        ))
+    }
+}

--- a/src/data/diagnostic/logstash.rs
+++ b/src/data/diagnostic/logstash.rs
@@ -2,13 +2,21 @@ use serde::Serialize;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum DataSet {
-    Nodes,
+    HotThreads,
+    Node,
+    NodeStats,
+    Plugins,
+    Version,
 }
 
 impl std::fmt::Display for DataSet {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            DataSet::Nodes => write!(fmt, "nodes"),
+            DataSet::HotThreads => write!(fmt, "logstash_hot_threads"),
+            DataSet::Node => write!(fmt, "logstash_node"),
+            DataSet::NodeStats => write!(fmt, "logstash_node_stats"),
+            DataSet::Plugins => write!(fmt, "logstash_plugins"),
+            DataSet::Version => write!(fmt, "logstash_version"),
         }
     }
 }

--- a/src/data/diagnostic/manifest.rs
+++ b/src/data/diagnostic/manifest.rs
@@ -1,6 +1,4 @@
-use super::{
-    data_source::DataSource, elasticsearch::ElasticsearchVersion, DataSet, DiagPath, Product,
-};
+use super::{elasticsearch::ElasticsearchVersion, DataSet, DataSource, DiagPath, Product};
 use crate::{data::elasticsearch, data::Uri};
 use color_eyre::eyre::{eyre, Result};
 use regex::Regex;

--- a/src/data/elasticsearch/aliases.rs
+++ b/src/data/elasticsearch/aliases.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, elasticsearch::DataSet},
+    diagnostic::{elasticsearch::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};

--- a/src/data/elasticsearch/cluster_settings.rs
+++ b/src/data/elasticsearch/cluster_settings.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, elasticsearch::DataSet},
+    diagnostic::{elasticsearch::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};

--- a/src/data/elasticsearch/data_streams.rs
+++ b/src/data/elasticsearch/data_streams.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, elasticsearch::DataSet},
+    diagnostic::{elasticsearch::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};
@@ -67,29 +67,5 @@ impl DataSource for DataStreams {
 
     fn name() -> String {
         format!("{}", DataSet::DataStreams)
-    }
-}
-
-#[derive(Clone, Serialize)]
-pub struct DataStreamName {
-    dataset: String,
-    namespace: String,
-    r#type: String,
-}
-
-impl From<&str> for DataStreamName {
-    fn from(name: &str) -> Self {
-        let terms: Vec<&str> = name.split('-').collect();
-        DataStreamName {
-            r#type: terms[0].to_string(),
-            dataset: terms[1].to_string(),
-            namespace: terms[2].to_string(),
-        }
-    }
-}
-
-impl ToString for DataStreamName {
-    fn to_string(&self) -> String {
-        format!("{}-{}-{}", self.r#type, self.dataset, self.namespace)
     }
 }

--- a/src/data/elasticsearch/ilm_explain.rs
+++ b/src/data/elasticsearch/ilm_explain.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, elasticsearch::DataSet},
+    diagnostic::{elasticsearch::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};

--- a/src/data/elasticsearch/indices_settings.rs
+++ b/src/data/elasticsearch/indices_settings.rs
@@ -1,6 +1,6 @@
 use super::DataStream;
 use crate::data::{
-    diagnostic::{data_source::DataSource, elasticsearch::DataSet},
+    diagnostic::{elasticsearch::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};

--- a/src/data/elasticsearch/indices_stats.rs
+++ b/src/data/elasticsearch/indices_stats.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, elasticsearch::DataSet},
+    diagnostic::{elasticsearch::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};

--- a/src/data/elasticsearch/nodes.rs
+++ b/src/data/elasticsearch/nodes.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, elasticsearch::DataSet},
+    diagnostic::{elasticsearch::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};

--- a/src/data/elasticsearch/nodes_stats.rs
+++ b/src/data/elasticsearch/nodes_stats.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, elasticsearch::DataSet},
+    diagnostic::{elasticsearch::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};

--- a/src/data/elasticsearch/searchable_snapshots_cache_stats.rs
+++ b/src/data/elasticsearch/searchable_snapshots_cache_stats.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, elasticsearch::DataSet},
+    diagnostic::{elasticsearch::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};

--- a/src/data/elasticsearch/searchable_snapshots_stats.rs
+++ b/src/data/elasticsearch/searchable_snapshots_stats.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, elasticsearch::DataSet},
+    diagnostic::{elasticsearch::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};

--- a/src/data/elasticsearch/tasks.rs
+++ b/src/data/elasticsearch/tasks.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, elasticsearch::DataSet},
+    diagnostic::{elasticsearch::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};

--- a/src/data/elasticsearch/version.rs
+++ b/src/data/elasticsearch/version.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, elasticsearch::DataSet},
+    diagnostic::{elasticsearch::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};

--- a/src/data/logstash.rs
+++ b/src/data/logstash.rs
@@ -1,0 +1,16 @@
+/// Logstash hot threads
+mod hot_threads;
+/// Logstash node settings
+mod node;
+/// Logstash node statistics
+mod node_stats;
+/// Logsstash plugins
+mod plugins;
+/// Logstash version
+mod version;
+
+pub use hot_threads::*;
+pub use node::*;
+pub use node_stats::*;
+pub use plugins::*;
+pub use version::*;

--- a/src/data/logstash/diagnostic.md
+++ b/src/data/logstash/diagnostic.md
@@ -1,0 +1,111 @@
+The Logstash diagnostic only contains five `.json` files with relevant non-duplicate data.
+
+```
+ 1. ✅ diagnostic_manifest.json
+ 2. ❌ diagnostics.log
+ 3. ❌ logstash_diagnostic_flow_metrics.html
+ 4. ✅ logstash_node.json
+ 5. ✅ logstash_node_stats.json
+ 6. ✅ logstash_nodes_hot_threads.json
+ 7. ❌ logstash_nodes_hot_threads_human.txt
+ 8. ✅ logstash_plugins.json
+ 9. ✅ logstash_version.json
+10. ☑️ manifest.json
+```
+
+The `manifest.json` is only used as a fallback if `diagnostic_manifest.json` is not present.
+
+#### logstash_version.json
+
+```yaml
+host: String,
+version: SemVer,
+http_address: IP:PORT,
+id: String,
+name: String,
+ephemeral_id: String,
+status: String,
+snapshot: boolean,
+pipeline: PipelineSettings,
+build_date: Timestamp,
+build_sha: String,
+build_snapshot: boolean,
+```
+
+**Datastream:** _None_
+
+The `logstash_version.json` is a good baseline for the document metadata.
+
+Only the `build_*` properties are not present in the other files.
+
+This can be nested inot the `logstash` property on other docs.
+
+The remaining files only list top-level properties not capture in `logstash_version.json`.
+
+#### logstash_node.json
+
+```yaml
+pipelines: HashMap<String, PipelineConfig>
+os: OSConfig,
+jvm: JVMConfig,
+```
+
+**Datastream:** `settings-logstash.node-esdiag`
+
+There is one `node` doc and fields nest under `node`.
++ Includes `build_*` properties from `logstash_version.*`
++ Includes `plugin.count` from `logstash_plugins.total`
++ Calculates `pipeline.count`
+- Extracts `pipelines`
+
+**Datastream:** `settings-logstash.pipeline-esdiag`
+
+Each `pipelines` entry is a doc with fields nested under `pipeline`.
+
+####  logstash_node_stats.json
+
+```yaml
+jvm: JVMStats,
+process: ProcessStats,
+events: EventStats,
+flow: FlowStats,
+pipelines: HashMap<PipelineStats>,
+reloads: ReloadStats,
+os: OSStats,
+queue: QueueStats,
+```
+
+**Datastream:** `metrics-logstash.node-esdiag`
+
+There is one `node` doc and fields nest under `node`.
+- Extracts `pipelines`
+
+**Datastream:** `metrics-logstash.pipeline-esdiag`
+
+Each `pipelines` entry is a doc with fields nested under `pipeline`.
+- Extracts `plugins`
+
+**Datastream:** `metrics-logstash.plugin-esdiag`
+
+Each `plugins` entry is a doc with fields nested under `plugin`.
+
+####  logstash_nodes_hot_threads.json
+
+**Datastream:** `logs-logstash.hot_threads-esdiag`
+
+```yaml
+hot_threads: HotThreads
+```
+
+Each `hot_threads` entry is a doc, with fields nested under `hot_thread`.
+
+####  logstash_plugins.json
+
+**Datastream:** `settings-logstash.plugins-esdiag`
+
+```yaml
+total: Number
+plugins: PluginList
+```
+
+Each `plugins` entry is a doc, with fields nested under `plugin`.

--- a/src/data/logstash/hot_threads.rs
+++ b/src/data/logstash/hot_threads.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, logstash::DataSet},
+    diagnostic::{logstash::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};

--- a/src/data/logstash/hot_threads.rs
+++ b/src/data/logstash/hot_threads.rs
@@ -6,7 +6,7 @@ use color_eyre::eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]
-pub struct LogstashHotThreads {
+pub struct NodeHotThreads {
     // Omitted duplicate metadata fields from deserialization
     hot_threads: HotThreads,
 }
@@ -27,7 +27,7 @@ struct Thread {
     traces: Vec<String>,
 }
 
-impl DataSource for LogstashHotThreads {
+impl DataSource for NodeHotThreads {
     fn source(uri: &Uri) -> Result<&'static str> {
         match uri {
             Uri::Directory(_) | Uri::File(_) => Ok("logstash_nodes_hot_threads.json"),

--- a/src/data/logstash/hot_threads.rs
+++ b/src/data/logstash/hot_threads.rs
@@ -1,0 +1,57 @@
+use crate::data::{
+    diagnostic::{data_source::DataSource, logstash::DataSet},
+    Uri,
+};
+use color_eyre::eyre::{eyre, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+pub struct LogstashHotThreads {
+    host: String,
+    version: String,
+    http_address: String,
+    id: String,
+    name: String,
+    ephemeral_id: String,
+    status: String,
+    snapshot: bool,
+    pipeline: Pipeline,
+    hot_threads: HotThreads,
+}
+
+#[derive(Deserialize, Serialize)]
+struct Pipeline {
+    workers: u32,
+    batch_size: u32,
+    batch_delay: u32,
+}
+
+#[derive(Deserialize, Serialize)]
+struct HotThreads {
+    time: String,
+    busiest_threads: u32,
+    threads: Vec<ThreadInfo>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ThreadInfo {
+    name: String,
+    thread_id: u32,
+    percent_of_cpu_time: f32,
+    state: String,
+    traces: Vec<String>,
+}
+
+impl DataSource for LogstashHotThreads {
+    fn source(uri: &Uri) -> Result<&'static str> {
+        match uri {
+            Uri::Directory(_) | Uri::File(_) => Ok("logstash_nodes_hot_threads.json"),
+            Uri::Host(_) | Uri::Url(_) => Ok("_node/hot_threads?threads=10000"),
+            _ => Err(eyre!("Unsupported source for Logstash hot threads ")),
+        }
+    }
+
+    fn name() -> String {
+        format!("{}", DataSet::HotThreads)
+    }
+}

--- a/src/data/logstash/hot_threads.rs
+++ b/src/data/logstash/hot_threads.rs
@@ -7,34 +7,19 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]
 pub struct LogstashHotThreads {
-    host: String,
-    version: String,
-    http_address: String,
-    id: String,
-    name: String,
-    ephemeral_id: String,
-    status: String,
-    snapshot: bool,
-    pipeline: Pipeline,
+    // Omitted duplicate metadata fields from deserialization
     hot_threads: HotThreads,
-}
-
-#[derive(Deserialize, Serialize)]
-struct Pipeline {
-    workers: u32,
-    batch_size: u32,
-    batch_delay: u32,
 }
 
 #[derive(Deserialize, Serialize)]
 struct HotThreads {
     time: String,
     busiest_threads: u32,
-    threads: Vec<ThreadInfo>,
+    threads: Vec<Thread>,
 }
 
 #[derive(Deserialize, Serialize)]
-struct ThreadInfo {
+struct Thread {
     name: String,
     thread_id: u32,
     percent_of_cpu_time: f32,

--- a/src/data/logstash/node.rs
+++ b/src/data/logstash/node.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, logstash::DataSet},
+    diagnostic::{logstash::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};

--- a/src/data/logstash/node.rs
+++ b/src/data/logstash/node.rs
@@ -9,13 +9,30 @@ use std::collections::HashMap;
 #[derive(Deserialize, Serialize)]
 pub struct LogstashNode {
     // Omitted duplicate metadata fields from deserialization
-    pipelines: HashMap<String, Pipeline>,
+    #[serde(skip_serializing)]
+    pipelines: Option<HashMap<String, Pipeline>>,
     os: Os,
     jvm: Jvm,
 }
 
+impl LogstashNode {
+    pub fn get_pipeline_count(&self) -> u32 {
+        match self.pipelines {
+            Some(ref pipelines) => pipelines.len() as u32,
+            None => 0,
+        }
+    }
+
+    pub fn take_pipelines(&mut self) -> HashMap<String, Pipeline> {
+        match self.pipelines.take() {
+            Some(pipelines) => pipelines,
+            None => HashMap::new(),
+        }
+    }
+}
+
 #[derive(Deserialize, Serialize)]
-struct Pipeline {
+pub struct Pipeline {
     ephemeral_id: String,
     hash: String,
     workers: u32,

--- a/src/data/logstash/node.rs
+++ b/src/data/logstash/node.rs
@@ -1,0 +1,84 @@
+use crate::data::{
+    diagnostic::{data_source::DataSource, logstash::DataSet},
+    Uri,
+};
+use color_eyre::eyre::{eyre, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Deserialize, Serialize)]
+pub struct LogstashNode {
+    host: String,
+    version: String,
+    http_address: String,
+    id: String,
+    name: String,
+    ephemeral_id: String,
+    status: String,
+    snapshot: bool,
+    pipeline: Pipeline,
+    pipelines: HashMap<String, PipelineConfig>,
+    os: OS,
+    jvm: JVM,
+}
+
+#[derive(Deserialize, Serialize)]
+struct Pipeline {
+    workers: u32,
+    batch_size: u32,
+    batch_delay: u32,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PipelineConfig {
+    ephemeral_id: String,
+    hash: String,
+    workers: u32,
+    batch_size: u32,
+    batch_delay: u32,
+    config_reload_automatic: bool,
+    config_reload_interval: u64,
+    dead_letter_queue_enabled: bool,
+}
+
+#[derive(Deserialize, Serialize)]
+struct OS {
+    name: String,
+    arch: String,
+    version: String,
+    available_processors: u32,
+}
+
+#[derive(Deserialize, Serialize)]
+struct JVM {
+    pid: u32,
+    version: String,
+    vm_version: String,
+    vm_vendor: String,
+    vm_name: String,
+    start_time_in_millis: u64,
+    mem: Memory,
+    gc_collectors: Vec<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct Memory {
+    heap_init_in_bytes: u64,
+    heap_max_in_bytes: u64,
+    non_heap_init_in_bytes: u64,
+    non_heap_max_in_bytes: u64,
+}
+
+impl DataSource for LogstashNode {
+    fn source(uri: &Uri) -> Result<&'static str> {
+        match uri {
+            Uri::Directory(_) | Uri::File(_) => Ok("logstash_node.json"),
+            Uri::Host(_) | Uri::Url(_) => Ok("_node"),
+            _ => Err(eyre!("Unsupported source for Logstash node")),
+        }
+    }
+
+    fn name() -> String {
+        format!("{}", DataSet::Node)
+    }
+}

--- a/src/data/logstash/node.rs
+++ b/src/data/logstash/node.rs
@@ -8,29 +8,14 @@ use std::collections::HashMap;
 
 #[derive(Deserialize, Serialize)]
 pub struct LogstashNode {
-    host: String,
-    version: String,
-    http_address: String,
-    id: String,
-    name: String,
-    ephemeral_id: String,
-    status: String,
-    snapshot: bool,
-    pipeline: Pipeline,
-    pipelines: HashMap<String, PipelineConfig>,
-    os: OS,
-    jvm: JVM,
+    // Omitted duplicate metadata fields from deserialization
+    pipelines: HashMap<String, Pipeline>,
+    os: Os,
+    jvm: Jvm,
 }
 
 #[derive(Deserialize, Serialize)]
 struct Pipeline {
-    workers: u32,
-    batch_size: u32,
-    batch_delay: u32,
-}
-
-#[derive(Deserialize, Serialize)]
-struct PipelineConfig {
     ephemeral_id: String,
     hash: String,
     workers: u32,
@@ -39,10 +24,12 @@ struct PipelineConfig {
     config_reload_automatic: bool,
     config_reload_interval: u64,
     dead_letter_queue_enabled: bool,
+    // Not in source file
+    name: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]
-struct OS {
+struct Os {
     name: String,
     arch: String,
     version: String,
@@ -50,7 +37,7 @@ struct OS {
 }
 
 #[derive(Deserialize, Serialize)]
-struct JVM {
+struct Jvm {
     pid: u32,
     version: String,
     vm_version: String,

--- a/src/data/logstash/node.rs
+++ b/src/data/logstash/node.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Deserialize, Serialize)]
-pub struct LogstashNode {
+pub struct Node {
     // Omitted duplicate metadata fields from deserialization
     #[serde(skip_serializing)]
     pipelines: Option<HashMap<String, Pipeline>>,
@@ -15,7 +15,7 @@ pub struct LogstashNode {
     jvm: Jvm,
 }
 
-impl LogstashNode {
+impl Node {
     pub fn get_pipeline_count(&self) -> u32 {
         match self.pipelines {
             Some(ref pipelines) => pipelines.len() as u32,
@@ -73,7 +73,7 @@ struct Memory {
     non_heap_max_in_bytes: u64,
 }
 
-impl DataSource for LogstashNode {
+impl DataSource for Node {
     fn source(uri: &Uri) -> Result<&'static str> {
         match uri {
             Uri::Directory(_) | Uri::File(_) => Ok("logstash_node.json"),

--- a/src/data/logstash/node_stats.rs
+++ b/src/data/logstash/node_stats.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, logstash::DataSet},
+    diagnostic::{logstash::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};

--- a/src/data/logstash/node_stats.rs
+++ b/src/data/logstash/node_stats.rs
@@ -8,30 +8,15 @@ use std::collections::HashMap;
 
 #[derive(Deserialize, Serialize)]
 pub struct LogstashNodeStats {
-    host: String,
-    version: String,
-    http_address: String,
-    id: String,
-    name: String,
-    ephemeral_id: String,
-    status: String,
-    snapshot: bool,
-    pipeline: PipelineStats,
+    // Omitted duplicate metadata fields from deserialization
     jvm: JvmStats,
     process: ProcessStats,
     events: EventStats,
-    flow: FlowStats,
-    pipelines: HashMap<String, PipelineDetails>,
+    flow: HashMap<String, StatsHistory>,
+    pipelines: HashMap<String, PipelineStats>,
     reloads: ReloadStats,
     os: OsStats,
     queue: QueueStats,
-}
-
-#[derive(Deserialize, Serialize)]
-struct PipelineStats {
-    workers: u32,
-    batch_size: u32,
-    batch_delay: u32,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -119,27 +104,18 @@ struct LoadAverageStats {
 
 #[derive(Deserialize, Serialize)]
 struct EventStats {
-    r#in: usize,
-    filtered: usize,
-    out: usize,
-    duration_in_millis: usize,
-    queue_push_duration_in_millis: usize,
+    r#in: Option<usize>,
+    out: Option<usize>,
+    filtered: Option<usize>,
+    duration_in_millis: Option<usize>,
+    queue_push_duration_in_millis: Option<usize>,
 }
 
 #[derive(Deserialize, Serialize)]
-struct FlowStats {
-    input_throughput: TrailingStats,
-    filter_throughput: TrailingStats,
-    output_throughput: TrailingStats,
-    queue_backpressure: TrailingStats,
-    worker_concurrency: TrailingStats,
-}
-
-#[derive(Deserialize, Serialize)]
-struct PipelineDetails {
-    r#events: PipelineEventsStats,
-    flow: PipelineFlowStats,
-    plugins: PipelinePlugins,
+struct PipelineStats {
+    r#events: EventStats,
+    flow: HashMap<String, StatsHistory>,
+    plugins: Option<Plugins>,
     reloads: PipelineReloadStats,
     queue: PipelineQueueStats,
     hash: String,
@@ -147,55 +123,24 @@ struct PipelineDetails {
 }
 
 #[derive(Deserialize, Serialize)]
-struct PipelineEventsStats {
-    out: usize,
-    duration_in_millis: usize,
-    filtered: usize,
-    r#in: usize,
-    queue_push_duration_in_millis: usize,
+struct Plugins {
+    inputs: Vec<InputPlugin>,
+    codecs: Vec<CodecPlugin>,
+    filters: Vec<FilterPlugin>,
+    outputs: Vec<OutputPlugin>,
 }
 
 #[derive(Deserialize, Serialize)]
-struct PipelineFlowStats {
-    queue_backpressure: TrailingStats,
-    output_throughput: TrailingStats,
-    input_throughput: TrailingStats,
-    queue_persisted_growth_bytes: Option<TrailingStats>,
-    filter_throughput: TrailingStats,
-    worker_concurrency: TrailingStats,
-    queue_persisted_growth_events: Option<TrailingStats>,
-}
-
-#[derive(Deserialize, Serialize)]
-struct PipelinePlugins {
-    inputs: Vec<PluginDetails>,
-    codecs: Vec<CodecDetails>,
-    filters: Vec<FilterDetails>,
-    outputs: Vec<OutputDetails>,
-}
-
-#[derive(Deserialize, Serialize)]
-struct PluginDetails {
+struct InputPlugin {
     id: String,
-    flow: PluginFlowStats,
+    flow: HashMap<String, StatsHistory>,
     name: String,
-    events: PluginEventsStats,
+    events: EventStats,
     address: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]
-struct PluginFlowStats {
-    throughput: TrailingStats,
-}
-
-#[derive(Deserialize, Serialize)]
-struct PluginEventsStats {
-    out: usize,
-    queue_push_duration_in_millis: usize,
-}
-
-#[derive(Deserialize, Serialize)]
-struct CodecDetails {
+struct CodecPlugin {
     id: String,
     encode: CodecStats,
     name: String,
@@ -209,21 +154,15 @@ struct CodecStats {
 }
 
 #[derive(Deserialize, Serialize)]
-struct FilterDetails {
+struct FilterPlugin {
     id: String,
-    flow: FilterFlowStats,
+    flow: HashMap<String, StatsHistory>,
     name: String,
-    r#events: FilterEventsStats,
+    r#events: EventStats,
 }
 
 #[derive(Deserialize, Serialize)]
-struct FilterFlowStats {
-    worker_millis_per_event: TrailingStats,
-    worker_utilization: TrailingStats,
-}
-
-#[derive(Deserialize, Serialize)]
-struct TrailingStats {
+struct StatsHistory {
     current: OptionF64,
     last_1_minute: OptionF64,
     last_5_minutes: OptionF64,
@@ -233,33 +172,13 @@ struct TrailingStats {
 }
 
 #[derive(Deserialize, Serialize)]
-struct FilterEventsStats {
-    out: usize,
-    duration_in_millis: usize,
-    r#in: usize,
-}
-
-#[derive(Deserialize, Serialize)]
-struct OutputDetails {
+struct OutputPlugin {
     id: String,
-    flow: OutputFlowStats,
+    flow: HashMap<String, StatsHistory>,
     name: String,
-    r#events: OutputEventsStats,
+    r#events: EventStats,
     documents: Option<OutputDocumentsStats>,
     bulk_requests: Option<OutputBulkRequestsStats>,
-}
-
-#[derive(Deserialize, Serialize)]
-struct OutputFlowStats {
-    worker_millis_per_event: TrailingStats,
-    worker_utilization: TrailingStats,
-}
-
-#[derive(Deserialize, Serialize)]
-struct OutputEventsStats {
-    out: usize,
-    duration_in_millis: usize,
-    r#in: usize,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/src/data/logstash/node_stats.rs
+++ b/src/data/logstash/node_stats.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Deserialize, Serialize)]
-pub struct LogstashNodeStats {
+pub struct NodeStats {
     // Omitted duplicate metadata fields from deserialization
     jvm: JvmStats,
     process: ProcessStats,
@@ -20,7 +20,7 @@ pub struct LogstashNodeStats {
     queue: QueueStats,
 }
 
-impl LogstashNodeStats {
+impl NodeStats {
     pub fn take_pipelines(&mut self) -> Option<HashMap<String, PipelineStats>> {
         self.pipelines.take()
     }
@@ -286,7 +286,7 @@ struct QueueStats {
     events_count: usize,
 }
 
-impl DataSource for LogstashNodeStats {
+impl DataSource for NodeStats {
     fn source(uri: &Uri) -> Result<&'static str> {
         match uri {
             Uri::Directory(_) | Uri::File(_) => Ok("logstash_node_stats.json"),

--- a/src/data/logstash/node_stats.rs
+++ b/src/data/logstash/node_stats.rs
@@ -1,0 +1,399 @@
+use crate::data::{
+    diagnostic::{data_source::DataSource, logstash::DataSet},
+    Uri,
+};
+use color_eyre::eyre::{eyre, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Deserialize, Serialize)]
+pub struct LogstashNodeStats {
+    host: String,
+    version: String,
+    http_address: String,
+    id: String,
+    name: String,
+    ephemeral_id: String,
+    status: String,
+    snapshot: bool,
+    pipeline: PipelineStats,
+    jvm: JvmStats,
+    process: ProcessStats,
+    events: EventStats,
+    flow: FlowStats,
+    pipelines: HashMap<String, PipelineDetails>,
+    reloads: ReloadStats,
+    os: OsStats,
+    queue: QueueStats,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PipelineStats {
+    workers: u32,
+    batch_size: u32,
+    batch_delay: u32,
+}
+
+#[derive(Deserialize, Serialize)]
+struct JvmStats {
+    threads: ThreadStats,
+    mem: MemoryStats,
+    gc: GarbageCollectionStats,
+    uptime_in_millis: usize,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ThreadStats {
+    count: u32,
+    peak_count: u32,
+}
+
+#[derive(Deserialize, Serialize)]
+struct MemoryStats {
+    heap_used_percent: u32,
+    heap_committed_in_bytes: usize,
+    heap_max_in_bytes: usize,
+    heap_used_in_bytes: usize,
+    non_heap_used_in_bytes: usize,
+    non_heap_committed_in_bytes: usize,
+    pools: PoolsStats,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PoolsStats {
+    survivor: PoolStats,
+    young: PoolStats,
+    old: PoolStats,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PoolStats {
+    peak_used_in_bytes: usize,
+    committed_in_bytes: usize,
+    used_in_bytes: usize,
+    peak_max_in_bytes: isize,
+    max_in_bytes: isize,
+}
+
+#[derive(Deserialize, Serialize)]
+struct GarbageCollectionStats {
+    collectors: HashMap<String, CollectorStats>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct CollectorStats {
+    collection_time_in_millis: usize,
+    collection_count: u32,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ProcessStats {
+    open_file_descriptors: u32,
+    peak_open_file_descriptors: u32,
+    max_file_descriptors: u32,
+    mem: ProcessMemoryStats,
+    cpu: ProcessCpuStats,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ProcessMemoryStats {
+    total_virtual_in_bytes: usize,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ProcessCpuStats {
+    total_in_millis: usize,
+    percent: u32,
+    load_average: LoadAverageStats,
+}
+
+#[derive(Deserialize, Serialize)]
+struct LoadAverageStats {
+    #[serde(rename = "1m")]
+    one: OptionF64,
+    #[serde(rename = "5m")]
+    five: OptionF64,
+    #[serde(rename = "15m")]
+    fifteen: OptionF64,
+}
+
+#[derive(Deserialize, Serialize)]
+struct EventStats {
+    r#in: usize,
+    filtered: usize,
+    out: usize,
+    duration_in_millis: usize,
+    queue_push_duration_in_millis: usize,
+}
+
+#[derive(Deserialize, Serialize)]
+struct FlowStats {
+    input_throughput: TrailingStats,
+    filter_throughput: TrailingStats,
+    output_throughput: TrailingStats,
+    queue_backpressure: TrailingStats,
+    worker_concurrency: TrailingStats,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PipelineDetails {
+    r#events: PipelineEventsStats,
+    flow: PipelineFlowStats,
+    plugins: PipelinePlugins,
+    reloads: PipelineReloadStats,
+    queue: PipelineQueueStats,
+    hash: String,
+    ephemeral_id: String,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PipelineEventsStats {
+    out: usize,
+    duration_in_millis: usize,
+    filtered: usize,
+    r#in: usize,
+    queue_push_duration_in_millis: usize,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PipelineFlowStats {
+    queue_backpressure: TrailingStats,
+    output_throughput: TrailingStats,
+    input_throughput: TrailingStats,
+    queue_persisted_growth_bytes: Option<TrailingStats>,
+    filter_throughput: TrailingStats,
+    worker_concurrency: TrailingStats,
+    queue_persisted_growth_events: Option<TrailingStats>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PipelinePlugins {
+    inputs: Vec<PluginDetails>,
+    codecs: Vec<CodecDetails>,
+    filters: Vec<FilterDetails>,
+    outputs: Vec<OutputDetails>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PluginDetails {
+    id: String,
+    flow: PluginFlowStats,
+    name: String,
+    events: PluginEventsStats,
+    address: Option<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PluginFlowStats {
+    throughput: TrailingStats,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PluginEventsStats {
+    out: usize,
+    queue_push_duration_in_millis: usize,
+}
+
+#[derive(Deserialize, Serialize)]
+struct CodecDetails {
+    id: String,
+    encode: CodecStats,
+    name: String,
+    decode: CodecStats,
+}
+
+#[derive(Deserialize, Serialize)]
+struct CodecStats {
+    writes_in: usize,
+    duration_in_millis: usize,
+}
+
+#[derive(Deserialize, Serialize)]
+struct FilterDetails {
+    id: String,
+    flow: FilterFlowStats,
+    name: String,
+    r#events: FilterEventsStats,
+}
+
+#[derive(Deserialize, Serialize)]
+struct FilterFlowStats {
+    worker_millis_per_event: TrailingStats,
+    worker_utilization: TrailingStats,
+}
+
+#[derive(Deserialize, Serialize)]
+struct TrailingStats {
+    current: OptionF64,
+    last_1_minute: OptionF64,
+    last_5_minutes: OptionF64,
+    last_15_minutes: OptionF64,
+    last_1_hour: OptionF64,
+    lifetime: OptionF64,
+}
+
+#[derive(Deserialize, Serialize)]
+struct FilterEventsStats {
+    out: usize,
+    duration_in_millis: usize,
+    r#in: usize,
+}
+
+#[derive(Deserialize, Serialize)]
+struct OutputDetails {
+    id: String,
+    flow: OutputFlowStats,
+    name: String,
+    r#events: OutputEventsStats,
+    documents: Option<OutputDocumentsStats>,
+    bulk_requests: Option<OutputBulkRequestsStats>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct OutputFlowStats {
+    worker_millis_per_event: TrailingStats,
+    worker_utilization: TrailingStats,
+}
+
+#[derive(Deserialize, Serialize)]
+struct OutputEventsStats {
+    out: usize,
+    duration_in_millis: usize,
+    r#in: usize,
+}
+
+#[derive(Deserialize, Serialize)]
+struct OutputDocumentsStats {
+    non_retryable_failures: usize,
+    successes: usize,
+}
+
+#[derive(Deserialize, Serialize)]
+struct OutputBulkRequestsStats {
+    with_errors: u32,
+    responses: HashMap<String, u32>,
+    successes: u32,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PipelineReloadStats {
+    failures: u32,
+    last_failure_timestamp: Option<String>,
+    last_error: Option<String>,
+    successes: u32,
+    last_success_timestamp: Option<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PipelineQueueStats {
+    r#type: String,
+    capacity: Option<QueueCapacityStats>,
+    events: Option<usize>,
+    data: Option<QueueDataStats>,
+    events_count: usize,
+    queue_size_in_bytes: usize,
+    max_queue_size_in_bytes: usize,
+}
+
+#[derive(Deserialize, Serialize)]
+struct QueueCapacityStats {
+    page_capacity_in_bytes: usize,
+    max_queue_size_in_bytes: usize,
+    queue_size_in_bytes: usize,
+    max_unread_events: u32,
+}
+
+#[derive(Deserialize, Serialize)]
+struct QueueDataStats {
+    storage_type: String,
+    free_space_in_bytes: usize,
+    path: String,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ReloadStats {
+    failures: u32,
+    successes: u32,
+}
+
+#[derive(Deserialize, Serialize)]
+struct OsStats {
+    cgroup: CgroupStats,
+}
+
+#[derive(Deserialize, Serialize)]
+struct CgroupStats {
+    cpu: CpuStats,
+    cpuacct: CpuAcctStats,
+}
+
+#[derive(Deserialize, Serialize)]
+struct CpuStats {
+    cfs_period_micros: u32,
+    cfs_quota_micros: u32,
+    control_group: String,
+    stat: CpuStatDetails,
+}
+
+#[derive(Deserialize, Serialize)]
+struct CpuStatDetails {
+    time_throttled_nanos: usize,
+    number_of_elapsed_periods: u32,
+    number_of_times_throttled: u32,
+}
+
+#[derive(Deserialize, Serialize)]
+struct CpuAcctStats {
+    usage_nanos: usize,
+    control_group: String,
+}
+
+#[derive(Deserialize, Serialize)]
+struct QueueStats {
+    events_count: usize,
+}
+
+impl DataSource for LogstashNodeStats {
+    fn source(uri: &Uri) -> Result<&'static str> {
+        match uri {
+            Uri::Directory(_) | Uri::File(_) => Ok("logstash_node_stats.json"),
+            Uri::Host(_) | Uri::Url(_) => Ok("_node/stats"),
+            _ => Err(eyre!("Unsupported source for Logstash node stats")),
+        }
+    }
+
+    fn name() -> String {
+        format!("{}", DataSet::NodeStats)
+    }
+}
+
+#[derive(Serialize)]
+struct OptionF64(Option<f64>);
+
+impl From<String> for OptionF64 {
+    fn from(value: String) -> Self {
+        match value.parse::<f64>() {
+            Ok(v) => OptionF64(Some(v)),
+            Err(_) => OptionF64(None),
+        }
+    }
+}
+
+impl From<f64> for OptionF64 {
+    fn from(value: f64) -> Self {
+        OptionF64(Some(value))
+    }
+}
+
+impl<'de> Deserialize<'de> for OptionF64 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        if let Ok(value) = f64::deserialize(deserializer) {
+            Ok(OptionF64::from(value))
+        } else {
+            Ok(OptionF64(None))
+        }
+    }
+}

--- a/src/data/logstash/node_stats.rs
+++ b/src/data/logstash/node_stats.rs
@@ -13,10 +13,17 @@ pub struct LogstashNodeStats {
     process: ProcessStats,
     events: EventStats,
     flow: HashMap<String, StatsHistory>,
-    pipelines: HashMap<String, PipelineStats>,
+    #[serde(skip_serializing)]
+    pipelines: Option<HashMap<String, PipelineStats>>,
     reloads: ReloadStats,
     os: OsStats,
     queue: QueueStats,
+}
+
+impl LogstashNodeStats {
+    pub fn take_pipelines(&mut self) -> Option<HashMap<String, PipelineStats>> {
+        self.pipelines.take()
+    }
 }
 
 #[derive(Deserialize, Serialize)]
@@ -112,26 +119,33 @@ struct EventStats {
 }
 
 #[derive(Deserialize, Serialize)]
-struct PipelineStats {
+pub struct PipelineStats {
     r#events: EventStats,
     flow: HashMap<String, StatsHistory>,
-    plugins: Option<Plugins>,
+    #[serde(skip_serializing)]
+    plugins: Option<PipelinePlugins>,
     reloads: PipelineReloadStats,
     queue: PipelineQueueStats,
     hash: String,
     ephemeral_id: String,
 }
 
-#[derive(Deserialize, Serialize)]
-struct Plugins {
-    inputs: Vec<InputPlugin>,
-    codecs: Vec<CodecPlugin>,
-    filters: Vec<FilterPlugin>,
-    outputs: Vec<OutputPlugin>,
+impl PipelineStats {
+    pub fn take_plugins(&mut self) -> Option<PipelinePlugins> {
+        self.plugins.take()
+    }
 }
 
 #[derive(Deserialize, Serialize)]
-struct InputPlugin {
+pub struct PipelinePlugins {
+    pub inputs: Vec<InputPlugin>,
+    pub codecs: Vec<CodecPlugin>,
+    pub filters: Vec<FilterPlugin>,
+    pub outputs: Vec<OutputPlugin>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct InputPlugin {
     id: String,
     flow: HashMap<String, StatsHistory>,
     name: String,
@@ -140,7 +154,7 @@ struct InputPlugin {
 }
 
 #[derive(Deserialize, Serialize)]
-struct CodecPlugin {
+pub struct CodecPlugin {
     id: String,
     encode: CodecStats,
     name: String,
@@ -154,7 +168,7 @@ struct CodecStats {
 }
 
 #[derive(Deserialize, Serialize)]
-struct FilterPlugin {
+pub struct FilterPlugin {
     id: String,
     flow: HashMap<String, StatsHistory>,
     name: String,
@@ -172,7 +186,7 @@ struct StatsHistory {
 }
 
 #[derive(Deserialize, Serialize)]
-struct OutputPlugin {
+pub struct OutputPlugin {
     id: String,
     flow: HashMap<String, StatsHistory>,
     name: String,

--- a/src/data/logstash/plugins.rs
+++ b/src/data/logstash/plugins.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, logstash::DataSet},
+    diagnostic::{logstash::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};

--- a/src/data/logstash/plugins.rs
+++ b/src/data/logstash/plugins.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Debug)]
 pub struct LogstashPlugins {
     // Omitted duplicate metadata fields from deserialization
-    total: u32,
+    pub total: u32,
     plugins: Vec<Plugin>,
 }
 

--- a/src/data/logstash/plugins.rs
+++ b/src/data/logstash/plugins.rs
@@ -5,15 +5,15 @@ use crate::data::{
 use color_eyre::eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize)]
 pub struct LogstashPlugins {
     // Omitted duplicate metadata fields from deserialization
     pub total: u32,
-    plugins: Vec<Plugin>,
+    pub plugins: Vec<Plugin>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
-struct Plugin {
+#[derive(Deserialize, Serialize)]
+pub struct Plugin {
     name: String,
     version: String,
 }

--- a/src/data/logstash/plugins.rs
+++ b/src/data/logstash/plugins.rs
@@ -7,24 +7,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct LogstashPlugins {
-    host: String,
-    version: String,
-    http_address: String,
-    id: String,
-    name: String,
-    ephemeral_id: String,
-    status: String,
-    snapshot: bool,
-    pipeline: Pipeline,
+    // Omitted duplicate metadata fields from deserialization
     total: u32,
     plugins: Vec<Plugin>,
-}
-
-#[derive(Deserialize, Serialize, Debug)]
-struct Pipeline {
-    workers: u32,
-    batch_size: u32,
-    batch_delay: u32,
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/data/logstash/plugins.rs
+++ b/src/data/logstash/plugins.rs
@@ -1,0 +1,48 @@
+use crate::data::{
+    diagnostic::{data_source::DataSource, logstash::DataSet},
+    Uri,
+};
+use color_eyre::eyre::{eyre, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct LogstashPlugins {
+    host: String,
+    version: String,
+    http_address: String,
+    id: String,
+    name: String,
+    ephemeral_id: String,
+    status: String,
+    snapshot: bool,
+    pipeline: Pipeline,
+    total: u32,
+    plugins: Vec<Plugin>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+struct Pipeline {
+    workers: u32,
+    batch_size: u32,
+    batch_delay: u32,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+struct Plugin {
+    name: String,
+    version: String,
+}
+
+impl DataSource for LogstashPlugins {
+    fn source(uri: &Uri) -> Result<&'static str> {
+        match uri {
+            Uri::Directory(_) | Uri::File(_) => Ok("logstash_plugins.json"),
+            Uri::Host(_) | Uri::Url(_) => Ok("_node/plugins"),
+            _ => Err(eyre!("Unsupported source for Logstash plugins ")),
+        }
+    }
+
+    fn name() -> String {
+        format!("{}", DataSet::Plugins)
+    }
+}

--- a/src/data/logstash/plugins.rs
+++ b/src/data/logstash/plugins.rs
@@ -6,7 +6,7 @@ use color_eyre::eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]
-pub struct LogstashPlugins {
+pub struct Plugins {
     // Omitted duplicate metadata fields from deserialization
     pub total: u32,
     pub plugins: Vec<Plugin>,
@@ -18,7 +18,7 @@ pub struct Plugin {
     version: String,
 }
 
-impl DataSource for LogstashPlugins {
+impl DataSource for Plugins {
     fn source(uri: &Uri) -> Result<&'static str> {
         match uri {
             Uri::Directory(_) | Uri::File(_) => Ok("logstash_plugins.json"),

--- a/src/data/logstash/version.rs
+++ b/src/data/logstash/version.rs
@@ -1,17 +1,17 @@
 use crate::data::{
-    diagnostic::{data_source::DataSource, logstash::DataSet},
+    diagnostic::{logstash::DataSet, DataSource},
     Uri,
 };
 use color_eyre::eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct LogstashVersion {
     host: String,
     version: String,
     http_address: String,
     id: String,
-    name: String,
+    pub name: String,
     ephemeral_id: String,
     status: String,
     snapshot: bool,
@@ -21,7 +21,7 @@ pub struct LogstashVersion {
     build_snapshot: bool,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 struct Pipeline {
     workers: u32,
     batch_size: u32,

--- a/src/data/logstash/version.rs
+++ b/src/data/logstash/version.rs
@@ -1,0 +1,43 @@
+use crate::data::{
+    diagnostic::{data_source::DataSource, logstash::DataSet},
+    Uri,
+};
+use color_eyre::eyre::{eyre, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+struct Pipeline {
+    workers: u32,
+    batch_size: u32,
+    batch_delay: u32,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct LogstashVersion {
+    host: String,
+    version: String,
+    http_address: String,
+    id: String,
+    name: String,
+    ephemeral_id: String,
+    status: String,
+    snapshot: bool,
+    pipeline: Pipeline,
+    build_date: String,
+    build_sha: String,
+    build_snapshot: bool,
+}
+
+impl DataSource for LogstashVersion {
+    fn source(uri: &Uri) -> Result<&'static str> {
+        match uri {
+            Uri::Directory(_) | Uri::File(_) => Ok("logstash_version.json"),
+            Uri::Host(_) | Uri::Url(_) => Ok("/"),
+            _ => Err(eyre!("Unsupported source for Logstash version")),
+        }
+    }
+
+    fn name() -> String {
+        format!("{}", DataSet::Version)
+    }
+}

--- a/src/data/logstash/version.rs
+++ b/src/data/logstash/version.rs
@@ -16,9 +16,12 @@ pub struct LogstashVersion {
     status: String,
     snapshot: bool,
     pipeline: Pipeline,
-    build_date: String,
-    build_sha: String,
-    build_snapshot: bool,
+    #[serde(skip_serializing)]
+    pub build_date: Option<String>,
+    #[serde(skip_serializing)]
+    pub build_sha: Option<String>,
+    #[serde(skip_serializing)]
+    pub build_snapshot: bool,
 }
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/src/data/logstash/version.rs
+++ b/src/data/logstash/version.rs
@@ -6,7 +6,7 @@ use color_eyre::eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
-pub struct LogstashVersion {
+pub struct Version {
     host: String,
     version: String,
     http_address: String,
@@ -31,7 +31,7 @@ struct Pipeline {
     batch_delay: u32,
 }
 
-impl DataSource for LogstashVersion {
+impl DataSource for Version {
     fn source(uri: &Uri) -> Result<&'static str> {
         match uri {
             Uri::Directory(_) | Uri::File(_) => Ok("logstash_version.json"),

--- a/src/data/logstash/version.rs
+++ b/src/data/logstash/version.rs
@@ -6,13 +6,6 @@ use color_eyre::eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]
-struct Pipeline {
-    workers: u32,
-    batch_size: u32,
-    batch_delay: u32,
-}
-
-#[derive(Deserialize, Serialize)]
 pub struct LogstashVersion {
     host: String,
     version: String,
@@ -26,6 +19,13 @@ pub struct LogstashVersion {
     build_date: String,
     build_sha: String,
     build_snapshot: bool,
+}
+
+#[derive(Deserialize, Serialize)]
+struct Pipeline {
+    workers: u32,
+    batch_size: u32,
+    batch_delay: u32,
 }
 
 impl DataSource for LogstashVersion {

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -2,6 +2,8 @@
 pub mod elastic_cloud_kubernetes;
 /// Processors for Elasticsearch diagnostics
 pub mod elasticsearch;
+/// Processors for Logstash diagnostics
+pub mod logstash;
 /// Lookup processors
 mod lookup;
 
@@ -9,6 +11,7 @@ use std::sync::Arc;
 
 use elastic_cloud_kubernetes::ElasticCloudKubernetesDiagnostic;
 use elasticsearch::{ElasticsearchDiagnostic, Lookups};
+use logstash::LogstashDiagnostic;
 
 use crate::{
     data::diagnostic::{DiagnosticManifest, Product},
@@ -21,7 +24,7 @@ pub enum Diagnostic {
     Elasticsearch(Box<ElasticsearchDiagnostic>),
     ElasticCloudKubernetes(Box<ElasticCloudKubernetesDiagnostic>),
     //Kibana(KibanaDiagnostic)
-    //Logstash(LogstashDiagnostic)
+    Logstash(Box<LogstashDiagnostic>),
 }
 
 impl Diagnostic {
@@ -45,6 +48,10 @@ impl Diagnostic {
                     ElasticCloudKubernetesDiagnostic::new(manifest, receiver, exporter).await?;
                 Ok(Self::ElasticCloudKubernetes(diagnostic))
             }
+            Product::Logstash => {
+                let diagnostic = LogstashDiagnostic::new(manifest, receiver, exporter).await?;
+                Ok(Self::Logstash(diagnostic))
+            }
             _ => Err(eyre!("Unsupported product or diagnostic bundle")),
         }
     }
@@ -54,7 +61,7 @@ impl Diagnostic {
             Self::Elasticsearch(diagnostic) => diagnostic.run().await,
             Self::ElasticCloudKubernetes(diagnostic) => diagnostic.run().await,
             //Self::Kibana(diagnostic) => diagnostic.run().await,
-            //Self::Logstash(diagnostic) => diagnostic.run().await,
+            Self::Logstash(diagnostic) => diagnostic.run().await,
         }
     }
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -10,7 +10,7 @@ mod lookup;
 use std::sync::Arc;
 
 use elastic_cloud_kubernetes::ElasticCloudKubernetesDiagnostic;
-use elasticsearch::{ElasticsearchDiagnostic, Lookups};
+use elasticsearch::ElasticsearchDiagnostic;
 use logstash::LogstashDiagnostic;
 
 use crate::{

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -66,12 +66,8 @@ impl Diagnostic {
     }
 }
 
-trait DataProcessor<T> {
-    fn generate_docs(
-        self,
-        lookups: Arc<Lookups>,
-        metadata: Arc<T>,
-    ) -> (String, Vec<serde_json::Value>);
+trait DataProcessor<T, U> {
+    fn generate_docs(self, lookups: Arc<T>, metadata: Arc<U>) -> (String, Vec<serde_json::Value>);
 }
 
 trait DiagnosticProcessor {

--- a/src/processor/elasticsearch.rs
+++ b/src/processor/elasticsearch.rs
@@ -21,7 +21,7 @@ use super::{lookup::Lookup, DataProcessor, DiagnosticProcessor, Metadata};
 use crate::{
     data::{
         self,
-        diagnostic::{data_source::DataSource, elasticsearch::DataSet, DiagnosticManifest},
+        diagnostic::{elasticsearch::DataSet, DataSource, DiagnosticManifest},
         elasticsearch::{
             Alias, AliasList, Cluster, ClusterSettings, DataStream, DataStreams, IlmExplain,
             IlmStats, IndexSettings, IndicesSettings, IndicesStats, Nodes, NodesStats,

--- a/src/processor/elasticsearch.rs
+++ b/src/processor/elasticsearch.rs
@@ -155,7 +155,7 @@ type DataProcessorTask = Pin<Box<JoinHandle<usize>>>;
 
 fn spawn_processor<T>(diagnostic: Arc<ElasticsearchDiagnostic>) -> DataProcessorTask
 where
-    T: DataSource + DataProcessor<ElasticsearchMetadata> + DeserializeOwned + Send + Sync,
+    T: DataSource + DataProcessor<Lookups, ElasticsearchMetadata> + DeserializeOwned + Send + Sync,
 {
     let lookups = diagnostic.lookups.clone();
     let metadata = diagnostic.metadata.clone();

--- a/src/processor/elasticsearch/cluster_settings.rs
+++ b/src/processor/elasticsearch/cluster_settings.rs
@@ -12,7 +12,7 @@ const DEFAULT: &str = "default";
 const PERSISTENT: &str = "persistent";
 const TRANSIENT: &str = "transient";
 
-impl DataProcessor<ElasticsearchMetadata> for ClusterSettings {
+impl DataProcessor<Lookups, ElasticsearchMetadata> for ClusterSettings {
     fn generate_docs(
         self,
         _lookups: Arc<Lookups>,

--- a/src/processor/elasticsearch/cluster_settings.rs
+++ b/src/processor/elasticsearch/cluster_settings.rs
@@ -1,6 +1,6 @@
 use super::{DataProcessor, ElasticsearchMetadata, Lookups};
 use crate::{
-    data::elasticsearch::{ClusterSettings, DataStreamName},
+    data::{diagnostic::DataStreamName, elasticsearch::ClusterSettings},
     processor::Metadata,
 };
 use json_patch::merge;

--- a/src/processor/elasticsearch/index_settings.rs
+++ b/src/processor/elasticsearch/index_settings.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use serde_json::Value;
 use std::sync::Arc;
 
-impl DataProcessor<ElasticsearchMetadata> for IndicesSettings {
+impl DataProcessor<Lookups, ElasticsearchMetadata> for IndicesSettings {
     fn generate_docs(
         mut self,
         lookups: Arc<Lookups>,

--- a/src/processor/elasticsearch/index_stats.rs
+++ b/src/processor/elasticsearch/index_stats.rs
@@ -5,7 +5,7 @@ use rayon::prelude::*;
 use serde_json::{json, Value};
 use std::sync::Arc;
 
-impl DataProcessor<ElasticsearchMetadata> for IndicesStats {
+impl DataProcessor<Lookups, ElasticsearchMetadata> for IndicesStats {
     fn generate_docs(
         self,
         lookups: Arc<Lookups>,

--- a/src/processor/elasticsearch/nodes.rs
+++ b/src/processor/elasticsearch/nodes.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use std::sync::Arc;
 
-impl DataProcessor<ElasticsearchMetadata> for Nodes {
+impl DataProcessor<Lookups, ElasticsearchMetadata> for Nodes {
     fn generate_docs(
         self,
         lookups: Arc<Lookups>,

--- a/src/processor/elasticsearch/nodes_stats.rs
+++ b/src/processor/elasticsearch/nodes_stats.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, LazyLock};
 
 static INGEST_ROLE: LazyLock<String> = LazyLock::new(|| String::from("ingest"));
 
-impl DataProcessor<ElasticsearchMetadata> for NodesStats {
+impl DataProcessor<Lookups, ElasticsearchMetadata> for NodesStats {
     fn generate_docs(
         self,
         lookups: Arc<Lookups>,

--- a/src/processor/elasticsearch/searchable_snapshots_stats.rs
+++ b/src/processor/elasticsearch/searchable_snapshots_stats.rs
@@ -4,7 +4,7 @@ use rayon::prelude::*;
 use serde::Serialize;
 use serde_json::Value;
 use std::sync::Arc;
-impl DataProcessor<ElasticsearchMetadata> for SearchableSnapshotsStats {
+impl DataProcessor<Lookups, ElasticsearchMetadata> for SearchableSnapshotsStats {
     fn generate_docs(
         self,
         _lookups: Arc<Lookups>,

--- a/src/processor/elasticsearch/tasks.rs
+++ b/src/processor/elasticsearch/tasks.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use serde_json::Value;
 use std::sync::Arc;
 
-impl DataProcessor<ElasticsearchMetadata> for Tasks {
+impl DataProcessor<Lookups, ElasticsearchMetadata> for Tasks {
     fn generate_docs(
         self,
         lookups: Arc<Lookups>,

--- a/src/processor/logstash.rs
+++ b/src/processor/logstash.rs
@@ -2,6 +2,8 @@
 mod metadata;
 /// Logstash node processor
 mod node;
+/// Logstash plugins
+mod plugins;
 
 use super::{DataProcessor, DiagnosticProcessor, Metadata};
 use crate::{
@@ -60,6 +62,18 @@ impl DiagnosticProcessor for LogstashDiagnostic {
         if let Ok((index, docs)) = self
             .receiver
             .get::<LogstashNode>()
+            .await
+            .map(|data| data.generate_docs(self.lookups.clone(), self.metadata.clone()))
+        {
+            match self.exporter.write(index, docs).await {
+                Ok(count) => doc_count += count,
+                Err(e) => log::error!("Elasticsearch exporter: {e}"),
+            }
+        };
+
+        if let Ok((index, docs)) = self
+            .receiver
+            .get::<LogstashPlugins>()
             .await
             .map(|data| data.generate_docs(self.lookups.clone(), self.metadata.clone()))
         {

--- a/src/processor/logstash.rs
+++ b/src/processor/logstash.rs
@@ -1,1 +1,81 @@
+use super::{lookup::Lookup, DiagnosticProcessor};
+use crate::{
+    data::{
+        self,
+        diagnostic::DiagnosticManifest,
+        logstash::{
+            LogstashHotThreads, LogstashNode, LogstashNodeStats, LogstashPlugins, LogstashVersion,
+        },
+    },
+    exporter::Exporter,
+    receiver::Receiver,
+};
+use color_eyre::eyre::Result;
+use serde::Serialize;
+use std::sync::Arc;
 
+#[derive(Serialize)]
+pub struct LogstashDiagnostic {
+    lookups: Arc<Lookups>,
+    #[serde(skip)]
+    exporter: Arc<Exporter>,
+    #[serde(skip)]
+    receiver: Arc<Receiver>,
+}
+
+impl DiagnosticProcessor for LogstashDiagnostic {
+    async fn new(
+        manifest: DiagnosticManifest,
+        receiver: Receiver,
+        exporter: Exporter,
+    ) -> Result<Box<Self>> {
+        let lookups = Arc::new(Lookups {});
+
+        Ok(Box::new(Self {
+            lookups,
+            exporter: Arc::new(exporter),
+            receiver: Arc::new(receiver),
+        }))
+    }
+
+    async fn run(self) -> Result<(String, usize)> {
+        log::debug!("Running Logstash diagnostic processors");
+        if log::max_level() >= log::Level::Debug {
+            data::save_file("diagnostic.json", &self)?;
+        }
+
+        let output = self.receiver.get::<LogstashVersion>().await?;
+        log::debug!(
+            "Logstash version: {}",
+            serde_json::to_string(&output).unwrap()
+        );
+        let output = self.receiver.get::<LogstashNode>().await?;
+        log::debug!(
+            "Logstash version: {}",
+            serde_json::to_string(&output).unwrap()
+        );
+        self.receiver.get::<LogstashNodeStats>().await?;
+        log::debug!(
+            "Logstash version: {}",
+            serde_json::to_string(&output).unwrap()
+        );
+        self.receiver.get::<LogstashPlugins>().await?;
+        log::debug!(
+            "Logstash version: {}",
+            serde_json::to_string(&output).unwrap()
+        );
+        self.receiver.get::<LogstashHotThreads>().await?;
+        log::debug!(
+            "Logstash version: {}",
+            serde_json::to_string(&output).unwrap()
+        );
+        Ok((String::from("Logstash"), 0))
+    }
+
+    async fn process_queue(&self) -> usize {
+        0
+    }
+}
+
+#[derive(Serialize)]
+pub struct Lookups {}

--- a/src/processor/logstash.rs
+++ b/src/processor/logstash.rs
@@ -1,4 +1,7 @@
-use super::DiagnosticProcessor;
+/// Logstash diagnostic metadata
+mod metadata;
+
+use super::{DiagnosticProcessor, Metadata};
 use crate::{
     data::{
         self,
@@ -11,11 +14,13 @@ use crate::{
     receiver::Receiver,
 };
 use color_eyre::eyre::Result;
+use metadata::LogstashMetadata;
 use serde::Serialize;
 use std::sync::Arc;
 
 #[derive(Serialize)]
 pub struct LogstashDiagnostic {
+    metadata: Arc<LogstashMetadata>,
     #[serde(skip)]
     exporter: Arc<Exporter>,
     #[serde(skip)]
@@ -28,7 +33,11 @@ impl DiagnosticProcessor for LogstashDiagnostic {
         receiver: Receiver,
         exporter: Exporter,
     ) -> Result<Box<Self>> {
+        let logstash_version = receiver.get::<LogstashVersion>().await?;
+        let metadata = LogstashMetadata::try_new(manifest, logstash_version)?;
+
         Ok(Box::new(Self {
+            metadata: Arc::new(metadata),
             exporter: Arc::new(exporter),
             receiver: Arc::new(receiver),
         }))
@@ -40,11 +49,6 @@ impl DiagnosticProcessor for LogstashDiagnostic {
             data::save_file("diagnostic.json", &self)?;
         }
 
-        let output = self.receiver.get::<LogstashVersion>().await?;
-        log::debug!(
-            "Logstash version: {}",
-            serde_json::to_string(&output).unwrap()
-        );
         let output = self.receiver.get::<LogstashNode>().await?;
         log::debug!(
             "Logstash version: {}",

--- a/src/processor/logstash.rs
+++ b/src/processor/logstash.rs
@@ -1,7 +1,9 @@
 /// Logstash diagnostic metadata
 mod metadata;
+/// Logstash node processor
+mod node;
 
-use super::{DiagnosticProcessor, Metadata};
+use super::{DataProcessor, DiagnosticProcessor, Metadata};
 use crate::{
     data::{
         self,
@@ -20,6 +22,7 @@ use std::sync::Arc;
 
 #[derive(Serialize)]
 pub struct LogstashDiagnostic {
+    lookups: Arc<Lookups>,
     metadata: Arc<LogstashMetadata>,
     #[serde(skip)]
     exporter: Arc<Exporter>,
@@ -35,8 +38,12 @@ impl DiagnosticProcessor for LogstashDiagnostic {
     ) -> Result<Box<Self>> {
         let logstash_version = receiver.get::<LogstashVersion>().await?;
         let metadata = LogstashMetadata::try_new(manifest, logstash_version)?;
+        let plugins = receiver.get::<LogstashPlugins>().await?;
 
         Ok(Box::new(Self {
+            lookups: Arc::new(Lookups {
+                plugin_count: plugins.total,
+            }),
             metadata: Arc::new(metadata),
             exporter: Arc::new(exporter),
             receiver: Arc::new(receiver),
@@ -48,31 +55,46 @@ impl DiagnosticProcessor for LogstashDiagnostic {
         if log::max_level() >= log::Level::Debug {
             data::save_file("diagnostic.json", &self)?;
         }
+        let mut doc_count = 0;
 
-        let output = self.receiver.get::<LogstashNode>().await?;
-        log::debug!(
-            "Logstash version: {}",
-            serde_json::to_string(&output).unwrap()
-        );
-        self.receiver.get::<LogstashNodeStats>().await?;
-        log::debug!(
-            "Logstash version: {}",
-            serde_json::to_string(&output).unwrap()
-        );
-        self.receiver.get::<LogstashPlugins>().await?;
-        log::debug!(
-            "Logstash version: {}",
-            serde_json::to_string(&output).unwrap()
-        );
-        self.receiver.get::<LogstashHotThreads>().await?;
-        log::debug!(
-            "Logstash version: {}",
-            serde_json::to_string(&output).unwrap()
-        );
-        Ok((String::from("Logstash"), 0))
+        if let Ok((index, docs)) = self
+            .receiver
+            .get::<LogstashNode>()
+            .await
+            .map(|data| data.generate_docs(self.lookups.clone(), self.metadata.clone()))
+        {
+            match self.exporter.write(index, docs).await {
+                Ok(count) => doc_count += count,
+                Err(e) => log::error!("Elasticsearch exporter: {e}"),
+            }
+        };
+
+        /*
+                let docs = self
+                    .receiver
+                    .get::<LogstashNodeStats>()
+                    .await
+                    .map(|data| data.generate_docs(self.lookups.clone(), self.metadata.clone()));
+
+                let docs = self.receiver
+                    .get::<LogstashPlugins>()
+                    .await
+                    .map(|data| data.generate_docs(self.lookups.clone(), self.metadata.clone()));
+
+                let docs = self.receiver
+                    .get::<LogstashHotThreads>()
+                    .await
+                    .map(|data| data.generate_docs(self.lookups.clone(), self.metadata.clone()));
+        */
+        Ok((String::from("Logstash"), doc_count))
     }
 
     async fn process_queue(&self) -> usize {
         0
     }
+}
+
+#[derive(Serialize)]
+struct Lookups {
+    plugin_count: u32,
 }

--- a/src/processor/logstash.rs
+++ b/src/processor/logstash.rs
@@ -2,6 +2,8 @@
 mod metadata;
 /// Logstash node processor
 mod node;
+/// Logstash node stats processor
+mod node_stats;
 /// Logstash plugins
 mod plugins;
 
@@ -83,23 +85,18 @@ impl DiagnosticProcessor for LogstashDiagnostic {
             }
         };
 
-        /*
-                let docs = self
-                    .receiver
-                    .get::<LogstashNodeStats>()
-                    .await
-                    .map(|data| data.generate_docs(self.lookups.clone(), self.metadata.clone()));
+        if let Ok((index, docs)) = self
+            .receiver
+            .get::<LogstashNodeStats>()
+            .await
+            .map(|data| data.generate_docs(self.lookups.clone(), self.metadata.clone()))
+        {
+            match self.exporter.write(index, docs).await {
+                Ok(count) => doc_count += count,
+                Err(e) => log::error!("Elasticsearch exporter: {e}"),
+            }
+        };
 
-                let docs = self.receiver
-                    .get::<LogstashPlugins>()
-                    .await
-                    .map(|data| data.generate_docs(self.lookups.clone(), self.metadata.clone()));
-
-                let docs = self.receiver
-                    .get::<LogstashHotThreads>()
-                    .await
-                    .map(|data| data.generate_docs(self.lookups.clone(), self.metadata.clone()));
-        */
         Ok((String::from("Logstash"), doc_count))
     }
 

--- a/src/processor/logstash.rs
+++ b/src/processor/logstash.rs
@@ -11,17 +11,15 @@ use super::{DataProcessor, DiagnosticProcessor, Metadata};
 use crate::{
     data::{
         self,
-        diagnostic::DiagnosticManifest,
-        logstash::{
-            LogstashHotThreads, LogstashNode, LogstashNodeStats, LogstashPlugins, LogstashVersion,
-        },
+        diagnostic::{DataSource, DiagnosticManifest},
+        logstash::{Node, NodeStats, Plugins, Version},
     },
     exporter::Exporter,
     receiver::Receiver,
 };
 use color_eyre::eyre::Result;
 use metadata::LogstashMetadata;
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Serialize};
 use std::sync::Arc;
 
 #[derive(Serialize)]
@@ -34,15 +32,32 @@ pub struct LogstashDiagnostic {
     receiver: Arc<Receiver>,
 }
 
+impl LogstashDiagnostic {
+    async fn process<T>(&self) -> Result<usize>
+    where
+        T: DataSource + DataProcessor<Lookups, LogstashMetadata> + DeserializeOwned + Send + Sync,
+    {
+        match self
+            .receiver
+            .get::<T>()
+            .await
+            .map(|data| data.generate_docs(self.lookups.clone(), self.metadata.clone()))
+        {
+            Ok((index, docs)) => self.exporter.write(index, docs).await,
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
 impl DiagnosticProcessor for LogstashDiagnostic {
     async fn new(
         manifest: DiagnosticManifest,
         receiver: Receiver,
         exporter: Exporter,
     ) -> Result<Box<Self>> {
-        let logstash_version = receiver.get::<LogstashVersion>().await?;
+        let logstash_version = receiver.get::<Version>().await?;
         let metadata = LogstashMetadata::try_new(manifest, logstash_version)?;
-        let plugins = receiver.get::<LogstashPlugins>().await?;
+        let plugins = receiver.get::<Plugins>().await?;
 
         Ok(Box::new(Self {
             lookups: Arc::new(Lookups {
@@ -59,43 +74,11 @@ impl DiagnosticProcessor for LogstashDiagnostic {
         if log::max_level() >= log::Level::Debug {
             data::save_file("diagnostic.json", &self)?;
         }
+
         let mut doc_count = 0;
-
-        if let Ok((index, docs)) = self
-            .receiver
-            .get::<LogstashNode>()
-            .await
-            .map(|data| data.generate_docs(self.lookups.clone(), self.metadata.clone()))
-        {
-            match self.exporter.write(index, docs).await {
-                Ok(count) => doc_count += count,
-                Err(e) => log::error!("Elasticsearch exporter: {e}"),
-            }
-        };
-
-        if let Ok((index, docs)) = self
-            .receiver
-            .get::<LogstashPlugins>()
-            .await
-            .map(|data| data.generate_docs(self.lookups.clone(), self.metadata.clone()))
-        {
-            match self.exporter.write(index, docs).await {
-                Ok(count) => doc_count += count,
-                Err(e) => log::error!("Elasticsearch exporter: {e}"),
-            }
-        };
-
-        if let Ok((index, docs)) = self
-            .receiver
-            .get::<LogstashNodeStats>()
-            .await
-            .map(|data| data.generate_docs(self.lookups.clone(), self.metadata.clone()))
-        {
-            match self.exporter.write(index, docs).await {
-                Ok(count) => doc_count += count,
-                Err(e) => log::error!("Elasticsearch exporter: {e}"),
-            }
-        };
+        doc_count += self.process::<Node>().await?;
+        doc_count += self.process::<NodeStats>().await?;
+        doc_count += self.process::<Plugins>().await?;
 
         Ok((String::from("Logstash"), doc_count))
     }

--- a/src/processor/logstash.rs
+++ b/src/processor/logstash.rs
@@ -1,4 +1,4 @@
-use super::{lookup::Lookup, DiagnosticProcessor};
+use super::DiagnosticProcessor;
 use crate::{
     data::{
         self,
@@ -16,7 +16,6 @@ use std::sync::Arc;
 
 #[derive(Serialize)]
 pub struct LogstashDiagnostic {
-    lookups: Arc<Lookups>,
     #[serde(skip)]
     exporter: Arc<Exporter>,
     #[serde(skip)]
@@ -29,10 +28,7 @@ impl DiagnosticProcessor for LogstashDiagnostic {
         receiver: Receiver,
         exporter: Exporter,
     ) -> Result<Box<Self>> {
-        let lookups = Arc::new(Lookups {});
-
         Ok(Box::new(Self {
-            lookups,
             exporter: Arc::new(exporter),
             receiver: Arc::new(receiver),
         }))
@@ -76,6 +72,3 @@ impl DiagnosticProcessor for LogstashDiagnostic {
         0
     }
 }
-
-#[derive(Serialize)]
-pub struct Lookups {}

--- a/src/processor/logstash/metadata.rs
+++ b/src/processor/logstash/metadata.rs
@@ -1,34 +1,25 @@
 use super::Metadata;
 use crate::data::{
     diagnostic::{DataStreamName, DiagnosticDoc, DiagnosticManifest},
-    elasticsearch::Cluster,
+    logstash::LogstashVersion,
 };
 use color_eyre::eyre::Result;
 use serde::Serialize;
 use serde_json::Value;
 
 #[derive(Clone, Serialize)]
-pub struct ElasticsearchMetadata {
-    pub cluster: Cluster,
+pub struct LogstashMetadata {
+    pub logstash: LogstashVersion,
     pub diagnostic: DiagnosticDoc,
     pub timestamp: i64,
     pub as_doc: MetadataDoc,
-}
-
-impl ElasticsearchMetadata {
-    pub fn for_data_stream(&self, data_stream: &str) -> MetadataDoc {
-        MetadataDoc {
-            data_stream: DataStreamName::from(data_stream),
-            ..self.as_doc.clone()
-        }
-    }
 }
 
 #[derive(Clone, Serialize)]
 pub struct MetadataDoc {
     #[serde(rename = "@timestamp")]
     pub timestamp: i64,
-    pub cluster: Cluster,
+    pub logstash: LogstashVersion,
     pub diagnostic: DiagnosticDoc,
     pub data_stream: DataStreamName,
 }
@@ -39,22 +30,22 @@ impl Metadata for MetadataDoc {
     }
 }
 
-impl ElasticsearchMetadata {
-    pub fn try_new(manifest: DiagnosticManifest, cluster: Cluster) -> Result<Self> {
-        let name = cluster.display_name.replace(" ", "_");
+impl LogstashMetadata {
+    pub fn try_new(manifest: DiagnosticManifest, logstash: LogstashVersion) -> Result<Self> {
+        let name = logstash.name.replace(" ", "_");
         let diagnostic = DiagnosticDoc::try_from(manifest.with_name(name))?;
         let timestamp = diagnostic.collection_date;
 
         let as_doc = MetadataDoc {
             timestamp,
-            cluster: cluster.clone(),
+            logstash: logstash.clone(),
             diagnostic: diagnostic.clone(),
             data_stream: DataStreamName::from("metrics-default-esdiag"),
         };
 
         Ok(Self {
             as_doc,
-            cluster,
+            logstash,
             diagnostic,
             timestamp,
         })

--- a/src/processor/logstash/metadata.rs
+++ b/src/processor/logstash/metadata.rs
@@ -1,7 +1,7 @@
 use super::Metadata;
 use crate::data::{
     diagnostic::{DataStreamName, DiagnosticDoc, DiagnosticManifest},
-    logstash::LogstashVersion,
+    logstash::Version,
 };
 use color_eyre::eyre::Result;
 use serde::Serialize;
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 #[derive(Clone, Serialize)]
 pub struct LogstashMetadata {
-    pub node: LogstashVersion,
+    pub node: Version,
     pub diagnostic: DiagnosticDoc,
     pub timestamp: i64,
     pub as_doc: MetadataDoc,
@@ -19,7 +19,7 @@ pub struct LogstashMetadata {
 pub struct MetadataDoc {
     #[serde(rename = "@timestamp")]
     pub timestamp: i64,
-    pub node: LogstashVersion,
+    pub node: Version,
     pub diagnostic: DiagnosticDoc,
     pub data_stream: DataStreamName,
 }
@@ -31,7 +31,7 @@ impl Metadata for MetadataDoc {
 }
 
 impl LogstashMetadata {
-    pub fn try_new(manifest: DiagnosticManifest, node: LogstashVersion) -> Result<Self> {
+    pub fn try_new(manifest: DiagnosticManifest, node: Version) -> Result<Self> {
         let name = node.name.replace(" ", "_");
         let diagnostic = DiagnosticDoc::try_from(manifest.with_name(name))?;
         let timestamp = diagnostic.collection_date;

--- a/src/processor/logstash/metadata.rs
+++ b/src/processor/logstash/metadata.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 #[derive(Clone, Serialize)]
 pub struct LogstashMetadata {
-    pub logstash: LogstashVersion,
+    pub node: LogstashVersion,
     pub diagnostic: DiagnosticDoc,
     pub timestamp: i64,
     pub as_doc: MetadataDoc,
@@ -19,7 +19,7 @@ pub struct LogstashMetadata {
 pub struct MetadataDoc {
     #[serde(rename = "@timestamp")]
     pub timestamp: i64,
-    pub logstash: LogstashVersion,
+    pub node: LogstashVersion,
     pub diagnostic: DiagnosticDoc,
     pub data_stream: DataStreamName,
 }
@@ -31,23 +31,30 @@ impl Metadata for MetadataDoc {
 }
 
 impl LogstashMetadata {
-    pub fn try_new(manifest: DiagnosticManifest, logstash: LogstashVersion) -> Result<Self> {
-        let name = logstash.name.replace(" ", "_");
+    pub fn try_new(manifest: DiagnosticManifest, node: LogstashVersion) -> Result<Self> {
+        let name = node.name.replace(" ", "_");
         let diagnostic = DiagnosticDoc::try_from(manifest.with_name(name))?;
         let timestamp = diagnostic.collection_date;
 
         let as_doc = MetadataDoc {
             timestamp,
-            logstash: logstash.clone(),
+            node: node.clone(),
             diagnostic: diagnostic.clone(),
             data_stream: DataStreamName::from("metrics-default-esdiag"),
         };
 
         Ok(Self {
             as_doc,
-            logstash,
+            node,
             diagnostic,
             timestamp,
         })
+    }
+
+    pub fn for_data_stream(&self, data_stream: &str) -> MetadataDoc {
+        MetadataDoc {
+            data_stream: DataStreamName::from(data_stream),
+            ..self.as_doc.clone()
+        }
     }
 }

--- a/src/processor/logstash/node.rs
+++ b/src/processor/logstash/node.rs
@@ -1,13 +1,13 @@
 use super::{DataProcessor, LogstashMetadata, Lookups};
 use crate::{
-    data::logstash::{LogstashNode, Pipeline},
+    data::logstash::{Node, Pipeline},
     processor::Metadata,
 };
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::{collections::HashMap, sync::Arc};
 
-impl DataProcessor<Lookups, LogstashMetadata> for LogstashNode {
+impl DataProcessor<Lookups, LogstashMetadata> for Node {
     fn generate_docs(
         mut self,
         lookups: Arc<Lookups>,
@@ -45,7 +45,7 @@ struct Count {
 }
 
 impl LogstashNodeDoc {
-    fn new(node: LogstashNode, metadata: Value, plugin_count: u32) -> Self {
+    fn new(node: Node, metadata: Value, plugin_count: u32) -> Self {
         let pipeline_count = node.get_pipeline_count();
         let mut node_with_metadata = json!(metadata.get("node").take());
         json_patch::merge(&mut node_with_metadata, &json!(node));

--- a/src/processor/logstash/node.rs
+++ b/src/processor/logstash/node.rs
@@ -1,0 +1,100 @@
+use super::{DataProcessor, LogstashMetadata, Lookups};
+use crate::{
+    data::logstash::{LogstashNode, Pipeline},
+    processor::Metadata,
+};
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::{collections::HashMap, sync::Arc};
+
+impl DataProcessor<Lookups, LogstashMetadata> for LogstashNode {
+    fn generate_docs(
+        mut self,
+        lookups: Arc<Lookups>,
+        metadata: Arc<LogstashMetadata>,
+    ) -> (String, Vec<Value>) {
+        let mut docs: Vec<Value> = Vec::new();
+        let data_stream = "settings-logstash.node-esdiag".to_string();
+        let mut pipeline_docs = generate_pipeline_docs(metadata.clone(), self.take_pipelines());
+        docs.append(&mut pipeline_docs);
+
+        let metadata_doc = metadata.for_data_stream(&data_stream).as_meta_doc();
+        let node_doc = json!(LogstashNodeDoc::new(
+            self,
+            metadata_doc,
+            lookups.plugin_count
+        ));
+        docs.push(node_doc);
+
+        (data_stream, docs)
+    }
+}
+
+#[derive(Serialize)]
+struct LogstashNodeDoc {
+    #[serde(flatten)]
+    metadata: Value,
+    node: Value,
+    plugins: Count,
+    pipelines: Count,
+}
+
+#[derive(Serialize)]
+struct Count {
+    count: u32,
+}
+
+impl LogstashNodeDoc {
+    fn new(node: LogstashNode, metadata: Value, plugin_count: u32) -> Self {
+        let pipeline_count = node.get_pipeline_count();
+        let mut node_with_metadata = json!(metadata.get("node").take());
+        json_patch::merge(&mut node_with_metadata, &json!(node));
+
+        Self {
+            metadata,
+            node: node_with_metadata,
+            plugins: Count {
+                count: plugin_count,
+            },
+            pipelines: Count {
+                count: pipeline_count,
+            },
+        }
+    }
+}
+
+fn generate_pipeline_docs(
+    metadata: Arc<LogstashMetadata>,
+    pipelines: HashMap<String, Pipeline>,
+) -> Vec<Value> {
+    let metadata = metadata
+        .for_data_stream("settings-logstash.pipeline-esdiag")
+        .as_meta_doc();
+    pipelines
+        .into_iter()
+        .map(|(name, pipeline)| json!(PipelineDoc::new(name, pipeline, metadata.clone())))
+        .collect()
+}
+
+#[derive(Serialize)]
+struct PipelineDoc {
+    #[serde(flatten)]
+    metadata: Value,
+    pipeline: NamedPipeline,
+}
+
+#[derive(Serialize)]
+struct NamedPipeline {
+    name: String,
+    #[serde(flatten)]
+    pipeline: Pipeline,
+}
+
+impl PipelineDoc {
+    fn new(name: String, pipeline: Pipeline, metadata: Value) -> Self {
+        Self {
+            metadata,
+            pipeline: NamedPipeline { name, pipeline },
+        }
+    }
+}

--- a/src/processor/logstash/node_stats.rs
+++ b/src/processor/logstash/node_stats.rs
@@ -1,13 +1,13 @@
 use super::{DataProcessor, LogstashMetadata, Lookups};
 use crate::{
-    data::logstash::{LogstashNodeStats, PipelinePlugins, PipelineStats},
+    data::logstash::{NodeStats, PipelinePlugins, PipelineStats},
     processor::Metadata,
 };
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::{collections::HashMap, sync::Arc};
 
-impl DataProcessor<Lookups, LogstashMetadata> for LogstashNodeStats {
+impl DataProcessor<Lookups, LogstashMetadata> for NodeStats {
     fn generate_docs(
         mut self,
         _: Arc<Lookups>,
@@ -36,7 +36,7 @@ struct NodeStatsDoc {
 }
 
 impl NodeStatsDoc {
-    fn new(node: LogstashNodeStats, metadata: Value) -> Self {
+    fn new(node: NodeStats, metadata: Value) -> Self {
         let mut node_with_metadata = json!(metadata.get("node").take());
         json_patch::merge(&mut node_with_metadata, &json!(node));
 

--- a/src/processor/logstash/node_stats.rs
+++ b/src/processor/logstash/node_stats.rs
@@ -1,0 +1,183 @@
+use super::{DataProcessor, LogstashMetadata, Lookups};
+use crate::{
+    data::logstash::{LogstashNodeStats, PipelinePlugins, PipelineStats},
+    processor::Metadata,
+};
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::{collections::HashMap, sync::Arc};
+
+impl DataProcessor<Lookups, LogstashMetadata> for LogstashNodeStats {
+    fn generate_docs(
+        mut self,
+        _: Arc<Lookups>,
+        metadata: Arc<LogstashMetadata>,
+    ) -> (String, Vec<Value>) {
+        let mut docs: Vec<Value> = Vec::new();
+        self.take_pipelines().map(|pipelines| {
+            let mut pipeline_docs = generate_pipeline_docs(metadata.clone(), pipelines);
+            docs.append(&mut pipeline_docs);
+        });
+
+        let data_stream = "metrics-logstash.node-esdiag".to_string();
+        let metadata_doc = metadata.for_data_stream(&data_stream).as_meta_doc();
+        let node_doc = json!(NodeStatsDoc::new(self, metadata_doc));
+        docs.push(node_doc);
+
+        (data_stream, docs)
+    }
+}
+
+#[derive(Serialize)]
+struct NodeStatsDoc {
+    #[serde(flatten)]
+    metadata: Value,
+    node: Value,
+}
+
+impl NodeStatsDoc {
+    fn new(node: LogstashNodeStats, metadata: Value) -> Self {
+        let mut node_with_metadata = json!(metadata.get("node").take());
+        json_patch::merge(&mut node_with_metadata, &json!(node));
+
+        Self {
+            metadata,
+            node: node_with_metadata,
+        }
+    }
+}
+
+fn generate_pipeline_docs(
+    metadata: Arc<LogstashMetadata>,
+    pipelines: HashMap<String, PipelineStats>,
+) -> Vec<Value> {
+    let pipeline_metadata_doc = metadata
+        .for_data_stream("metrics-logstash.pipeline-esdiag")
+        .as_meta_doc();
+
+    let mut plugin_docs: Vec<Value> = Vec::new();
+    let mut pipeline_docs: Vec<Value> = pipelines
+        .into_iter()
+        .map(|(name, mut stats)| {
+            stats.take_plugins().map(|plugins| {
+                let mut docs = generate_plugin_docs(metadata.clone(), plugins);
+                plugin_docs.append(&mut docs);
+            });
+            json!(PipelineDoc::new(name, stats, pipeline_metadata_doc.clone()))
+        })
+        .collect();
+
+    pipeline_docs.append(&mut plugin_docs);
+    pipeline_docs
+}
+
+#[derive(Serialize)]
+struct PipelineDoc {
+    #[serde(flatten)]
+    metadata: Value,
+    pipeline: NamedPipelineStats,
+}
+
+#[derive(Serialize)]
+struct NamedPipelineStats {
+    name: String,
+    #[serde(flatten)]
+    stats: PipelineStats,
+}
+
+impl PipelineDoc {
+    fn new(name: String, stats: PipelineStats, metadata: Value) -> Self {
+        Self {
+            metadata,
+            pipeline: NamedPipelineStats { name, stats },
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct PluginDoc {
+    #[serde(flatten)]
+    metadata: Value,
+    plugin: TypedPluginStats,
+}
+
+#[derive(Serialize)]
+struct TypedPluginStats {
+    r#type: String,
+    #[serde(flatten)]
+    stats: Value,
+}
+
+impl PluginDoc {
+    fn new(plugin_type: String, stats: Value, metadata: Value) -> Self {
+        Self {
+            metadata,
+            plugin: TypedPluginStats {
+                r#type: plugin_type,
+                stats,
+            },
+        }
+    }
+}
+
+fn generate_plugin_docs(metadata: Arc<LogstashMetadata>, plugins: PipelinePlugins) -> Vec<Value> {
+    let plugin_metadata_doc = metadata
+        .for_data_stream("metrics-logstash.plugin-esdiag")
+        .as_meta_doc();
+
+    let mut docs: Vec<Value> = Vec::new();
+
+    let mut input_docs = plugins
+        .inputs
+        .into_iter()
+        .map(|stats| {
+            json!(PluginDoc::new(
+                "input".to_string(),
+                json!(stats),
+                plugin_metadata_doc.clone()
+            ))
+        })
+        .collect::<Vec<Value>>();
+
+    let mut codec_docs = plugins
+        .codecs
+        .into_iter()
+        .map(|stats| {
+            json!(PluginDoc::new(
+                "codec".to_string(),
+                json!(stats),
+                plugin_metadata_doc.clone()
+            ))
+        })
+        .collect::<Vec<Value>>();
+
+    let mut filter_docs = plugins
+        .filters
+        .into_iter()
+        .map(|stats| {
+            json!(PluginDoc::new(
+                "filter".to_string(),
+                json!(stats),
+                plugin_metadata_doc.clone()
+            ))
+        })
+        .collect::<Vec<Value>>();
+
+    let mut output_docs = plugins
+        .outputs
+        .into_iter()
+        .map(|stats| {
+            json!(PluginDoc::new(
+                "output".to_string(),
+                json!(stats),
+                plugin_metadata_doc.clone()
+            ))
+        })
+        .collect::<Vec<Value>>();
+
+    docs.append(&mut input_docs);
+    docs.append(&mut codec_docs);
+    docs.append(&mut filter_docs);
+    docs.append(&mut output_docs);
+    docs
+}

--- a/src/processor/logstash/plugins.rs
+++ b/src/processor/logstash/plugins.rs
@@ -1,13 +1,13 @@
 use super::{DataProcessor, LogstashMetadata, Lookups};
 use crate::{
-    data::logstash::{LogstashPlugins, Plugin},
+    data::logstash::{Plugin, Plugins},
     processor::Metadata,
 };
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::sync::Arc;
 
-impl DataProcessor<Lookups, LogstashMetadata> for LogstashPlugins {
+impl DataProcessor<Lookups, LogstashMetadata> for Plugins {
     fn generate_docs(
         self,
         _: Arc<Lookups>,

--- a/src/processor/logstash/plugins.rs
+++ b/src/processor/logstash/plugins.rs
@@ -1,0 +1,38 @@
+use super::{DataProcessor, LogstashMetadata, Lookups};
+use crate::{
+    data::logstash::{LogstashPlugins, Plugin},
+    processor::Metadata,
+};
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+impl DataProcessor<Lookups, LogstashMetadata> for LogstashPlugins {
+    fn generate_docs(
+        self,
+        _: Arc<Lookups>,
+        metadata: Arc<LogstashMetadata>,
+    ) -> (String, Vec<Value>) {
+        let data_stream = "settings-logstash.plugin-esdiag".to_string();
+        let metadata_doc = metadata.for_data_stream(&data_stream).as_meta_doc();
+        let docs: Vec<Value> = self
+            .plugins
+            .into_iter()
+            .map(|plugin| json!(PluginDoc::new(plugin, metadata_doc.clone())))
+            .collect();
+        (data_stream, docs)
+    }
+}
+
+#[derive(Serialize)]
+struct PluginDoc {
+    #[serde(flatten)]
+    metadata: Value,
+    plugin: Plugin,
+}
+
+impl PluginDoc {
+    fn new(plugin: Plugin, metadata: Value) -> Self {
+        Self { metadata, plugin }
+    }
+}

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -10,7 +10,7 @@ use directory::DirectoryReceiver;
 use elasticsearch::ElasticsearchReceiver;
 
 use crate::data::{
-    diagnostic::{data_source::DataSource, DiagnosticManifest, Manifest},
+    diagnostic::{DataSource, DiagnosticManifest, Manifest},
     elasticsearch::Cluster,
     Uri,
 };

--- a/src/receiver/archive.rs
+++ b/src/receiver/archive.rs
@@ -1,5 +1,5 @@
 use super::Receive;
-use crate::data::{diagnostic::data_source::DataSource, Uri};
+use crate::data::{diagnostic::DataSource, Uri};
 use color_eyre::{eyre::eyre, Result};
 use serde::de::DeserializeOwned;
 use std::{fs::File, io::BufReader, path::PathBuf, sync::Arc};

--- a/src/receiver/directory.rs
+++ b/src/receiver/directory.rs
@@ -1,5 +1,5 @@
 use super::Receive;
-use crate::data::{diagnostic::data_source::DataSource, Uri};
+use crate::data::{diagnostic::DataSource, Uri};
 use color_eyre::eyre::{eyre, Result};
 use serde::de::DeserializeOwned;
 use std::{fs::File, io::BufReader, path::PathBuf};

--- a/src/receiver/elasticsearch.rs
+++ b/src/receiver/elasticsearch.rs
@@ -1,6 +1,6 @@
 use super::Receive;
 use crate::client::Host;
-use crate::data::{diagnostic::data_source::DataSource, Uri};
+use crate::data::{diagnostic::DataSource, Uri};
 use color_eyre::eyre::{eyre, Result};
 use elasticsearch::{http, Elasticsearch};
 use serde::de::DeserializeOwned;


### PR DESCRIPTION
Resolves #71 

Imports the Logstash diagnostic bundle then processes and exports the the node, node stats, and plugin information.

Will consider exporting the hot threads information as a future enhancement.