### PR TITLE
Add collect command for Elasticsearch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ Elastic Stack Diagnostics (esdiag) - collect diagnostics and import into Elastic
 Usage: esdiag <COMMAND>
 
 Commands:
-  collect  [NOT IMPLEMENTED] Collects diagnostics from a host's API endpoints
+  collect  Collects diagnostics from an Elasticsearch host's API endpoints, saves to a directory
   import   Process, enrich and import a diagnostic into Elasticsearch
   host     Configure and test a remote host connection
   setup    Setup required assets to visualize diagnostic imports
@@ -174,6 +174,7 @@ The `esdiag import` command allows these `target` and `source` options:
 
 `source`
     1. directory
+
 ```
 Process, enrich and import a diagnostic into Elasticsearch
 
@@ -190,7 +191,22 @@ Options:
 
 #### Collect
 
-🚧 This command is not yet implemented! 🚧
+The `esdiag collect` command pulls the minimum required diagnostics from an Elasticsearch host and saves them to a directory. These are JSON-only, not pretty-printed, and do not include human-readable metrics. This bunlde captures only what is needed to then import with `esdiag`.
+
+Authentication must be setup in advance with the `esdiag host` command or `hosts.yml` file. Direct access to the clsuter is required, this cannot be done through any Elastic Cloud API.
+
+```
+Collects diagnostics from an Elasticsearch host's API endpoints, saves to a directory
+
+Usage: esdiag collect <HOST> <OUTPUT>
+
+Arguments:
+  <HOST>    The Elasticsearch host to collect diagnostics from
+  <OUTPUT>  The directory to save the diagnostics files to
+
+Options:
+  -h, --help  Print help
+```
 
 ### Debugging
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -1,0 +1,82 @@
+use crate::{
+    data::{
+        diagnostic::{data_source::PathType, DataSource},
+        elasticsearch::{
+            AliasList, ClusterSettings, DataStreams, IlmExplain, IndicesSettings, IndicesStats,
+            Nodes, NodesStats, SearchableSnapshotsCacheStats, SearchableSnapshotsStats, Tasks,
+        },
+    },
+    exporter::DirectoryExporter,
+    receiver::Receiver,
+};
+use color_eyre::eyre::{eyre, Result};
+use std::path::PathBuf;
+
+pub enum Collector {
+    Elasticsearch(ElasticsearchCollector),
+}
+
+impl Collector {
+    pub async fn try_new(receiver: Receiver, exporter: DirectoryExporter) -> Result<Self> {
+        if let Receiver::Elasticsearch(_) = &receiver {
+            let collector = ElasticsearchCollector::new(receiver, exporter).await?;
+            Ok(Self::Elasticsearch(collector))
+        } else {
+            Err(eyre!(
+                "Collect is only implemented from Elasticsearch to a Directory"
+            ))
+        }
+    }
+
+    pub async fn collect(&self) -> Result<usize> {
+        match self {
+            Self::Elasticsearch(collector) => collector.collect().await,
+        }
+    }
+}
+
+pub struct ElasticsearchCollector {
+    receiver: Receiver,
+    exporter: DirectoryExporter,
+}
+
+impl ElasticsearchCollector {
+    pub async fn new(receiver: Receiver, exporter: DirectoryExporter) -> Result<Self> {
+        Ok(Self { receiver, exporter })
+    }
+
+    pub async fn collect(&self) -> Result<usize> {
+        self.save(self.receiver.try_get_manifest().await?).await?;
+        self.save(self.receiver.get::<AliasList>().await?).await?;
+        self.save(self.receiver.get::<ClusterSettings>().await?)
+            .await?;
+        self.save(self.receiver.get::<DataStreams>().await?).await?;
+        self.save(self.receiver.get::<IlmExplain>().await?).await?;
+        self.save(self.receiver.get::<IndicesSettings>().await?)
+            .await?;
+        self.save(self.receiver.get::<IndicesStats>().await?)
+            .await?;
+        self.save(self.receiver.get::<Nodes>().await?).await?;
+        self.save(self.receiver.get::<NodesStats>().await?).await?;
+        self.save(self.receiver.get::<SearchableSnapshotsCacheStats>().await?)
+            .await?;
+        match self.receiver.get::<SearchableSnapshotsStats>().await {
+            Ok(stats) => self.save(stats).await?,
+            Err(_) => log::warn!("No searchable snapshots stats available"),
+        };
+        self.save(self.receiver.get::<Tasks>().await?).await?;
+
+        let file_count = 1;
+        log::info!("Collected {file_count} files into {}", self.exporter);
+        Ok(file_count)
+    }
+
+    async fn save<T>(&self, content: T) -> Result<()>
+    where
+        T: serde::Serialize + DataSource,
+    {
+        let path = PathBuf::from(T::source(PathType::File)?);
+        self.exporter.save(path, content).await?;
+        Ok(())
+    }
+}

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -1,9 +1,10 @@
 use crate::{
     data::{
-        diagnostic::{data_source::PathType, DataSource},
+        diagnostic::{data_source::PathType, DataSource, DiagnosticManifest, Product},
         elasticsearch::{
-            AliasList, ClusterSettings, DataStreams, IlmExplain, IndicesSettings, IndicesStats,
-            Nodes, NodesStats, SearchableSnapshotsCacheStats, SearchableSnapshotsStats, Tasks,
+            AliasList, Cluster, ClusterSettings, DataStreams, IlmExplain, IndicesSettings,
+            IndicesStats, Nodes, NodesStats, SearchableSnapshotsCacheStats,
+            SearchableSnapshotsStats, Tasks,
         },
     },
     exporter::DirectoryExporter,
@@ -46,10 +47,12 @@ impl ElasticsearchCollector {
     }
 
     pub async fn collect(&self) -> Result<usize> {
-        let total = 12;
         let mut file_count = 0;
-        //self.save(self.receiver.try_get_manifest().await?).await?;
+        let total = 13;
+
+        file_count += self.save_diagnostic_manifest().await?;
         file_count += self.save::<AliasList>().await?;
+        file_count += self.save::<Cluster>().await?;
         file_count += self.save::<ClusterSettings>().await?;
         file_count += self.save::<DataStreams>().await?;
         file_count += self.save::<IlmExplain>().await?;
@@ -74,6 +77,36 @@ impl ElasticsearchCollector {
     {
         let content = self.receiver.get_raw::<T>().await?;
         let path = PathBuf::from(T::source(PathType::File)?);
-        self.exporter.save(path, content).await.map(|_| 1)
+        let filename = format!("{}", path.display());
+        match self.exporter.save(path, content).await {
+            Ok(()) => Ok(1),
+            Err(e) => {
+                log::error!("Failed to save {filename}: {e}");
+                Ok(0)
+            }
+        }
+    }
+
+    async fn save_diagnostic_manifest(&self) -> Result<usize> {
+        let cluster = self.receiver.get::<Cluster>().await?;
+        let manifest = DiagnosticManifest {
+            name: Some(cluster.diagnostic_node.clone()),
+            collection_date: chrono::Utc::now()
+                .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            diagnostic: Some(format!("esdiag-{}", env!("CARGO_PKG_VERSION"))),
+            flags: None,
+            included_diagnostics: None,
+            mode: Some("esdiag".to_string()),
+            product: Product::Elasticsearch,
+            r#type: Some("elasticsearch_diagnostic".to_string()),
+            runner: Some("esdiag".to_string()),
+            version: Some(cluster.version.number.to_string()),
+        };
+        let path = PathBuf::from(DiagnosticManifest::source(PathType::File)?);
+        let filename = format!("{}", path.display());
+        let content = serde_json::to_string_pretty(&manifest)?;
+        self.exporter.save(path, content).await?;
+        log::debug!("Saved {filename}.json");
+        Ok(1)
     }
 }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -46,37 +46,34 @@ impl ElasticsearchCollector {
     }
 
     pub async fn collect(&self) -> Result<usize> {
-        self.save(self.receiver.try_get_manifest().await?).await?;
-        self.save(self.receiver.get::<AliasList>().await?).await?;
-        self.save(self.receiver.get::<ClusterSettings>().await?)
-            .await?;
-        self.save(self.receiver.get::<DataStreams>().await?).await?;
-        self.save(self.receiver.get::<IlmExplain>().await?).await?;
-        self.save(self.receiver.get::<IndicesSettings>().await?)
-            .await?;
-        self.save(self.receiver.get::<IndicesStats>().await?)
-            .await?;
-        self.save(self.receiver.get::<Nodes>().await?).await?;
-        self.save(self.receiver.get::<NodesStats>().await?).await?;
-        self.save(self.receiver.get::<SearchableSnapshotsCacheStats>().await?)
-            .await?;
-        match self.receiver.get::<SearchableSnapshotsStats>().await {
-            Ok(stats) => self.save(stats).await?,
-            Err(_) => log::warn!("No searchable snapshots stats available"),
-        };
-        self.save(self.receiver.get::<Tasks>().await?).await?;
+        let total = 12;
+        let mut file_count = 0;
+        //self.save(self.receiver.try_get_manifest().await?).await?;
+        file_count += self.save::<AliasList>().await?;
+        file_count += self.save::<ClusterSettings>().await?;
+        file_count += self.save::<DataStreams>().await?;
+        file_count += self.save::<IlmExplain>().await?;
+        file_count += self.save::<IndicesSettings>().await?;
+        file_count += self.save::<IndicesStats>().await?;
+        file_count += self.save::<Nodes>().await?;
+        file_count += self.save::<NodesStats>().await?;
+        file_count += self.save::<SearchableSnapshotsCacheStats>().await?;
+        file_count += self.save::<SearchableSnapshotsStats>().await?;
+        file_count += self.save::<Tasks>().await?;
 
-        let file_count = 1;
-        log::info!("Collected {file_count} files into {}", self.exporter);
+        log::info!(
+            "Collected {file_count} of {total} files into {}",
+            self.exporter
+        );
         Ok(file_count)
     }
 
-    async fn save<T>(&self, content: T) -> Result<()>
+    async fn save<T>(&self) -> Result<usize>
     where
-        T: serde::Serialize + DataSource,
+        T: DataSource,
     {
+        let content = self.receiver.get_raw::<T>().await?;
         let path = PathBuf::from(T::source(PathType::File)?);
-        self.exporter.save(path, content).await?;
-        Ok(())
+        self.exporter.save(path, content).await.map(|_| 1)
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,3 +1,5 @@
+/// Collect diagnostic data from applications
+pub mod collector;
 /// Diagnostic bundle types and data structures
 pub mod diagnostic;
 /// Elasticsearch data types and structures
@@ -7,6 +9,7 @@ pub mod logstash;
 /// Classify an input string as a type of univeral resource identifier (URI)
 pub mod uri;
 
+pub use collector::Collector;
 pub use uri::Uri;
 
 // ------ Utility Function -------

--- a/src/data/collector.rs
+++ b/src/data/collector.rs
@@ -1,0 +1,43 @@
+/// Diagnostic collector for Elasticsearch
+mod elasticsearch;
+
+use crate::{exporter::DirectoryExporter, receiver::Receiver};
+use color_eyre::eyre::{eyre, Result};
+use elasticsearch::ElasticsearchCollector;
+
+pub enum Collector {
+    Elasticsearch(ElasticsearchCollector),
+}
+
+impl Collector {
+    pub async fn try_new(receiver: Receiver, exporter: DirectoryExporter) -> Result<Self> {
+        if let Receiver::Elasticsearch(_) = &receiver {
+            let collector = ElasticsearchCollector::new(receiver, exporter).await?;
+            Ok(Self::Elasticsearch(collector))
+        } else {
+            Err(eyre!(
+                "Collect is only implemented from Elasticsearch to a Directory"
+            ))
+        }
+    }
+
+    pub async fn collect(&self) -> Result<()> {
+        let result = match self {
+            Self::Elasticsearch(collector) => collector.collect().await?,
+        };
+
+        log::info!(
+            "Collected {} of {} files into {}",
+            result.success,
+            result.total,
+            result.path
+        );
+        Ok(())
+    }
+}
+
+pub struct CollectionResult {
+    pub path: String,
+    pub success: usize,
+    pub total: usize,
+}

--- a/src/data/collector/elasticsearch.rs
+++ b/src/data/collector/elasticsearch.rs
@@ -1,3 +1,4 @@
+use super::CollectionResult;
 use crate::{
     data::{
         diagnostic::{data_source::PathType, DataSource, DiagnosticManifest, Product},
@@ -7,34 +8,10 @@ use crate::{
             SearchableSnapshotsStats, Tasks,
         },
     },
-    exporter::DirectoryExporter,
-    receiver::Receiver,
+    {exporter::DirectoryExporter, receiver::Receiver},
 };
-use color_eyre::eyre::{eyre, Result};
+use color_eyre::eyre::Result;
 use std::path::PathBuf;
-
-pub enum Collector {
-    Elasticsearch(ElasticsearchCollector),
-}
-
-impl Collector {
-    pub async fn try_new(receiver: Receiver, exporter: DirectoryExporter) -> Result<Self> {
-        if let Receiver::Elasticsearch(_) = &receiver {
-            let collector = ElasticsearchCollector::new(receiver, exporter).await?;
-            Ok(Self::Elasticsearch(collector))
-        } else {
-            Err(eyre!(
-                "Collect is only implemented from Elasticsearch to a Directory"
-            ))
-        }
-    }
-
-    pub async fn collect(&self) -> Result<usize> {
-        match self {
-            Self::Elasticsearch(collector) => collector.collect().await,
-        }
-    }
-}
 
 pub struct ElasticsearchCollector {
     receiver: Receiver,
@@ -46,29 +23,28 @@ impl ElasticsearchCollector {
         Ok(Self { receiver, exporter })
     }
 
-    pub async fn collect(&self) -> Result<usize> {
-        let mut file_count = 0;
-        let total = 13;
+    pub async fn collect(&self) -> Result<CollectionResult> {
+        let mut result = CollectionResult {
+            path: self.exporter.to_string().clone(),
+            success: 0,
+            total: 13,
+        };
 
-        file_count += self.save_diagnostic_manifest().await?;
-        file_count += self.save::<AliasList>().await?;
-        file_count += self.save::<Cluster>().await?;
-        file_count += self.save::<ClusterSettings>().await?;
-        file_count += self.save::<DataStreams>().await?;
-        file_count += self.save::<IlmExplain>().await?;
-        file_count += self.save::<IndicesSettings>().await?;
-        file_count += self.save::<IndicesStats>().await?;
-        file_count += self.save::<Nodes>().await?;
-        file_count += self.save::<NodesStats>().await?;
-        file_count += self.save::<SearchableSnapshotsCacheStats>().await?;
-        file_count += self.save::<SearchableSnapshotsStats>().await?;
-        file_count += self.save::<Tasks>().await?;
+        result.success += self.save_diagnostic_manifest().await?;
+        result.success += self.save::<AliasList>().await?;
+        result.success += self.save::<Cluster>().await?;
+        result.success += self.save::<ClusterSettings>().await?;
+        result.success += self.save::<DataStreams>().await?;
+        result.success += self.save::<IlmExplain>().await?;
+        result.success += self.save::<IndicesSettings>().await?;
+        result.success += self.save::<IndicesStats>().await?;
+        result.success += self.save::<Nodes>().await?;
+        result.success += self.save::<NodesStats>().await?;
+        result.success += self.save::<SearchableSnapshotsCacheStats>().await?;
+        result.success += self.save::<SearchableSnapshotsStats>().await?;
+        result.success += self.save::<Tasks>().await?;
 
-        log::info!(
-            "Collected {file_count} of {total} files into {}",
-            self.exporter
-        );
-        Ok(file_count)
+        Ok(result)
     }
 
     async fn save<T>(&self) -> Result<usize>
@@ -79,7 +55,10 @@ impl ElasticsearchCollector {
         let path = PathBuf::from(T::source(PathType::File)?);
         let filename = format!("{}", path.display());
         match self.exporter.save(path, content).await {
-            Ok(()) => Ok(1),
+            Ok(()) => {
+                log::info!("Saved {filename}");
+                Ok(1)
+            }
             Err(e) => {
                 log::error!("Failed to save {filename}: {e}");
                 Ok(0)
@@ -90,23 +69,24 @@ impl ElasticsearchCollector {
     async fn save_diagnostic_manifest(&self) -> Result<usize> {
         let cluster = self.receiver.get::<Cluster>().await?;
         let manifest = DiagnosticManifest {
-            name: Some(cluster.diagnostic_node.clone()),
             collection_date: chrono::Utc::now()
                 .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
             diagnostic: Some(format!("esdiag-{}", env!("CARGO_PKG_VERSION"))),
             flags: None,
             included_diagnostics: None,
-            mode: Some("esdiag".to_string()),
+            mode: Some("standard".to_string()),
+            name: Some(cluster.diagnostic_node.clone()),
             product: Product::Elasticsearch,
             r#type: Some("elasticsearch_diagnostic".to_string()),
             runner: Some("esdiag".to_string()),
             version: Some(cluster.version.number.to_string()),
         };
+
         let path = PathBuf::from(DiagnosticManifest::source(PathType::File)?);
         let filename = format!("{}", path.display());
         let content = serde_json::to_string_pretty(&manifest)?;
         self.exporter.save(path, content).await?;
-        log::debug!("Saved {filename}.json");
+        log::info!("Saved {filename}");
         Ok(1)
     }
 }

--- a/src/data/elasticsearch/aliases.rs
+++ b/src/data/elasticsearch/aliases.rs
@@ -5,11 +5,11 @@ use std::collections::HashMap;
 
 pub type AliasList = HashMap<String, Aliases>;
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Aliases {
     pub aliases: HashMap<String, AliasSettings>,
 }
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AliasSettings {
     pub is_hidden: Option<bool>,
     pub is_write_index: Option<bool>,

--- a/src/data/elasticsearch/ilm_explain.rs
+++ b/src/data/elasticsearch/ilm_explain.rs
@@ -55,7 +55,7 @@ impl DataSource for IlmExplain {
     fn source(path: PathType) -> Result<&'static str> {
         match path {
             PathType::File => Ok("commercial/ilm_explain.json"),
-            PathType::Url => Ok("_ilm/explain"),
+            PathType::Url => Ok("_all/_ilm/explain"),
         }
     }
 

--- a/src/data/elasticsearch/indices_settings.rs
+++ b/src/data/elasticsearch/indices_settings.rs
@@ -60,7 +60,7 @@ impl IndexSettings {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 pub struct Settings {
     settings: Index,
 }
@@ -72,7 +72,7 @@ impl Settings {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 struct Index {
     index: IndexSettings,
 }

--- a/src/data/elasticsearch/indices_settings.rs
+++ b/src/data/elasticsearch/indices_settings.rs
@@ -60,6 +60,40 @@ impl IndexSettings {
     }
 }
 
+impl std::default::Default for IndexSettings {
+    fn default() -> Self {
+        IndexSettings {
+            allocation: None,
+            auto_expand_replicas: None,
+            blocks: None,
+            codec: "unkown".to_string(),
+            creation_date: None,
+            default_pipeline: None,
+            final_pipeline: None,
+            hidden: None,
+            lifecycle: None,
+            mapping: None,
+            mode: "unkown".to_string(),
+            number_of_replicas: None,
+            number_of_shards: None,
+            priority: None,
+            provided_name: None,
+            query: None,
+            refresh_interval: "unkown".to_string(),
+            routing: None,
+            shard: None,
+            shard_limit: None,
+            store: None,
+            sort: None,
+            uuid: "".to_string(),
+            version: Value::Null,
+            age: None,
+            data_stream: None,
+            name: None,
+        }
+    }
+}
+
 #[derive(Deserialize, Serialize)]
 pub struct Settings {
     settings: Index,

--- a/src/data/elasticsearch/indices_stats.rs
+++ b/src/data/elasticsearch/indices_stats.rs
@@ -25,7 +25,7 @@ impl DataSource for IndicesStats {
     fn source(path: PathType) -> Result<&'static str> {
         match path {
             PathType::File => Ok("indices_stats.json"),
-            PathType::Url => Ok("_index/stats?level=shards"),
+            PathType::Url => Ok("_all/_stats?level=shards"),
         }
     }
 

--- a/src/data/elasticsearch/nodes.rs
+++ b/src/data/elasticsearch/nodes.rs
@@ -44,10 +44,10 @@ struct ComponentVersion {
 #[derive(Clone, Deserialize, Serialize)]
 pub struct OsDetails {
     pub refresh_interval_in_millis: usize,
-    pub name: String,
-    pub pretty_name: String,
-    pub arch: String,
-    pub version: String,
+    pub name: Option<String>,
+    pub pretty_name: Option<String>,
+    pub arch: Option<String>,
+    pub version: Option<String>,
     pub available_processors: usize,
     pub allocated_processors: usize,
 }

--- a/src/data/elasticsearch/nodes.rs
+++ b/src/data/elasticsearch/nodes.rs
@@ -52,9 +52,7 @@ pub struct OsDetails {
     pub allocated_processors: usize,
 }
 
-// Deserializing data structures
-
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 pub struct Nodes {
     _nodes: Value,
     //cluster_name: String,

--- a/src/data/elasticsearch/nodes_stats.rs
+++ b/src/data/elasticsearch/nodes_stats.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 pub struct NodesStats {
     _nodes: Value,
     //cluster_name: String,

--- a/src/data/elasticsearch/searchable_snapshots_cache_stats.rs
+++ b/src/data/elasticsearch/searchable_snapshots_cache_stats.rs
@@ -3,12 +3,12 @@ use color_eyre::eyre::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct SearchableSnapshotsCacheStats {
     pub nodes: HashMap<String, SharedCache>,
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct SharedCache {
     pub shared_cache: SharedCacheStats,
 }

--- a/src/data/elasticsearch/searchable_snapshots_stats.rs
+++ b/src/data/elasticsearch/searchable_snapshots_stats.rs
@@ -4,14 +4,14 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct SearchableSnapshotsStats {
     pub _shards: Value,
     pub total: Vec<Value>,
     pub indices: HashMap<String, Total>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Total {
     pub total: Vec<Value>,
 }

--- a/src/data/elasticsearch/tasks.rs
+++ b/src/data/elasticsearch/tasks.rs
@@ -37,7 +37,7 @@ impl DataSource for Tasks {
     fn source(path: PathType) -> Result<&'static str> {
         match path {
             PathType::File => Ok("tasks.json"),
-            PathType::Url => Ok("_tasks"),
+            PathType::Url => Ok("_tasks?detailed=true"),
         }
     }
 

--- a/src/data/elasticsearch/tasks.rs
+++ b/src/data/elasticsearch/tasks.rs
@@ -4,12 +4,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Tasks {
     pub nodes: HashMap<String, NodeTasks>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct NodeTasks {
     pub tasks: HashMap<String, Task>,
 }
@@ -19,7 +19,7 @@ pub struct Task {
     action: String,
     cancellable: bool,
     cancelled: Option<bool>,
-    description: String,
+    description: Option<String>,
     headers: Option<Value>,
     id: u64,
     //node: Option<String>, // omitted in favor of enriched node field

--- a/src/exporter.rs
+++ b/src/exporter.rs
@@ -1,3 +1,5 @@
+/// Write to a directory
+mod directory;
 /// Export to an Elasticsearch cluster with the `_bulk` API
 mod elasticsearch;
 /// Write to an `.ndjson` file
@@ -5,6 +7,7 @@ mod file;
 /// Write `ndjson` to std out
 mod stream;
 
+pub use directory::DirectoryExporter;
 use elasticsearch::ElasticsearchExporter;
 use file::FileExporter;
 use stream::StreamExporter;

--- a/src/exporter/directory.rs
+++ b/src/exporter/directory.rs
@@ -1,0 +1,59 @@
+use color_eyre::eyre::{eyre, Result};
+use serde::Serialize;
+use std::{fs::File, path::PathBuf};
+
+use crate::data::Uri;
+
+pub struct DirectoryExporter {
+    path: PathBuf,
+}
+
+impl DirectoryExporter {
+    pub async fn save<T>(&self, path: PathBuf, content: T) -> Result<()>
+    where
+        T: Serialize,
+    {
+        let path = &self.path.join(path);
+        log::debug!("Writing file: {}", &path.display());
+        let file = File::create(path)?;
+        serde_json::to_writer_pretty(&file, &content)?;
+        Ok(())
+    }
+}
+
+impl TryFrom<Uri> for DirectoryExporter {
+    type Error = color_eyre::eyre::Report;
+
+    fn try_from(uri: Uri) -> Result<Self> {
+        match uri {
+            Uri::Directory(path) => Self::try_from(path),
+            Uri::File(path) => Self::try_from(path),
+            _ => Err(eyre!("Expected directory got {uri:?}")),
+        }
+    }
+}
+
+impl TryFrom<PathBuf> for DirectoryExporter {
+    type Error = color_eyre::eyre::Report;
+
+    fn try_from(path: PathBuf) -> Result<Self> {
+        let subpath = path.join("commercial");
+        if !path.exists() {
+            log::debug!("Creating directory: {}", &subpath.display());
+            std::fs::create_dir_all(subpath)?;
+        }
+        match path.is_dir() {
+            true => Ok(Self { path }),
+            false => Err(eyre!(
+                "Directory input must be a directory: {}",
+                path.display()
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for DirectoryExporter {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.path.display())
+    }
+}

--- a/src/exporter/directory.rs
+++ b/src/exporter/directory.rs
@@ -1,22 +1,17 @@
-use color_eyre::eyre::{eyre, Result};
-use serde::Serialize;
-use std::{fs::File, path::PathBuf};
-
 use crate::data::Uri;
+use color_eyre::eyre::{eyre, Result};
+use std::{fs::File, io::Write, path::PathBuf};
 
 pub struct DirectoryExporter {
     path: PathBuf,
 }
 
 impl DirectoryExporter {
-    pub async fn save<T>(&self, path: PathBuf, content: T) -> Result<()>
-    where
-        T: Serialize,
-    {
+    pub async fn save(&self, path: PathBuf, content: String) -> Result<()> {
         let path = &self.path.join(path);
         log::debug!("Writing file: {}", &path.display());
-        let file = File::create(path)?;
-        serde_json::to_writer_pretty(&file, &content)?;
+        let mut file = File::create(path)?;
+        file.write_all(content.as_bytes())?;
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 /// Shared client libraries for remote connections
 pub mod client;
+/// Collect diagnostic data from applications
+pub mod collector;
 /// Data structures and types for serializing and deserializing
 pub mod data;
 /// Environment variables

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 /// Shared client libraries for remote connections
 pub mod client;
-/// Collect diagnostic data from applications
-pub mod collector;
 /// Data structures and types for serializing and deserializing
 pub mod data;
 /// Environment variables

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,7 @@ use clap::{Parser, Subcommand};
 use color_eyre::eyre::{eyre, Result};
 use esdiag::{
     client::Host,
-    collector::Collector,
-    data::Uri,
+    data::{Collector, Uri},
     env::LOG_LEVEL,
     exporter::{DirectoryExporter, Exporter},
     processor::Diagnostic,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,13 +22,13 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
-    /// [NOT IMPLEMENTED] Collects diagnostics from a host's API endpoints
+    /// Collects diagnostics from an Elasticsearch host's API endpoints, saves to a directory
     Collect {
         /// The host to collect diagnostics from
-        #[arg(help = "The host to collect diagnostics from")]
+        #[arg(help = "The Elasticsearch host to collect diagnostics from")]
         host: String,
         /// The output directory to save the diagnostics to
-        #[arg(help = "Theoutput to save the diagnostics to (file, directory)")]
+        #[arg(help = "The directory to save the diagnostics files to")]
         output: String,
     },
     /// Configure and test a remote host connection

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,14 @@
 use clap::{Parser, Subcommand};
 use color_eyre::eyre::{eyre, Result};
 use esdiag::{
-    client::Host, data::Uri, env::LOG_LEVEL, exporter::Exporter, processor::Diagnostic,
-    receiver::Receiver, setup,
+    client::Host,
+    collector::Collector,
+    data::Uri,
+    env::LOG_LEVEL,
+    exporter::{DirectoryExporter, Exporter},
+    processor::Diagnostic,
+    receiver::Receiver,
+    setup,
 };
 use url::Url;
 
@@ -118,11 +124,21 @@ async fn run() -> Result<&'static str> {
     let cli = Cli::parse();
 
     match &cli.command {
-        Commands::Collect { host, output } => Err(eyre!(
-            "Collect command not yet implemented! host: {}, output: {}",
-            host,
-            output
-        )),
+        Commands::Collect { host, output } => {
+            let host = Uri::parse(host)?;
+            let output = Uri::parse(output)?;
+            match host {
+                Uri::Host(_) => {
+                    log::info!("Collecting diagnostic from {host}");
+                    let receiver = Receiver::try_from(host)?;
+                    let exporter = DirectoryExporter::try_from(output)?;
+                    let collector = Collector::try_new(receiver, exporter).await?;
+                    collector.collect().await?;
+                    Ok("collect")
+                }
+                _ => Err(eyre!("Collect requires a known host")),
+            }
+        }
         Commands::Host {
             name,
             app,

--- a/src/processor/elasticsearch/index_stats.rs
+++ b/src/processor/elasticsearch/index_stats.rs
@@ -1,5 +1,8 @@
 use super::{DataProcessor, ElasticsearchMetadata, Lookups};
-use crate::{data::elasticsearch::IndicesStats, processor::Metadata};
+use crate::{
+    data::elasticsearch::{IndexSettings, IndicesStats},
+    processor::Metadata,
+};
 use json_patch::merge;
 use rayon::prelude::*;
 use serde_json::{json, Value};
@@ -32,14 +35,7 @@ impl DataProcessor<Lookups, ElasticsearchMetadata> for IndicesStats {
                 let ilm = lookup.ilm_explain.by_name(&index);
                 let index_settings = match lookup.index_settings.by_name(&index) {
                     Some(settings) => settings,
-                    None if &index == ".geoip_databases" || &index == ".tasks" => {
-                        log::debug!("Skipping index: {}", index);
-                        return Vec::new();
-                    }
-                    None => {
-                        log::debug!("No index settings found for index: {}", index);
-                        return Vec::new();
-                    }
+                    None => &IndexSettings::default(),
                 };
                 let is_write_index = {
                     data_stream.is_some_and(|ds| ds.is_write_index)

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -7,7 +7,7 @@ mod elasticsearch;
 
 use archive::ArchiveReceiver;
 use directory::DirectoryReceiver;
-use elasticsearch::ElasticsearchReceiver;
+pub use elasticsearch::ElasticsearchReceiver;
 
 use crate::data::{
     diagnostic::{DataSource, DiagnosticManifest, Manifest},

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -24,6 +24,9 @@ trait Receive {
     async fn get<T>(&self) -> Result<T>
     where
         T: DataSource + DeserializeOwned;
+    async fn get_raw<T>(&self) -> Result<String>
+    where
+        T: DataSource;
 }
 
 /// The different types of receivers for data input.
@@ -55,6 +58,19 @@ impl Receiver {
             Receiver::Directory(directory_receiver) => directory_receiver.get::<T>().await,
             Receiver::Elasticsearch(elasticsearch_receiver) => {
                 elasticsearch_receiver.get::<T>().await
+            }
+        }
+    }
+
+    pub async fn get_raw<T>(&self) -> Result<String>
+    where
+        T: DataSource,
+    {
+        match self {
+            Receiver::Archive(archive_receiver) => archive_receiver.get_raw::<T>().await,
+            Receiver::Directory(directory_receiver) => directory_receiver.get_raw::<T>().await,
+            Receiver::Elasticsearch(elasticsearch_receiver) => {
+                elasticsearch_receiver.get_raw::<T>().await
             }
         }
     }

--- a/src/receiver/archive.rs
+++ b/src/receiver/archive.rs
@@ -2,7 +2,12 @@ use super::Receive;
 use crate::data::diagnostic::{data_source::PathType, DataSource};
 use color_eyre::{eyre::eyre, Result};
 use serde::de::DeserializeOwned;
-use std::{fs::File, io::BufReader, path::PathBuf, sync::Arc};
+use std::{
+    fs::File,
+    io::{BufReader, Read},
+    path::PathBuf,
+    sync::Arc,
+};
 use tokio::sync::RwLock;
 use zip::ZipArchive;
 
@@ -81,6 +86,31 @@ impl Receive for ArchiveReceiver {
         let file = archive.by_name(&file_str)?;
         let reader = BufReader::new(file);
         let data: T = serde_json::from_reader(reader)?;
+        Ok(data)
+    }
+
+    async fn get_raw<T>(&self) -> Result<String>
+    where
+        T: DataSource,
+    {
+        let filename = T::source(PathType::File)?;
+        let file_str = match &self.subdir {
+            // Ugly hack to make ECK bundles with double-slashed paths work
+            // This will break if the sub-paths are fixed in the ECK bundles
+            Some(subdir) => &format!("{}//{}", subdir.display(), filename),
+            None => {
+                let subdir = self.get_subdir().await.map(|s| s.join(filename))?;
+                &format!("{}", subdir.display())
+            }
+        };
+        let mut archive = self.archive.write().await;
+
+        // Read lines directly from the compressed file
+        log::debug!("Reading {}", file_str);
+        let file = archive.by_name(&file_str)?;
+        let mut reader = BufReader::new(file);
+        let mut data = String::new();
+        reader.read_to_string(&mut data)?;
         Ok(data)
     }
 

--- a/src/receiver/directory.rs
+++ b/src/receiver/directory.rs
@@ -2,7 +2,11 @@ use super::Receive;
 use crate::data::diagnostic::{data_source::PathType, DataSource};
 use color_eyre::eyre::{eyre, Result};
 use serde::de::DeserializeOwned;
-use std::{fs::File, io::BufReader, path::PathBuf};
+use std::{
+    fs::File,
+    io::{BufReader, Read},
+    path::PathBuf,
+};
 
 #[derive(Clone)]
 pub struct DirectoryReceiver {
@@ -53,6 +57,22 @@ impl Receive for DirectoryReceiver {
         let file = File::open(&filename)?;
         let reader = BufReader::new(file);
         let data: T = serde_json::from_reader(reader)?;
+        Ok(data)
+    }
+
+    async fn get_raw<T>(&self) -> Result<String>
+    where
+        T: DataSource,
+    {
+        let filename = &self
+            .path
+            .join(&self.work_dir)
+            .join(T::source(PathType::File)?);
+        log::debug!("Reading file: {}", &filename.display());
+        let file = File::open(&filename)?;
+        let mut reader = BufReader::new(file);
+        let mut data = String::new();
+        reader.read_to_string(&mut data)?;
         Ok(data)
     }
 

--- a/src/receiver/elasticsearch.rs
+++ b/src/receiver/elasticsearch.rs
@@ -83,8 +83,31 @@ impl Receive for ElasticsearchReceiver {
             )
             .await?;
 
-        // turbo-fish serde deserialization of the JSON response
         response.json::<T>().await.map_err(Into::into)
+    }
+
+    async fn get_raw<T>(&self) -> Result<String>
+    where
+        T: DataSource,
+    {
+        // Get the API URL path for the provided type
+        let path = T::source(PathType::Url)?;
+        log::debug!("Getting API: {}", &path);
+
+        // Send a simple GET request to the API path
+        let response = self
+            .client
+            .send(
+                http::Method::Get,
+                &path,
+                http::headers::HeaderMap::new(),
+                Option::<&String>::None,
+                Option::<&String>::None,
+                None,
+            )
+            .await?;
+
+        response.text().await.map_err(Into::into)
     }
 
     fn set_work_dir(&mut self, work_dir: &str) -> Result<()> {


### PR DESCRIPTION
First implementation of the `collect` command. Only works for a current Elasticsearch cluster (not tested against legacy version), saved in a known host, to a local directory.