### PR TITLE
Adds a process command to replace import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "esdiag"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esdiag"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.80"
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 Elastic Stack Diagnostics
 ==============================
 
-The Elastic Stack Diagnostics (`esdiag`) tool simplifies processing and importing diagnostic bundles into Elasticsearch. By pre-processing, splitting, and enriching the raw API outputs, building Kibana dashboards and ES|QL queries on diagnostic data is easy.
+The Elastic Stack Diagnostics (`esdiag`) tool simplifies processing and importing diagnostic bundles into Elasticsearch. It pre-processes, split and enriches the raw API outputs into Elasticsearch-friendly documents. This makes building diagnostic Kibana dashboards, ES|QL queries, and more, easy.
 
 Installation
 --------------------
@@ -84,18 +84,17 @@ Usage
 
 1. Save a target Elasticsearch cluster to the hosts configuration
     ```sh
-    esdiag host my_cluster elasticsearch http://localhost:9200 --auth None --save
+    esdiag host my_cluster elasticsearch http://localhost:9200 --auth none
     ```
-
 
 2. Setup the Elasticsearch cluster with the templates, data streams, etc.
     ```sh
     esdiag setup my_cluster
     ```
 
-3. Import a diagnostic bundle from a local directory
+3. Process a diagnostic bundle from a local directory to `my_cluster`
     ```sh
-    esdiag import my_cluster ~/downloads/api-diagnostic-20240506-0050225
+    esdiag process ~/downloads/api-diagnostic-20240506-0050225 my_cluster
     ```
 
 4. Open Kibana and explore!
@@ -113,10 +112,11 @@ Elastic Stack Diagnostics (esdiag) - collect diagnostics and import into Elastic
 Usage: esdiag <COMMAND>
 
 Commands:
-  collect  Collects diagnostics from an Elasticsearch host's API endpoints, saves to a directory
-  import   Process, enrich and import a diagnostic into Elasticsearch
+  collect  Collect a diagnostic bundle from a known host's API endpoints, writes output to a directory
   host     Configure and test a remote host connection
-  setup    Setup required assets to visualize diagnostic imports
+  import   [DEPRECATED] Process, enrich and import a diagnostic into Elasticsearch
+  process  Receives a diagnostic from the input, processes it, and sends processed docs to the output
+  setup    Import assets (templates, ingest pipelines, etc.) to a known Elasticsearch host
   help     Print this message or the help of the given subcommand(s)
 
 Options:
@@ -125,10 +125,10 @@ Options:
 
 #### Host
 
-The `esdiag host` command allows you configure and test authentication information, then save it to your `~/esdiag/hosts.yml` file for easy re-use.
+The `esdiag host` command allows you configure and test authentication information. On a succesful connection test, it writes the configuration to your `~/esdiag/hosts.yml` file for easy re-use.
 
 ```
-Configure and test a remote host connection
+Configure, test and save a remote host connection to `~/.esdiag/hosts.yml`
 
 Usage: esdiag host [OPTIONS] <NAME> [APP] [URL]
 
@@ -138,26 +138,27 @@ Arguments:
   [URL]   A host URL to connect to
 
 Options:
-      --auth <AUTH>          Authentication method to use (none, basic, apikey, etc.) [default: none]
-  -a, --apikey <APIKEY>      ApiKey, passed as http header
-  -c, --cloud-id <CLOUD_ID>  Elastic Cloud ID (optional)
-  -u, --username <USERNAME>  Username for authentication
-  -p, --password <PASSWORD>  Password for authentication
-  -s, --save                 Save the host configuration
-  -h, --help                 Print help
+      --auth <AUTH>           Authentication method to use (none, basic, apikey, etc.) [default: none]
+      --accept-invalid-certs  Accept invalid certificates
+  -a, --apikey <APIKEY>       ApiKey, passed as http header
+  -c, --cloud-id <CLOUD_ID>   Elastic Cloud ID (optional)
+  -u, --username <USERNAME>   Username for authentication
+  -p, --password <PASSWORD>   Password for authentication
+  -n, --nosave                Don't save the host configuration on succesful connection
+  -h, --help                  Print help
 ```
 
 #### Setup
 
-The `esdiag setup` command will send all the required index templates and other assets into the target host, this must be an Elasticsearch cluster!
+You must setup a known host to use the `esdiag setup` command. It will send the required index templates and other assets into your Elasticsearch cluster.
 
 ```
-Setup required assets to visualize diagnostic imports
+Import assets (templates, ingest pipelines, etc.) to a known Elasticsearch host
 
 Usage: esdiag setup <HOST>
 
 Arguments:
-  <HOST>  Host to setup assets in
+  <HOST>  Known Elasticsearch host to import assets into
 
 Options:
   -h, --help  Print help
@@ -165,28 +166,57 @@ Options:
 
 #### Import
 
-The `esdiag import` command allows these `target` and `source` options:
+> ⚠️ DEPRECATED: This command will be removed in a future version.
 
-`target`
-    1. stdout (use `-` as the target name)
-    2. directory (the root directory of a diagnostic bundle)
-    3. host (a known host saved to your `hosts.yml`)
+#### Process
 
-`source`
-    1. directory
+The `esdiag process <input> <output>` will read the diagnostic data from `<input>`, run the source documents through a series of processors, and send the enriched documents to the `<output>` target.
+
+The `<input>` may be:
+    1. Archive file - a `.zip` output from the [support diangostic](https://github.com/elastic/support-diagnostics) tool
+    2. Directory - the uncompressed directory from an archive
+    3. Known host - saved in the `hosts.yml`
+
+The `<output>` may be:
+    1. Known host - Must be an Elasticsearch host saved in the `hosts.yml`
+    2. File - writes in an `.ndjson` format
+    3. `stdout` - use `-` as the output name
 
 ```
-Process, enrich and import a diagnostic into Elasticsearch
+Receives a diagnostic from the input, processes it, and sends processed docs to the output
 
-Usage: esdiag import [OPTIONS] <TARGET> <SOURCE>
+Usage: esdiag process <INPUT> <OUTPUT>
 
 Arguments:
-  <TARGET>  Target to write processed diagnostic documents to (`-` for stdout)
-  <SOURCE>  Source to read diagnostic data from
+  <INPUT>   Source to read diagnostic data from (archive, directory, or known host)
+  <OUTPUT>  Target to send processed diagnostic documents to (known host, file, or stdout)
 
 Options:
-  -p, --pretty  Pretty print JSON
-  -h, --help    Print help
+  -h, --help  Print help
+```
+
+Once you have known hosts configured, you can add a simple shell commands shortcuts to your `~/.bashrc` or `~/.zshrc`. For example if you have `diag-cluster` as a known host:
+
+```sh
+esd() { esdiag process $1 diag-cluster }
+```
+
+Allows you to process diagnostics into the remote cluster with only:
+
+```sh
+esd ~/Downloads/api-diagnostic-20240506-0050225.zip
+```
+
+And a second function for an Elasticsearch cluster on your local machine, with `localhost` as a configured known host:
+
+```sh
+esdl() { esdiag process $1 localhost }
+```
+
+To pull a diagnostic into your local cluster directly from `diag-cluster`:
+
+```sh
+esdl diag-cluster
 ```
 
 #### Collect
@@ -196,7 +226,7 @@ The `esdiag collect` command pulls the minimum required diagnostics from an Elas
 Authentication must be setup in advance with the `esdiag host` command or `hosts.yml` file. Direct access to the clsuter is required, this cannot be done through any Elastic Cloud API.
 
 ```
-Collects diagnostics from an Elasticsearch host's API endpoints, saves to a directory
+Collect a diagnostic bundle from a known host's API endpoints, writes output to a directory
 
 Usage: esdiag collect <HOST> <OUTPUT>
 
@@ -216,7 +246,7 @@ Use a shell environment variables to enable debug logging:
 export LOG_LEVEL=debug
 ```
 
-This will enable debug-level messages. Also, when you import a diagnostic `esdiag` will write two new files in your `~/.esdiag` directory:
+This will enable debug-level log messages and when processing a diagnostic, `esdiag` will write debugging files into an `~/.esdiag/last_run` directory:
 
 1. `metadata.ndjson` - This contains the diagnostic metadata and lookup tables generated while processing the diagnostic.
 2. `responses.ndjson` - This contains all the HTTP responses from the Elasticsearch `_bulk` API.

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,8 +3,8 @@ mod auth;
 /// Wrapper for building Elasticsearch connections
 mod elasticsearch;
 /// Manage saving and loading hosts from a YAML file
-mod host;
+mod known_host;
 
 pub use auth::{Auth, AuthType};
 pub use elasticsearch::ElasticsearchBuilder;
-pub use host::Host;
+pub use known_host::KnownHost;

--- a/src/client/elasticsearch.rs
+++ b/src/client/elasticsearch.rs
@@ -1,4 +1,4 @@
-use super::{auth::Auth, host::Host};
+use super::{auth::Auth, known_host::KnownHost};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use color_eyre::eyre::Result;
 use elasticsearch::{
@@ -84,12 +84,12 @@ impl ElasticsearchBuilder {
     }
 }
 
-impl TryFrom<Host> for Elasticsearch {
+impl TryFrom<KnownHost> for Elasticsearch {
     type Error = color_eyre::eyre::Report;
 
-    fn try_from(host: Host) -> Result<Elasticsearch> {
+    fn try_from(host: KnownHost) -> Result<Elasticsearch> {
         let client = match host {
-            Host::ApiKey {
+            KnownHost::ApiKey {
                 apikey,
                 url,
                 accept_invalid_certs,
@@ -98,7 +98,7 @@ impl TryFrom<Host> for Elasticsearch {
                 .apikey(apikey)
                 .insecure(accept_invalid_certs.unwrap_or(false))
                 .build()?,
-            Host::Basic {
+            KnownHost::Basic {
                 accept_invalid_certs,
                 username,
                 password,
@@ -108,7 +108,7 @@ impl TryFrom<Host> for Elasticsearch {
                 .basic_auth(username, password)
                 .insecure(accept_invalid_certs.unwrap_or(false))
                 .build()?,
-            Host::None { url, .. } => ElasticsearchBuilder::new(url).build()?,
+            KnownHost::None { url, .. } => ElasticsearchBuilder::new(url).build()?,
         };
         Ok(client)
     }

--- a/src/client/known_host.rs
+++ b/src/client/known_host.rs
@@ -83,7 +83,7 @@ impl KnownHost {
         }
     }
 
-    pub fn save(self, name: String) -> Result<String> {
+    pub fn save(self, name: &String) -> Result<String> {
         // parse the ~/.esdiag/hosts.yml file into a HashMap<String, Host>
         let mut hosts = match KnownHost::parse_hosts_yml() {
             Ok(hosts) => hosts,

--- a/src/client/known_host.rs
+++ b/src/client/known_host.rs
@@ -16,7 +16,7 @@ use url::Url;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "auth")]
-pub enum Host {
+pub enum KnownHost {
     /// A host using API key authentication
     ApiKey {
         accept_invalid_certs: Option<bool>,
@@ -40,7 +40,7 @@ pub enum Host {
     None { app: Product, url: Url },
 }
 
-impl Host {
+impl KnownHost {
     pub fn new(
         url: Url,
         app: String,
@@ -52,14 +52,14 @@ impl Host {
         password: Option<String>,
     ) -> Self {
         match Auth::from_str(&auth) {
-            Ok(Auth::ApiKey) => Host::ApiKey {
+            Ok(Auth::ApiKey) => KnownHost::ApiKey {
                 apikey: apikey.expect("ApiKey auth requires an API key!"),
                 app: Product::from_str(&app).expect("A valid application is required!"),
                 accept_invalid_certs: Some(accept_invalid_certs),
                 cloud_id,
                 url,
             },
-            Ok(Auth::Basic) => Host::Basic {
+            Ok(Auth::Basic) => KnownHost::Basic {
                 app: Product::from_str(&app).expect("A valid application is required!"),
                 accept_invalid_certs: Some(accept_invalid_certs),
                 cloud_id,
@@ -67,7 +67,7 @@ impl Host {
                 url,
                 username: username.expect("Basic auth requires a username!"),
             },
-            Ok(Auth::None) => Host::None {
+            Ok(Auth::None) => KnownHost::None {
                 app: Product::from_str(&app).expect("A valid application is required!"),
                 url,
             },
@@ -85,7 +85,7 @@ impl Host {
 
     pub fn save(self, name: String) -> Result<String> {
         // parse the ~/.esdiag/hosts.yml file into a HashMap<String, Host>
-        let mut hosts = match Host::parse_hosts_yml() {
+        let mut hosts = match KnownHost::parse_hosts_yml() {
             Ok(hosts) => hosts,
             Err(e) => {
                 log::error!("Error parsing hosts.yml: {}", e);
@@ -103,12 +103,12 @@ impl Host {
                 hosts.insert(name.clone(), self);
             }
         }
-        Host::write_hosts_yml(&hosts)
+        KnownHost::write_hosts_yml(&hosts)
     }
 
     pub fn get_known(host: &String) -> Option<Self> {
         // parse the ~/.esdiag/hosts.yml file into a HashMap<String, Host>
-        let hosts = match Host::parse_hosts_yml() {
+        let hosts = match KnownHost::parse_hosts_yml() {
             Ok(hosts) => hosts,
             Err(e) => {
                 log::error!("Error parsing hosts.yml: {}", e);
@@ -128,7 +128,7 @@ impl Host {
     }
 
     pub fn from_url(url: &Url) -> Self {
-        Host::None {
+        KnownHost::None {
             app: Product::Elasticsearch,
             url: url.clone(),
         }
@@ -242,14 +242,14 @@ impl Host {
     }
 
     /// loads hosts from the resources directory
-    pub fn parse_hosts_yml() -> Result<BTreeMap<String, Host>> {
-        let path = Host::get_hosts_path();
+    pub fn parse_hosts_yml() -> Result<BTreeMap<String, KnownHost>> {
+        let path = KnownHost::get_hosts_path();
         log::debug!("Parsing {:?}", path);
         match path.is_file() {
             true => {
                 let file = File::open(path)?;
                 let reader = BufReader::new(file);
-                let hosts: BTreeMap<String, Host> = serde_yaml::from_reader(reader)?;
+                let hosts: BTreeMap<String, KnownHost> = serde_yaml::from_reader(reader)?;
                 Ok(hosts)
             }
             false => {
@@ -260,8 +260,8 @@ impl Host {
         }
     }
 
-    pub fn write_hosts_yml(hosts: &BTreeMap<String, Host>) -> Result<String> {
-        let path = Host::get_hosts_path();
+    pub fn write_hosts_yml(hosts: &BTreeMap<String, KnownHost>) -> Result<String> {
+        let path = KnownHost::get_hosts_path();
         log::debug!(
             "Writing hosts: {} to {:?}",
             hosts
@@ -279,7 +279,7 @@ impl Host {
     }
 }
 
-impl Display for Host {
+impl Display for KnownHost {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ApiKey {
@@ -310,10 +310,10 @@ impl Display for Host {
     }
 }
 
-impl FromStr for Host {
+impl FromStr for KnownHost {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match Host::get_known(&s.to_string()) {
+        match KnownHost::get_known(&s.to_string()) {
             Some(host) => Ok(host),
             None => Err(()),
         }

--- a/src/data/uri.rs
+++ b/src/data/uri.rs
@@ -1,5 +1,5 @@
-use crate::client::Host;
-use color_eyre::eyre::Result;
+use crate::client::KnownHost;
+use color_eyre::eyre::{Report, Result};
 use std::{
     path::{Path, PathBuf},
     str::FromStr,
@@ -10,7 +10,7 @@ use url::Url;
 #[derive(Clone, Debug)]
 pub enum Uri {
     /// Represents a host saved in the hosts.yml
-    Host(Host),
+    KnownHost(KnownHost),
     /// Represents a standard URL
     Url(Url),
     /// Represents a directory path on the local file system
@@ -21,14 +21,14 @@ pub enum Uri {
     Stream,
 }
 
-/// Classifies a URI string into a specific `Uri` variant based on its type.
+/// Converts a string slice into a specific `Uri` variant based on its type.
 ///
-/// This function takes a URI string and categorizes it into different types represented by the `Uri` enum.
-/// It supports classifying a URI as a stream, host, URL, directory, or file based on various checks.
+/// This implementation of the `TryFrom` trait takes a URI string and categorizes it into different types represented by the `Uri` enum.
+/// It supports converting a URI string into a stream, host, URL, directory, or file based on various checks.
 ///
 /// # Arguments
 ///
-/// * `uri` - A string slice representing the URI to classify.
+/// * `uri` - A string slice representing the URI to convert.
 ///
 /// # Returns
 ///
@@ -38,11 +38,11 @@ pub enum Uri {
 /// - `Ok(Uri::Url(url))` if the URI can be parsed into a `Url`.
 /// - `Ok(Uri::Directory(path))` if the URI is a valid directory path.
 /// - `Ok(Uri::File(path))` if the URI is a valid file path.
-/// - `Err(std::io::Error)` if there are errors during file creation or other I/O operations.
+/// - `Err(Report)` if there are errors during file creation or other I/O operations.
 ///
 /// # Errors
 ///
-/// Returns an `Err(std::io::Error)` if there are errors during file creation or other I/O operations.
+/// Returns an `Err(Report)` if there are errors during file creation or other I/O operations.
 ///
 /// # Examples
 ///
@@ -50,22 +50,24 @@ pub enum Uri {
 /// use std::path::PathBuf;
 ///
 /// let uri = "-";
-/// match classify(uri) {
+/// match Uri::try_from(uri) {
 ///     Ok(Uri::Stream) => println!("URI is a stream"),
 ///     Ok(_) => println!("URI classified successfully"),
-///     Err(e) => eprintln!("Failed to classify URI: {}", e),
+///     Err(e) => eprintln!("Failed to parse URI: {}", e),
 /// }
 /// ```
 
-impl Uri {
-    pub fn parse(uri: &str) -> Result<Self> {
+impl TryFrom<&str> for Uri {
+    type Error = Report;
+
+    fn try_from(uri: &str) -> Result<Self> {
         match uri {
             "-" => Ok(Uri::Stream),
             _ => {
-                let host = Host::from_str(&uri);
+                let host = KnownHost::from_str(&uri);
                 match host {
                     Err(_) => log::debug!("No known host {uri}"),
-                    Ok(host) => return Ok(Uri::Host(host)),
+                    Ok(host) => return Ok(Uri::KnownHost(host)),
                 }
                 match Url::parse(&uri) {
                     Err(_) => log::debug!("Not a valid URL {uri}"),
@@ -92,10 +94,26 @@ impl Uri {
     }
 }
 
+impl TryFrom<&String> for Uri {
+    type Error = Report;
+
+    fn try_from(uri: &String) -> Result<Self> {
+        Uri::try_from(uri.as_str())
+    }
+}
+
+impl TryFrom<String> for Uri {
+    type Error = Report;
+
+    fn try_from(uri: String) -> Result<Self> {
+        Uri::try_from(uri.as_str())
+    }
+}
+
 impl std::fmt::Display for Uri {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Uri::Host(host) => write!(f, "{}", host),
+            Uri::KnownHost(host) => write!(f, "{}", host),
             Uri::Url(url) => write!(f, "{}", url),
             Uri::Directory(path) => write!(f, "{}", path.display()),
             Uri::File(path) => write!(f, "{}", path.display()),

--- a/src/exporter.rs
+++ b/src/exporter.rs
@@ -68,7 +68,7 @@ impl TryFrom<Uri> for Exporter {
     fn try_from(uri: Uri) -> std::result::Result<Self, Self::Error> {
         match uri {
             Uri::File(file) => Ok(Exporter::File(FileExporter::try_from(file)?)),
-            Uri::Host(host) => Ok(Exporter::Elasticsearch(ElasticsearchExporter::try_from(
+            Uri::KnownHost(host) => Ok(Exporter::Elasticsearch(ElasticsearchExporter::try_from(
                 host,
             )?)),
             Uri::Stream => Ok(Exporter::Stream(StreamExporter::new())),

--- a/src/exporter/elasticsearch.rs
+++ b/src/exporter/elasticsearch.rs
@@ -1,6 +1,6 @@
 use super::Export;
 use crate::{
-    client::{Auth, ElasticsearchBuilder, Host},
+    client::{Auth, ElasticsearchBuilder, KnownHost},
     data,
 };
 use color_eyre::eyre::{eyre, Result};
@@ -57,10 +57,10 @@ impl ElasticsearchExporter {
     }
 }
 
-impl TryFrom<Host> for ElasticsearchExporter {
+impl TryFrom<KnownHost> for ElasticsearchExporter {
     type Error = color_eyre::eyre::Report;
 
-    fn try_from(host: Host) -> Result<Self> {
+    fn try_from(host: KnownHost) -> Result<Self> {
         let url = host.get_url();
         let client = Elasticsearch::try_from(host)?;
         Ok(Self { client, url })

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
-    /// Collects diagnostics from an Elasticsearch host's API endpoints, saves to a directory
+    /// Collect a diagnostic bundle from a known host's API endpoints, writes output to a directory
     Collect {
         /// The host to collect diagnostics from
         #[arg(help = "The Elasticsearch host to collect diagnostics from")]
@@ -65,10 +65,14 @@ enum Commands {
         #[arg(help = "Password for authentication", long, short)]
         password: Option<String>,
         /// Save the host configuration
-        #[arg(help = "Save the host configuration", long, short)]
-        save: bool,
+        #[arg(
+            help = "Don't save the host configuration on succesful connection",
+            long,
+            short
+        )]
+        nosave: bool,
     },
-    /// Process, enrich and import a diagnostic into Elasticsearch
+    /// [DEPRECATED] Process, enrich and import a diagnostic into Elasticsearch
     Import {
         /// The target to write processed diagnostic data to
         #[arg(help = "Target to write processed diagnostic documents to (`-` for stdout)")]
@@ -78,19 +82,22 @@ enum Commands {
         #[arg(help = "Source to read diagnostic data from")]
         source: String,
     },
+    /// Receives a diagnostic from the input, processes it, and sends processed docs to the output
     Process {
-        /// The source to read diagnostic data from
-        #[arg(help = "The source to read diagnostic data from")]
+        /// Source to read diagnostic data from
+        #[arg(help = "Source to read diagnostic data from (archive, directory, or known host)")]
         input: String,
 
-        /// The target to write processed diagnostic data to
-        #[arg(help = "The target to send processed diagnostic documents to")]
+        /// Target to send processed diagnostic documents to
+        #[arg(
+            help = "Target to send processed diagnostic documents to (known host, file, or stdout)"
+        )]
         output: String,
     },
-    /// Setup required assets to visualize diagnostic imports
+    /// Import assets (templates, ingest pipelines, etc.) to a known Elasticsearch host
     Setup {
-        /// Known host to setup assets in, only supports Elasticsearch or Kibana
-        #[arg(help = "Host to setup assets in")]
+        /// Known Elasticsaerch host to import assets into
+        #[arg(help = "Known Elasticsearch host to import assets into")]
         host: String,
     },
 }
@@ -131,7 +138,7 @@ async fn run() -> Result<&'static str> {
     // use clap to parse command line arguments
     let cli = Cli::parse();
 
-    match &cli.command {
+    match cli.command {
         Commands::Collect { host, output } => {
             let known_host = Uri::try_from(host)?;
             let output = Uri::try_from(output)?;
@@ -158,23 +165,24 @@ async fn run() -> Result<&'static str> {
             cloud_id,
             username,
             password,
-            save,
+            nosave,
         } => {
             log::info!("Configuring host {name}");
-            let host = match app.is_some() && url.is_some() {
-                false => KnownHost::get_known(&name).ok_or(eyre!(
-                    "Host {name} not found, include `app` and `url` to setup a new host."
-                ))?,
-                true => KnownHost::new(
-                    url.clone().unwrap(),
-                    app.clone().unwrap(),
-                    auth.clone(),
-                    accept_invalid_certs.clone(),
-                    apikey.clone(),
-                    cloud_id.clone(),
-                    username.clone(),
-                    password.clone(),
-                ),
+            let host = if let (Some(app), Some(url)) = (app, url) {
+                KnownHost::new(
+                    url,
+                    app,
+                    auth,
+                    accept_invalid_certs,
+                    apikey,
+                    cloud_id,
+                    username,
+                    password,
+                )
+            } else {
+                KnownHost::get_known(&name).ok_or(eyre!(
+                    "Host {name} not found, must include `url` and `app` to setup a new host."
+                ))?
             };
 
             let valid_connection = match host.test().await {
@@ -193,13 +201,14 @@ async fn run() -> Result<&'static str> {
                 }
             };
 
-            if *save {
-                let hostfile = host.save(name.to_string())?;
-                log::info!("Host {name} successfully saved to {hostfile}");
-            }
-            match valid_connection {
-                true => Ok("host"),
-                false => Err(eyre!("Host connection failed")),
+            if valid_connection {
+                if !nosave {
+                    let hostfile = host.save(&name)?;
+                    log::info!("Host {name} successfully saved to {hostfile}");
+                }
+                Ok("host")
+            } else {
+                Err(eyre!("Host connection failed"))
             }
         }
         Commands::Process { input, output } => {
@@ -266,6 +275,7 @@ fn clear_last_run_files() -> Result<()> {
     for file in files {
         let file = last_run.join(file);
         log::debug!("Removing {}", &file.display());
+        // Ignore "file not found" errors on delete
         let _ = std::fs::remove_file(file);
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ enum Commands {
         #[arg(help = "The directory to save the diagnostics files to")]
         output: String,
     },
-    /// Configure and test a remote host connection
+    /// Configure, test and save a remote host connection to `~/.esdiag/hosts.yml`
     Host {
         /// A name to identify this host
         #[arg(help = "A name to identify this host")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 use color_eyre::eyre::{eyre, Result};
 use esdiag::{
-    client::Host,
+    client::KnownHost,
     data::{Collector, Uri},
     env::LOG_LEVEL,
     exporter::{DirectoryExporter, Exporter},
@@ -78,6 +78,15 @@ enum Commands {
         #[arg(help = "Source to read diagnostic data from")]
         source: String,
     },
+    Process {
+        /// The source to read diagnostic data from
+        #[arg(help = "The source to read diagnostic data from")]
+        input: String,
+
+        /// The target to write processed diagnostic data to
+        #[arg(help = "The target to send processed diagnostic documents to")]
+        output: String,
+    },
     /// Setup required assets to visualize diagnostic imports
     Setup {
         /// Known host to setup assets in, only supports Elasticsearch or Kibana
@@ -124,12 +133,13 @@ async fn run() -> Result<&'static str> {
 
     match &cli.command {
         Commands::Collect { host, output } => {
-            let host = Uri::parse(host)?;
-            let output = Uri::parse(output)?;
-            match host {
-                Uri::Host(_) => {
-                    log::info!("Collecting diagnostic from {host}");
-                    let receiver = Receiver::try_from(host)?;
+            let known_host = Uri::try_from(host)?;
+            let output = Uri::try_from(output)?;
+            match known_host {
+                Uri::KnownHost(_) => {
+                    log::info!("Collecting diagnostic from {known_host}");
+                    log::info!("Saving diagnostic to {output}");
+                    let receiver = Receiver::try_from(known_host)?;
                     let exporter = DirectoryExporter::try_from(output)?;
                     let collector = Collector::try_new(receiver, exporter).await?;
                     collector.collect().await?;
@@ -152,10 +162,10 @@ async fn run() -> Result<&'static str> {
         } => {
             log::info!("Configuring host {name}");
             let host = match app.is_some() && url.is_some() {
-                false => Host::get_known(&name).ok_or(eyre!(
+                false => KnownHost::get_known(&name).ok_or(eyre!(
                     "Host {name} not found, include `app` and `url` to setup a new host."
                 ))?,
-                true => Host::new(
+                true => KnownHost::new(
                     url.clone().unwrap(),
                     app.clone().unwrap(),
                     auth.clone(),
@@ -192,18 +202,41 @@ async fn run() -> Result<&'static str> {
                 false => Err(eyre!("Host connection failed")),
             }
         }
-        Commands::Import { target, source } => {
-            let output_uri = Uri::parse(target)?;
-            let input_uri = Uri::parse(source)?;
+        Commands::Process { input, output } => {
+            let input_uri = Uri::try_from(input)?;
+            let output_uri = Uri::try_from(output)?;
             log::info!("input: {}", input_uri);
             log::info!("output: {}", output_uri);
 
-            let receiver = Receiver::try_from(input_uri.clone())?;
-            let exporter = Exporter::try_from(output_uri.clone())?;
+            let receiver = Receiver::try_from(input_uri)?;
+            let exporter = Exporter::try_from(output_uri)?;
 
             let manifest = receiver.try_get_manifest().await?;
 
-            log::trace!("{}", serde_json::to_string(&manifest).unwrap());
+            log::trace!("{}", serde_json::to_string(&manifest)?);
+            let diagnostic_processor =
+                Diagnostic::try_new_processor(manifest, receiver, exporter).await?;
+            let (diag_id, doc_count) = diagnostic_processor.run().await?;
+            log::info!(
+                "Created {} documents for diagnostic: {}",
+                doc_count,
+                diag_id
+            );
+            Ok("process")
+        }
+        Commands::Import { target, source } => {
+            let output_uri = Uri::try_from(target)?;
+            let input_uri = Uri::try_from(source)?;
+            log::info!("input: {}", input_uri);
+            log::info!("output: {}", output_uri);
+            log::warn!("The `import` command is deprecated, please use `process` instead");
+
+            let receiver = Receiver::try_from(input_uri)?;
+            let exporter = Exporter::try_from(output_uri)?;
+
+            let manifest = receiver.try_get_manifest().await?;
+
+            log::trace!("{}", serde_json::to_string(&manifest)?);
             let diagnostic_processor =
                 Diagnostic::try_new_processor(manifest, receiver, exporter).await?;
             let (diag_id, doc_count) = diagnostic_processor.run().await?;
@@ -216,7 +249,7 @@ async fn run() -> Result<&'static str> {
         }
         Commands::Setup { host } => {
             log::info!("Setting up Elasticsearch assets in {host}");
-            let uri = Uri::parse(host)?;
+            let uri = Uri::try_from(host)?;
             let exporter = Exporter::try_from(uri)?;
             setup::assets(exporter).await?;
             Ok("setup")

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -122,7 +122,7 @@ impl TryFrom<Uri> for Receiver {
         match uri {
             Uri::Directory(dir) => Ok(Receiver::Directory(DirectoryReceiver::try_from(dir)?)),
             Uri::File(file) => Ok(Receiver::Archive(ArchiveReceiver::try_from(file)?)),
-            Uri::Host(host) => Ok(Receiver::Elasticsearch(ElasticsearchReceiver::try_from(
+            Uri::KnownHost(host) => Ok(Receiver::Elasticsearch(ElasticsearchReceiver::try_from(
                 host,
             )?)),
             _ => Err(eyre!("Unsupported URI")),

--- a/src/receiver/elasticsearch.rs
+++ b/src/receiver/elasticsearch.rs
@@ -1,6 +1,6 @@
 use super::Receive;
 use crate::{
-    client::Host,
+    client::KnownHost,
     data::diagnostic::{data_source::PathType, DataSource},
 };
 use color_eyre::eyre::{eyre, Result};
@@ -21,10 +21,10 @@ impl ElasticsearchReceiver {
     }
 }
 
-impl TryFrom<Host> for ElasticsearchReceiver {
+impl TryFrom<KnownHost> for ElasticsearchReceiver {
     type Error = color_eyre::eyre::Report;
 
-    fn try_from(host: Host) -> Result<Self> {
+    fn try_from(host: KnownHost) -> Result<Self> {
         let url = host.get_url();
         let client = Elasticsearch::try_from(host)?;
         Ok(Self { client, url })


### PR DESCRIPTION
Deprecates the `import` command in favor of a new `process` command. Updates the readme and documentation for the new usage. Some other minor refactoring.