### PR TITLE
Add Elastic Uploader as a data source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,7 @@ name = "esdiag"
 version = "0.3.2"
 dependencies = [
  "base64",
+ "bytes",
  "chrono",
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = "1.80"
 
 [dependencies]
 base64 = "0.22.1"
+bytes = "1.9.0"
 chrono = "^0.4"
 clap = { version = "^4.5", features = ["derive"] }
 color-eyre = "0.6.3"

--- a/readme.md
+++ b/readme.md
@@ -175,6 +175,7 @@ The `<input>` may be:
     1. Archive file - a `.zip` output from the [support diangostic](https://github.com/elastic/support-diagnostics) tool
     2. Directory - the uncompressed directory from an archive
     3. Known host - saved in the `hosts.yml`
+    4. Elastic Uploader link - A url with auth token formated as `https://token:0123456789@upload.elastic.co/d/abcdefghijklmnopqrstuvwxyz`
 
 The `<output>` may be:
     1. Known host - Must be an Elasticsearch host saved in the `hosts.yml`
@@ -187,7 +188,7 @@ Receives a diagnostic from the input, processes it, and sends processed docs to 
 Usage: esdiag process <INPUT> <OUTPUT>
 
 Arguments:
-  <INPUT>   Source to read diagnostic data from (archive, directory, or known host)
+  <INPUT>   Source to read diagnostic data from (archive, directory, known host, or uploader URL)
   <OUTPUT>  Target to send processed diagnostic documents to (known host, file, or stdout)
 
 Options:

--- a/src/client/elasticsearch.rs
+++ b/src/client/elasticsearch.rs
@@ -108,7 +108,7 @@ impl TryFrom<KnownHost> for Elasticsearch {
                 .basic_auth(username, password)
                 .insecure(accept_invalid_certs.unwrap_or(false))
                 .build()?,
-            KnownHost::None { url, .. } => ElasticsearchBuilder::new(url).build()?,
+            KnownHost::NoAuth { url, .. } => ElasticsearchBuilder::new(url).build()?,
         };
         Ok(client)
     }

--- a/src/client/known_host.rs
+++ b/src/client/known_host.rs
@@ -37,7 +37,7 @@ pub enum KnownHost {
         username: String,
     },
     /// A host with no authentication
-    None { app: Product, url: Url },
+    NoAuth { app: Product, url: Url },
 }
 
 impl KnownHost {
@@ -66,7 +66,7 @@ impl KnownHost {
                 url,
                 username,
             }),
-            (None, None, None) => Ok(KnownHost::None {
+            (None, None, None) => Ok(KnownHost::NoAuth {
                 app: Product::from_str(&app).expect("A valid application is required!"),
                 url,
             }),
@@ -78,7 +78,7 @@ impl KnownHost {
         match self {
             Self::ApiKey { url, .. } => url.clone(),
             Self::Basic { url, .. } => url.clone(),
-            Self::None { url, .. } => url.clone(),
+            Self::NoAuth { url, .. } => url.clone(),
         }
     }
 
@@ -98,7 +98,7 @@ impl KnownHost {
             Self::Basic { .. } => {
                 hosts.insert(name.clone(), self);
             }
-            Self::None { .. } => {
+            Self::NoAuth { .. } => {
                 hosts.insert(name.clone(), self);
             }
         }
@@ -127,7 +127,7 @@ impl KnownHost {
     }
 
     pub fn from_url(url: &Url) -> Self {
-        KnownHost::None {
+        KnownHost::NoAuth {
             app: Product::Elasticsearch,
             url: url.clone(),
         }
@@ -138,7 +138,7 @@ impl KnownHost {
         let body = response.text().await.expect("Failed to read test body");
         let json = serde_json::from_str(&body).unwrap_or(serde_json::Value::Null);
         let app = match self {
-            Self::ApiKey { app, .. } | Self::Basic { app, .. } | Self::None { app, .. } => app,
+            Self::ApiKey { app, .. } | Self::Basic { app, .. } | Self::NoAuth { app, .. } => app,
         };
         match app {
             Product::Elasticsearch => match json.get("tagline") {
@@ -209,7 +209,7 @@ impl KnownHost {
                     Err(e) => Err(e),
                 }
             }
-            Self::None { app, url } => {
+            Self::NoAuth { app, url } => {
                 // test the connection
                 log::info!("Testing {} connection", &app);
                 let response = reqwest::get(url.as_str()).await;
@@ -240,7 +240,7 @@ impl KnownHost {
         }
     }
 
-    /// loads hosts from the resources directory
+    /// Loads hosts from the ~/.esdiag/hosts.yml (defalt) file
     pub fn parse_hosts_yml() -> Result<BTreeMap<String, KnownHost>> {
         let path = KnownHost::get_hosts_path();
         log::debug!("Parsing {:?}", path);
@@ -285,7 +285,7 @@ impl Display for KnownHost {
                 app, cloud_id, url, ..
             } => write!(
                 fmt,
-                "Host ApiKey: {} {} {}",
+                "KnownHost ApiKey: {} {} {}",
                 app,
                 url,
                 cloud_id.as_deref().unwrap_or(""),
@@ -298,13 +298,13 @@ impl Display for KnownHost {
                 ..
             } => write!(
                 fmt,
-                "Host Basic: {} {}@ {} {}",
+                "KnownHost Basic: {} {}@ {} {}",
                 app,
                 username,
                 url,
                 cloud_id.as_deref().unwrap_or(""),
             ),
-            Self::None { app, url } => write!(fmt, "Host None: {} {}", app, url),
+            Self::NoAuth { app, url } => write!(fmt, "KnownHost NoAuth: {} {}", app, url),
         }
     }
 }

--- a/src/data/uri.rs
+++ b/src/data/uri.rs
@@ -6,113 +6,71 @@ use std::{
 };
 use url::Url;
 
-/// Represents various types of URIs classified by the system.
+/// The different types of supported URIs
 #[derive(Clone, Debug)]
 pub enum Uri {
-    /// Represents a host saved in the hosts.yml
+    /// Known host saved in the ~/.esdiag/hosts.yml by default
     KnownHost(KnownHost),
-    /// Represents an Elastic Uploader service URL
+    /// An Elastic Uploader service URL, embed the auth token as `token:<value>@` instead of `username:password` in the URL
     ElasticUploader(Url),
-    /// Represents a standard URL
+    /// A standard URL
     Url(Url),
-    /// Represents a directory path on the local file system
+    /// Directory on the local file system
     Directory(PathBuf),
-    /// Represents a file path on the local filesystem
+    /// File on the local filesystem
     File(PathBuf),
-    /// Represents an input/output stream (e.g., stdin/stdout)
+    /// An input/output stream (stdin/stdout)
     Stream,
 }
-
-/// Converts a string slice into a specific `Uri` variant based on its type.
-///
-/// This implementation of the `TryFrom` trait takes a URI string and categorizes it into different types represented by the `Uri` enum.
-/// It supports converting a URI string into a stream, host, URL, directory, or file based on various checks.
-///
-/// # Arguments
-///
-/// * `uri` - A string slice representing the URI to convert.
-///
-/// # Returns
-///
-/// Returns a `Result` with a `Uri` enum variant:
-/// - `Ok(Uri::Stream)` if the URI is `"-"`.
-/// - `Ok(Uri::Host(host))` if the URI can be parsed into a `Host`.
-/// - `Ok(Uri::Url(url))` if the URI can be parsed into a `Url`.
-/// - `Ok(Uri::Directory(path))` if the URI is a valid directory path.
-/// - `Ok(Uri::File(path))` if the URI is a valid file path.
-/// - `Err(Report)` if there are errors during file creation or other I/O operations.
-///
-/// # Errors
-///
-/// Returns an `Err(Report)` if there are errors during file creation or other I/O operations.
-///
-/// # Examples
-///
-/// ```rust
-/// use std::path::PathBuf;
-///
-/// let uri = "-";
-/// match Uri::try_from(uri) {
-///     Ok(Uri::Stream) => println!("URI is a stream"),
-///     Ok(_) => println!("URI classified successfully"),
-///     Err(e) => eprintln!("Failed to parse URI: {}", e),
-/// }
-/// ```
 
 impl TryFrom<&str> for Uri {
     type Error = Report;
 
     fn try_from(uri: &str) -> Result<Self> {
-        match uri {
-            "-" => Ok(Uri::Stream),
-            _ => {
-                let host = KnownHost::from_str(&uri);
-                match host {
-                    Err(_) => log::debug!("No known host {uri}"),
-                    Ok(host) => return Ok(Uri::KnownHost(host)),
+        if uri == "-" {
+            log::debug!("Creating Uri::Stream");
+            return Ok(Uri::Stream);
+        }
+
+        if let Ok(host) = KnownHost::from_str(&uri) {
+            log::debug!("Creating Uri::KnownHost");
+            return Ok(Uri::KnownHost(host));
+        }
+        log::debug!("No known host {uri}");
+
+        if let Ok(url) = Url::parse(&uri) {
+            let domain = url.domain().ok_or_eyre("URL is missing a domain")?;
+            match (domain, url.username(), url.password()) {
+                ("upload.elastic.co", "token", Some(_)) => {
+                    log::debug!("Creating Uri::ElasticUploader");
+                    return Ok(Uri::ElasticUploader(url));
                 }
-                match Url::parse(&uri) {
-                    Err(_) => log::error!("Not a valid URL {uri}"),
-                    Ok(url) => {
-                        let domain = url.domain().ok_or_eyre("URL is missing a domain")?;
-                        log::debug!(
-                            "Domain: {domain} Username: {} Password: {}",
-                            url.username(),
-                            url.password().is_some()
-                        );
-                        match (domain, url.username(), url.password()) {
-                            ("upload.elastic.co", "token", Some(_)) => {
-                                log::debug!("Creating Uri::ElasticUploader");
-                                return Ok(Uri::ElasticUploader(url));
-                            }
-                            ("upload.elastic.co", _, None) => {
-                                log::debug!("Missing auth token for Elastic Uploader");
-                                return Err(eyre!("Elastic Uploader URLs require an auth token"));
-                            }
-                            _ => {
-                                log::debug!("Creating Uri::Url");
-                                return Ok(Uri::Url(url));
-                            }
-                        }
-                    }
+                ("upload.elastic.co", _, None) => {
+                    log::debug!("Missing auth token for Elastic Uploader");
+                    return Err(eyre!("Elastic Uploader URLs require an auth token"));
                 }
-                let path = Path::new(&uri);
-                match path.is_dir() {
-                    false => log::debug!("Not a directory {uri}"),
-                    true => {
-                        log::debug!("Directory {uri}");
-                        let path_buf = PathBuf::from_str(&uri).unwrap();
-                        return Ok(Uri::Directory(path_buf));
-                    }
-                }
-                match path.is_file() {
-                    false => {
-                        log::debug!("File does not exist: {uri}");
-                        return Ok(Uri::File(PathBuf::from_str(&uri).unwrap()));
-                    }
-                    true => return Ok(Uri::File(PathBuf::from_str(&uri).unwrap())),
+                _ => {
+                    log::debug!("Creating Uri::Url");
+                    return Ok(Uri::Url(url));
                 }
             }
+        }
+
+        let path = Path::new(&uri);
+        match path.is_dir() {
+            false => log::debug!("Not a directory {uri}"),
+            true => {
+                log::debug!("Directory {uri}");
+                let path_buf = PathBuf::from_str(&uri)?;
+                return Ok(Uri::Directory(path_buf));
+            }
+        }
+        match path.is_file() {
+            false => {
+                log::debug!("File does not exist: {uri}");
+                return Ok(Uri::File(PathBuf::from_str(&uri)?));
+            }
+            true => return Ok(Uri::File(PathBuf::from_str(&uri)?)),
         }
     }
 }
@@ -137,7 +95,9 @@ impl std::fmt::Display for Uri {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Uri::KnownHost(host) => write!(f, "{}", host),
-            Uri::ElasticUploader(url) => write!(f, "{}", url),
+            Uri::ElasticUploader(url) => {
+                write!(f, "{}{}", url.domain().expect("No domain"), url.path())
+            }
             Uri::Url(url) => write!(f, "{}", url),
             Uri::Directory(path) => write!(f, "{}", path.display()),
             Uri::File(path) => write!(f, "{}", path.display()),

--- a/src/data/uri.rs
+++ b/src/data/uri.rs
@@ -1,5 +1,5 @@
 use crate::client::KnownHost;
-use color_eyre::eyre::{Report, Result};
+use color_eyre::eyre::{eyre, OptionExt, Report, Result};
 use std::{
     path::{Path, PathBuf},
     str::FromStr,
@@ -11,6 +11,8 @@ use url::Url;
 pub enum Uri {
     /// Represents a host saved in the hosts.yml
     KnownHost(KnownHost),
+    /// Represents an Elastic Uploader service URL
+    ElasticUploader(Url),
     /// Represents a standard URL
     Url(Url),
     /// Represents a directory path on the local file system
@@ -70,8 +72,29 @@ impl TryFrom<&str> for Uri {
                     Ok(host) => return Ok(Uri::KnownHost(host)),
                 }
                 match Url::parse(&uri) {
-                    Err(_) => log::debug!("Not a valid URL {uri}"),
-                    Ok(url) => return Ok(Uri::Url(url)),
+                    Err(_) => log::error!("Not a valid URL {uri}"),
+                    Ok(url) => {
+                        let domain = url.domain().ok_or_eyre("URL is missing a domain")?;
+                        log::debug!(
+                            "Domain: {domain} Username: {} Password: {}",
+                            url.username(),
+                            url.password().is_some()
+                        );
+                        match (domain, url.username(), url.password()) {
+                            ("upload.elastic.co", "token", Some(_)) => {
+                                log::debug!("Creating Uri::ElasticUploader");
+                                return Ok(Uri::ElasticUploader(url));
+                            }
+                            ("upload.elastic.co", _, None) => {
+                                log::debug!("Missing auth token for Elastic Uploader");
+                                return Err(eyre!("Elastic Uploader URLs require an auth token"));
+                            }
+                            _ => {
+                                log::debug!("Creating Uri::Url");
+                                return Ok(Uri::Url(url));
+                            }
+                        }
+                    }
                 }
                 let path = Path::new(&uri);
                 match path.is_dir() {
@@ -114,6 +137,7 @@ impl std::fmt::Display for Uri {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Uri::KnownHost(host) => write!(f, "{}", host),
+            Uri::ElasticUploader(url) => write!(f, "{}", url),
             Uri::Url(url) => write!(f, "{}", url),
             Uri::Directory(path) => write!(f, "{}", path.display()),
             Uri::File(path) => write!(f, "{}", path.display()),

--- a/src/exporter.rs
+++ b/src/exporter.rs
@@ -76,3 +76,13 @@ impl TryFrom<Uri> for Exporter {
         }
     }
 }
+
+impl std::fmt::Display for Exporter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Exporter::Elasticsearch(exporter) => write!(f, "Elasticsearch {}", exporter),
+            Exporter::File(exporter) => write!(f, "File {}", exporter),
+            Exporter::Stream(exporter) => write!(f, "Stream {}", exporter),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,11 +205,11 @@ async fn run() -> Result<&'static str> {
         Commands::Process { input, output } => {
             let input_uri = Uri::try_from(input)?;
             let output_uri = Uri::try_from(output)?;
-            log::info!("input: {}", input_uri);
-            log::info!("output: {}", output_uri);
 
             let receiver = Receiver::try_from(input_uri)?;
             let exporter = Exporter::try_from(output_uri)?;
+            log::info!("input: {}", receiver);
+            log::info!("output: {}", exporter);
 
             let manifest = receiver.try_get_manifest().await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,9 @@ enum Commands {
     /// Receives a diagnostic from the input, processes it, and sends processed docs to the output
     Process {
         /// Source to read diagnostic data from
-        #[arg(help = "Source to read diagnostic data from (archive, directory, or known host)")]
+        #[arg(
+            help = "Source to read diagnostic data from (archive, directory, known host or uploader URL)"
+        )]
         input: String,
 
         /// Target to send processed diagnostic documents to
@@ -205,11 +207,11 @@ async fn run() -> Result<&'static str> {
         Commands::Process { input, output } => {
             let input_uri = Uri::try_from(input)?;
             let output_uri = Uri::try_from(output)?;
+            log::info!("input: {}", input_uri);
+            log::info!("output: {}", output_uri);
 
             let receiver = Receiver::try_from(input_uri)?;
             let exporter = Exporter::try_from(output_uri)?;
-            log::info!("input: {}", receiver);
-            log::info!("output: {}", exporter);
 
             let manifest = receiver.try_get_manifest().await?;
 

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -2,11 +2,14 @@
 mod archive;
 /// Read from a direcotry in the local file system
 mod directory;
+/// Get file from Elastic Uploader service
+mod elastic_uploader;
 /// Request API calls from Elasticsearch
 mod elasticsearch;
 
 use archive::ArchiveReceiver;
 use directory::DirectoryReceiver;
+use elastic_uploader::ElasticUploaderReceiver;
 pub use elasticsearch::ElasticsearchReceiver;
 
 use crate::data::{
@@ -18,12 +21,17 @@ use color_eyre::eyre::{eyre, Result};
 use serde::de::DeserializeOwned;
 
 trait Receive {
-    #[allow(dead_code)]
     async fn is_connected(&self) -> bool;
-    fn set_work_dir(&mut self, work_dir: &str) -> Result<()>;
     async fn get<T>(&self) -> Result<T>
     where
         T: DataSource + DeserializeOwned;
+}
+
+trait ReceiveMultiple {
+    fn set_work_dir(&mut self, work_dir: &str) -> Result<()>;
+}
+
+trait ReceiveRaw {
     async fn get_raw<T>(&self) -> Result<String>
     where
         T: DataSource;
@@ -46,6 +54,8 @@ pub enum Receiver {
     Directory(DirectoryReceiver),
     /// Request API calls from Elasticsearch
     Elasticsearch(ElasticsearchReceiver),
+    /// Get file from Elastic Uploader service
+    ElasticUploader(ElasticUploaderReceiver),
 }
 
 impl Receiver {
@@ -54,11 +64,10 @@ impl Receiver {
         T: DataSource + DeserializeOwned,
     {
         match self {
-            Receiver::Archive(archive_receiver) => archive_receiver.get::<T>().await,
-            Receiver::Directory(directory_receiver) => directory_receiver.get::<T>().await,
-            Receiver::Elasticsearch(elasticsearch_receiver) => {
-                elasticsearch_receiver.get::<T>().await
-            }
+            Receiver::Archive(receiver) => receiver.get::<T>().await,
+            Receiver::Directory(receiver) => receiver.get::<T>().await,
+            Receiver::Elasticsearch(receiver) => receiver.get::<T>().await,
+            Receiver::ElasticUploader(receiver) => receiver.get::<T>().await,
         }
     }
 
@@ -67,11 +76,9 @@ impl Receiver {
         T: DataSource,
     {
         match self {
-            Receiver::Archive(archive_receiver) => archive_receiver.get_raw::<T>().await,
-            Receiver::Directory(directory_receiver) => directory_receiver.get_raw::<T>().await,
-            Receiver::Elasticsearch(elasticsearch_receiver) => {
-                elasticsearch_receiver.get_raw::<T>().await
-            }
+            Receiver::Archive(receiver) => receiver.get_raw::<T>().await,
+            Receiver::Elasticsearch(receiver) => receiver.get_raw::<T>().await,
+            _ => Err(eyre!("Raw data is not supported for this receiver")),
         }
     }
 
@@ -82,6 +89,9 @@ impl Receiver {
             Receiver::Elasticsearch(elasticsearch_receiver) => {
                 elasticsearch_receiver.is_connected().await
             }
+            Receiver::ElasticUploader(elastic_uploader_receiver) => {
+                elastic_uploader_receiver.is_connected().await
+            }
         }
     }
 
@@ -89,9 +99,7 @@ impl Receiver {
         match self {
             Receiver::Archive(archive_receiver) => archive_receiver.set_work_dir(work_dir),
             Receiver::Directory(directory_receiver) => directory_receiver.set_work_dir(work_dir),
-            Receiver::Elasticsearch(elasticsearch_receiver) => {
-                elasticsearch_receiver.set_work_dir(work_dir)
-            }
+            _ => Err(eyre!("Cannot set working directly on {}", self)),
         }
     }
 
@@ -129,7 +137,10 @@ impl TryFrom<Uri> for Receiver {
             Uri::KnownHost(host) => Ok(Receiver::Elasticsearch(ElasticsearchReceiver::try_from(
                 host,
             )?)),
-            _ => Err(eyre!("Unsupported URI")),
+            Uri::ElasticUploader(url) => Ok(Receiver::ElasticUploader(
+                ElasticUploaderReceiver::try_from(url)?,
+            )),
+            _ => Err(eyre!("Unsupported URI: {uri}")),
         }
     }
 }
@@ -137,10 +148,15 @@ impl TryFrom<Uri> for Receiver {
 impl std::fmt::Display for Receiver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Receiver::Archive(archive_receiver) => write!(f, "file {}", archive_receiver),
-            Receiver::Directory(directory_receiver) => write!(f, "file {}", directory_receiver),
+            Receiver::Archive(archive_receiver) => write!(f, "File {}", archive_receiver),
+            Receiver::Directory(directory_receiver) => {
+                write!(f, "Directory {}", directory_receiver)
+            }
             Receiver::Elasticsearch(elasticsearch_receiver) => {
-                write!(f, "elasticsearch {}", elasticsearch_receiver)
+                write!(f, "Elasticsearch {}", elasticsearch_receiver)
+            }
+            Receiver::ElasticUploader(elastic_uploader_receiver) => {
+                write!(f, "Elastic Uploader {}", elastic_uploader_receiver)
             }
         }
     }

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -45,6 +45,7 @@ trait ReceiveRaw {
 ///
 /// - `Archive`: Reads data from a `.zip` archive file.
 /// - `Directory`: Reads data from a directory in the local file system.
+/// - `ElasticUploader`: Downloads an archive file from the Elastic Uploader service.
 /// - `Elasticsearch`: Requests data via API calls from an Elasticsearch service.
 #[derive(Clone)]
 pub enum Receiver {
@@ -52,10 +53,10 @@ pub enum Receiver {
     Archive(ArchiveReceiver),
     /// Read from a direcotry in the local file system
     Directory(DirectoryReceiver),
-    /// Request API calls from Elasticsearch
-    Elasticsearch(ElasticsearchReceiver),
     /// Get file from Elastic Uploader service
     ElasticUploader(ElasticUploaderReceiver),
+    /// Request API calls from Elasticsearch
+    Elasticsearch(ElasticsearchReceiver),
 }
 
 impl Receiver {
@@ -66,8 +67,8 @@ impl Receiver {
         match self {
             Receiver::Archive(receiver) => receiver.get::<T>().await,
             Receiver::Directory(receiver) => receiver.get::<T>().await,
-            Receiver::Elasticsearch(receiver) => receiver.get::<T>().await,
             Receiver::ElasticUploader(receiver) => receiver.get::<T>().await,
+            Receiver::Elasticsearch(receiver) => receiver.get::<T>().await,
         }
     }
 
@@ -84,21 +85,17 @@ impl Receiver {
 
     pub async fn is_connected(&self) -> bool {
         match self {
-            Receiver::Archive(archive_receiver) => archive_receiver.is_connected().await,
-            Receiver::Directory(directory_receiver) => directory_receiver.is_connected().await,
-            Receiver::Elasticsearch(elasticsearch_receiver) => {
-                elasticsearch_receiver.is_connected().await
-            }
-            Receiver::ElasticUploader(elastic_uploader_receiver) => {
-                elastic_uploader_receiver.is_connected().await
-            }
+            Receiver::Archive(receiver) => receiver.is_connected().await,
+            Receiver::Directory(receiver) => receiver.is_connected().await,
+            Receiver::Elasticsearch(receiver) => receiver.is_connected().await,
+            Receiver::ElasticUploader(receiver) => receiver.is_connected().await,
         }
     }
 
     pub fn set_work_dir(&mut self, work_dir: &str) -> Result<()> {
         match self {
-            Receiver::Archive(archive_receiver) => archive_receiver.set_work_dir(work_dir),
-            Receiver::Directory(directory_receiver) => directory_receiver.set_work_dir(work_dir),
+            Receiver::Archive(reciever) => reciever.set_work_dir(work_dir),
+            Receiver::Directory(reciever) => reciever.set_work_dir(work_dir),
             _ => Err(eyre!("Cannot set working directly on {}", self)),
         }
     }
@@ -131,33 +128,26 @@ impl Receiver {
 impl TryFrom<Uri> for Receiver {
     type Error = color_eyre::Report;
     fn try_from(uri: Uri) -> std::result::Result<Self, Self::Error> {
-        match uri {
-            Uri::Directory(dir) => Ok(Receiver::Directory(DirectoryReceiver::try_from(dir)?)),
-            Uri::File(file) => Ok(Receiver::Archive(ArchiveReceiver::try_from(file)?)),
-            Uri::KnownHost(host) => Ok(Receiver::Elasticsearch(ElasticsearchReceiver::try_from(
-                host,
-            )?)),
-            Uri::ElasticUploader(url) => Ok(Receiver::ElasticUploader(
-                ElasticUploaderReceiver::try_from(url)?,
-            )),
-            _ => Err(eyre!("Unsupported URI: {uri}")),
-        }
+        let receiver = match uri {
+            Uri::Directory(dir) => Receiver::Directory(DirectoryReceiver::try_from(dir)?),
+            Uri::File(file) => Receiver::Archive(ArchiveReceiver::try_from(file)?),
+            Uri::KnownHost(host) => Receiver::Elasticsearch(ElasticsearchReceiver::try_from(host)?),
+            Uri::ElasticUploader(url) => {
+                Receiver::ElasticUploader(ElasticUploaderReceiver::try_from(url)?)
+            }
+            _ => return Err(eyre!("Unsupported URI: {uri}")),
+        };
+        Ok(receiver)
     }
 }
 
 impl std::fmt::Display for Receiver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Receiver::Archive(archive_receiver) => write!(f, "File {}", archive_receiver),
-            Receiver::Directory(directory_receiver) => {
-                write!(f, "Directory {}", directory_receiver)
-            }
-            Receiver::Elasticsearch(elasticsearch_receiver) => {
-                write!(f, "Elasticsearch {}", elasticsearch_receiver)
-            }
-            Receiver::ElasticUploader(elastic_uploader_receiver) => {
-                write!(f, "Elastic Uploader {}", elastic_uploader_receiver)
-            }
+            Receiver::Archive(receiver) => write!(f, "File {receiver}"),
+            Receiver::Directory(receiver) => write!(f, "Directory {receiver}"),
+            Receiver::ElasticUploader(receiver) => write!(f, "Elastic Uploader {receiver}"),
+            Receiver::Elasticsearch(receiver) => write!(f, "Elasticsearch {receiver}"),
         }
     }
 }

--- a/src/receiver/archive.rs
+++ b/src/receiver/archive.rs
@@ -1,4 +1,4 @@
-use super::Receive;
+use super::{Receive, ReceiveMultiple, ReceiveRaw};
 use crate::data::diagnostic::{data_source::PathType, DataSource};
 use color_eyre::{eyre::eyre, Result};
 use serde::de::DeserializeOwned;
@@ -75,7 +75,7 @@ impl Receive for ArchiveReceiver {
             // This will break if the sub-paths are fixed in the ECK bundles
             Some(subdir) => &format!("{}//{}", subdir.display(), filename),
             None => {
-                let subdir = self.get_subdir().await.map(|s| s.join(filename))?;
+                let subdir = self.get_subdir().await?.join(filename);
                 &format!("{}", subdir.display())
             }
         };
@@ -88,7 +88,9 @@ impl Receive for ArchiveReceiver {
         let data: T = serde_json::from_reader(reader)?;
         Ok(data)
     }
+}
 
+impl ReceiveRaw for ArchiveReceiver {
     async fn get_raw<T>(&self) -> Result<String>
     where
         T: DataSource,
@@ -113,7 +115,9 @@ impl Receive for ArchiveReceiver {
         reader.read_to_string(&mut data)?;
         Ok(data)
     }
+}
 
+impl ReceiveMultiple for ArchiveReceiver {
     fn set_work_dir(&mut self, work_dir: &str) -> Result<()> {
         log::trace!("Setting subdir: {}", work_dir);
         self.subdir = Some(PathBuf::from(work_dir));

--- a/src/receiver/directory.rs
+++ b/src/receiver/directory.rs
@@ -1,4 +1,4 @@
-use super::Receive;
+use super::{Receive, ReceiveMultiple, ReceiveRaw};
 use crate::data::diagnostic::{data_source::PathType, DataSource};
 use color_eyre::eyre::{eyre, Result};
 use serde::de::DeserializeOwned;
@@ -59,7 +59,9 @@ impl Receive for DirectoryReceiver {
         let data: T = serde_json::from_reader(reader)?;
         Ok(data)
     }
+}
 
+impl ReceiveRaw for DirectoryReceiver {
     async fn get_raw<T>(&self) -> Result<String>
     where
         T: DataSource,
@@ -75,7 +77,9 @@ impl Receive for DirectoryReceiver {
         reader.read_to_string(&mut data)?;
         Ok(data)
     }
+}
 
+impl ReceiveMultiple for DirectoryReceiver {
     fn set_work_dir(&mut self, work_dir: &str) -> Result<()> {
         self.work_dir = String::from(work_dir);
         Ok(())

--- a/src/receiver/elastic_uploader.rs
+++ b/src/receiver/elastic_uploader.rs
@@ -1,0 +1,109 @@
+use super::Receive;
+use crate::data::diagnostic::{data_source::PathType, DataSource};
+use bytes::Bytes;
+use color_eyre::eyre::{eyre, Result};
+use serde::de::DeserializeOwned;
+use std::{
+    io::{BufReader, Cursor},
+    path::PathBuf,
+    sync::Arc,
+};
+use tokio::sync::RwLock;
+use url::Url;
+use zip::ZipArchive;
+
+type ArchiveCursor = ZipArchive<BufReader<Cursor<Bytes>>>;
+type ArchivePointer = Arc<RwLock<Option<ArchiveCursor>>>;
+
+#[derive(Clone)]
+pub struct ElasticUploaderReceiver {
+    url: Url,
+    token: String,
+    archive: ArchivePointer,
+}
+
+impl Receive for ElasticUploaderReceiver {
+    async fn is_connected(&self) -> bool {
+        let client = reqwest::Client::new();
+        let request = client.head(self.url.clone());
+        let request = request.header("Authorization", format!("Bearer {}", self.token));
+
+        match request.send().await {
+            Ok(response) => response.status().is_success(),
+            Err(_) => false,
+        }
+    }
+
+    async fn get<T>(&self) -> Result<T>
+    where
+        T: DataSource + DeserializeOwned,
+    {
+        // We are using interior mutability here to cache the archive to memory only once
+        let mut archive_lock = self.archive.write().await;
+        if archive_lock.is_none() {
+            let file = download_file(self.url.clone(), &self.token).await?;
+            archive_lock.replace(file);
+        }
+
+        let filename = T::source(PathType::File)?;
+
+        let data: T = if let Some(archive) = archive_lock.as_mut() {
+            let mut file_str = PathBuf::from(archive.by_index(0)?.name().to_string());
+            if file_str.extension() != None {
+                file_str.pop();
+            }
+            let file_str = file_str.join(filename).display().to_string();
+
+            // Read lines directly from the compressed file
+            log::debug!("Reading {}", file_str);
+            let file = archive.by_name(&file_str)?;
+            let reader = BufReader::new(file);
+            serde_json::from_reader(reader)?
+        } else {
+            return Err(eyre!("Archive is not inialized"));
+        };
+        Ok(data)
+    }
+}
+
+impl TryFrom<Url> for ElasticUploaderReceiver {
+    type Error = color_eyre::eyre::Report;
+
+    fn try_from(url: Url) -> Result<Self> {
+        let mut url = url.clone();
+        let token = url
+            .password()
+            .ok_or_else(|| eyre!("No token provided"))?
+            .to_string();
+        url.set_username("").ok();
+        url.set_password(None).ok();
+        log::info!("Downloading archive from {url}");
+        Ok(Self {
+            url,
+            token,
+            archive: Arc::new(RwLock::new(None)),
+        })
+    }
+}
+
+async fn download_file(url: Url, token: &String) -> Result<ArchiveCursor> {
+    let client = reqwest::Client::new();
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        "Authorization",
+        reqwest::header::HeaderValue::from_str(&token)?,
+    );
+    let request = client.get(url.clone()).headers(headers);
+    let response = request.send().await?;
+    let bytes = response.bytes().await?;
+    log::debug!("Archive size: {} bytes", bytes.len());
+    let cursor = BufReader::new(Cursor::new(bytes));
+    let archive = ZipArchive::new(cursor)?;
+    Ok(archive)
+}
+
+impl std::fmt::Display for ElasticUploaderReceiver {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.url)
+    }
+}

--- a/src/receiver/elastic_uploader.rs
+++ b/src/receiver/elastic_uploader.rs
@@ -17,11 +17,13 @@ type ArchivePointer = Arc<RwLock<Option<ArchiveCursor>>>;
 
 #[derive(Clone)]
 pub struct ElasticUploaderReceiver {
-    url: Url,
-    token: String,
     archive: ArchivePointer,
+    token: String,
+    url: Url,
 }
 
+/// A receiver for the Elastic Uploader service (https://upload.elastic.co).
+/// This will download the archive on first use and cache it in memory.
 impl Receive for ElasticUploaderReceiver {
     async fn is_connected(&self) -> bool {
         let client = reqwest::Client::new();
@@ -34,33 +36,35 @@ impl Receive for ElasticUploaderReceiver {
         }
     }
 
+    /// Read the type's file from the in-memory archive
     async fn get<T>(&self) -> Result<T>
     where
         T: DataSource + DeserializeOwned,
     {
-        // We are using interior mutability here to cache the archive to memory only once
         let mut archive_lock = self.archive.write().await;
+        // We are using interior mutability here to cache the archive to memory on first access
         if archive_lock.is_none() {
-            let file = download_file(self.url.clone(), &self.token).await?;
-            archive_lock.replace(file);
+            let archive = get_file_from_uploader(self.url.clone(), &self.token).await?;
+            archive_lock.replace(archive);
         }
 
         let filename = T::source(PathType::File)?;
 
         let data: T = if let Some(archive) = archive_lock.as_mut() {
-            let mut file_str = PathBuf::from(archive.by_index(0)?.name().to_string());
-            if file_str.extension() != None {
-                file_str.pop();
+            // Use the first file in the archive as the base path
+            let mut path = PathBuf::from(archive.by_index(0)?.name().to_string());
+            if path.extension() != None {
+                path.pop();
             }
-            let file_str = file_str.join(filename).display().to_string();
+            let filename = path.join(filename).display().to_string();
 
             // Read lines directly from the compressed file
-            log::debug!("Reading {}", file_str);
-            let file = archive.by_name(&file_str)?;
+            log::debug!("Reading {}", filename);
+            let file = archive.by_name(&filename)?;
             let reader = BufReader::new(file);
             serde_json::from_reader(reader)?
         } else {
-            return Err(eyre!("Archive is not inialized"));
+            return Err(eyre!("Archive as not downloaded and cached"));
         };
         Ok(data)
     }
@@ -75,6 +79,7 @@ impl TryFrom<Url> for ElasticUploaderReceiver {
             .password()
             .ok_or_else(|| eyre!("No token provided"))?
             .to_string();
+        // Since token authentication is by header, clear provided username and password from the URL
         url.set_username("").ok();
         url.set_password(None).ok();
         log::info!("Downloading archive from {url}");
@@ -86,7 +91,9 @@ impl TryFrom<Url> for ElasticUploaderReceiver {
     }
 }
 
-async fn download_file(url: Url, token: &String) -> Result<ArchiveCursor> {
+/// Downloads a file from the Elastic Uploader service given a URL and token
+/// The URL format of `https://upload.elastic.co/...` will have been validated previously.
+async fn get_file_from_uploader(url: Url, token: &String) -> Result<ArchiveCursor> {
     let client = reqwest::Client::new();
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert(
@@ -96,10 +103,9 @@ async fn download_file(url: Url, token: &String) -> Result<ArchiveCursor> {
     let request = client.get(url.clone()).headers(headers);
     let response = request.send().await?;
     let bytes = response.bytes().await?;
-    log::debug!("Archive size: {} bytes", bytes.len());
+    log::debug!("Downloaded archive size: {} bytes", bytes.len());
     let cursor = BufReader::new(Cursor::new(bytes));
-    let archive = ZipArchive::new(cursor)?;
-    Ok(archive)
+    Ok(ZipArchive::new(cursor)?)
 }
 
 impl std::fmt::Display for ElasticUploaderReceiver {

--- a/src/receiver/elasticsearch.rs
+++ b/src/receiver/elasticsearch.rs
@@ -1,9 +1,9 @@
-use super::Receive;
+use super::{Receive, ReceiveRaw};
 use crate::{
     client::KnownHost,
     data::diagnostic::{data_source::PathType, DataSource},
 };
-use color_eyre::eyre::{eyre, Result};
+use color_eyre::eyre::Result;
 use elasticsearch::{http, Elasticsearch};
 use serde::de::DeserializeOwned;
 use url::Url;
@@ -85,7 +85,9 @@ impl Receive for ElasticsearchReceiver {
 
         response.json::<T>().await.map_err(Into::into)
     }
+}
 
+impl ReceiveRaw for ElasticsearchReceiver {
     async fn get_raw<T>(&self) -> Result<String>
     where
         T: DataSource,
@@ -108,12 +110,6 @@ impl Receive for ElasticsearchReceiver {
             .await?;
 
         response.text().await.map_err(Into::into)
-    }
-
-    fn set_work_dir(&mut self, work_dir: &str) -> Result<()> {
-        Err(eyre!(
-            "ElasticsearchReceiver does not support setting a working directory: {work_dir}"
-        ))
     }
 }
 


### PR DESCRIPTION
Allows directly processing a diagnostic bundle from an Elastic Uploader service link.