### PR TITLE
Fix directory creation on collect command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -232,7 +232,7 @@ Usage: esdiag collect <HOST> <OUTPUT>
 
 Arguments:
   <HOST>    The Elasticsearch host to collect diagnostics from
-  <OUTPUT>  The directory to save the diagnostics files to
+  <OUTPUT>  An existing directory to create a diagnostic directory and files in
 
 Options:
   -h, --help  Print help

--- a/src/exporter/directory.rs
+++ b/src/exporter/directory.rs
@@ -33,7 +33,7 @@ impl TryFrom<PathBuf> for DirectoryExporter {
 
     fn try_from(path: PathBuf) -> Result<Self> {
         if !path.exists() {
-            return Err(eyre!("Directory output not fount: {}", path.display()));
+            return Err(eyre!("Directory output not found: {}", path.display()));
         }
         let timestamp = chrono::Local::now().format("%Y%m%d-%H%M%S").to_string();
         let directory = path.join(format!("api-diagnostic-{}", timestamp));

--- a/src/exporter/directory.rs
+++ b/src/exporter/directory.rs
@@ -32,18 +32,15 @@ impl TryFrom<PathBuf> for DirectoryExporter {
     type Error = color_eyre::eyre::Report;
 
     fn try_from(path: PathBuf) -> Result<Self> {
-        let subpath = path.join("commercial");
         if !path.exists() {
-            log::debug!("Creating directory: {}", &subpath.display());
-            std::fs::create_dir_all(subpath)?;
+            return Err(eyre!("Directory output not fount: {}", path.display()));
         }
-        match path.is_dir() {
-            true => Ok(Self { path }),
-            false => Err(eyre!(
-                "Directory input must be a directory: {}",
-                path.display()
-            )),
-        }
+        let timestamp = chrono::Local::now().format("%Y%m%d-%H%M%S").to_string();
+        let directory = path.join(format!("api-diagnostic-{}", timestamp));
+        log::debug!("Creating directory: {}", &directory.display());
+        std::fs::create_dir_all(directory.clone().join("commercial"))?;
+
+        Ok(Self { path: directory })
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ enum Commands {
         #[arg(help = "The Elasticsearch host to collect diagnostics from")]
         host: String,
         /// The output directory to save the diagnostics to
-        #[arg(help = "The directory to save the diagnostics files to")]
+        #[arg(help = "An existing directory to create a diagnostic directory and files in")]
         output: String,
     },
     /// Configure, test and save a remote host connection to `~/.esdiag/hosts.yml`


### PR DESCRIPTION
Using the `collect` subcommand now creates an `api-diagnostic-{datetime}` subdirectory.

Also improved error message when providing a non-existent directory.

Fixes #90 