### PR TITLE
Add host-by-env option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -169,7 +169,7 @@ Options:
 
 #### Process
 
-The `esdiag process <input> <output>` will read the diagnostic data from `<input>`, run the source documents through a series of processors, and send the enriched documents to the `<output>` target.
+The `esdiag process <input> [output]` will read the diagnostic data from `<input>`, run the source documents through a series of processors, and send the enriched documents to the `<output>` target.
 
 The `<input>` may be:
     1. Archive file - a `.zip` output from the [support diangostic](https://github.com/elastic/support-diagnostics) tool
@@ -177,22 +177,27 @@ The `<input>` may be:
     3. Known host - saved in the `hosts.yml`
     4. Elastic Uploader link - A url with auth token formated as `https://token:0123456789@upload.elastic.co/d/abcdefghijklmnopqrstuvwxyz`
 
-The `<output>` may be:
+The optional `[output]` may be:
     1. Known host - Must be an Elasticsearch host saved in the `hosts.yml`
     2. File - writes in an `.ndjson` format
     3. `stdout` - use `-` as the output name
+    4. Omitted - Uses values read from `ESDIAG_OUTPUT_*` environment variables
 
 ```
 Receives a diagnostic from the input, processes it, and sends processed docs to the output
 
-Usage: esdiag process <INPUT> <OUTPUT>
+Usage: esdiag process <INPUT> [OUTPUT]
 
 Arguments:
-  <INPUT>   Source to read diagnostic data from (archive, directory, known host, or uploader URL)
-  <OUTPUT>  Target to send processed diagnostic documents to (known host, file, or stdout)
+  <INPUT>
+          Source to read diagnostic data from (archive, directory, known host or uploader URL)
+
+  [OUTPUT]
+          Target to send the processed diagnostic documents to (known host, file, stdout, or env). Strings will be checked against the known hosts stored in `~/.esdiag/hosts.yml` and will fallback to a filename if not found. Use `-` for stdout. If nothing is provided, the target will be determined based on the environment variables: ESDIAG_OUTPUT_URL, ESDIAG_OUTPUT_APIKEY, ESDIAG_OUTPUT_USERNAME, and ESDIAG_OUTPUT_PASSWORD.
 
 Options:
-  -h, --help  Print help
+  -h, --help
+          Print help (see a summary with '-h')
 ```
 
 Once you have known hosts configured, you can add a simple shell commands shortcuts to your `~/.bashrc` or `~/.zshrc`. For example if you have `diag-cluster` as a known host:

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,4 +7,4 @@ mod known_host;
 
 pub use auth::{Auth, AuthType};
 pub use elasticsearch::ElasticsearchBuilder;
-pub use known_host::KnownHost;
+pub use known_host::{KnownHost, KnownHostBuilder};

--- a/src/client/elasticsearch.rs
+++ b/src/client/elasticsearch.rs
@@ -96,7 +96,7 @@ impl TryFrom<KnownHost> for Elasticsearch {
                 ..
             } => ElasticsearchBuilder::new(url)
                 .apikey(apikey)
-                .insecure(accept_invalid_certs.unwrap_or(false))
+                .insecure(accept_invalid_certs)
                 .build()?,
             KnownHost::Basic {
                 accept_invalid_certs,
@@ -106,7 +106,7 @@ impl TryFrom<KnownHost> for Elasticsearch {
                 ..
             } => ElasticsearchBuilder::new(url)
                 .basic_auth(username, password)
-                .insecure(accept_invalid_certs.unwrap_or(false))
+                .insecure(accept_invalid_certs)
                 .build()?,
             KnownHost::NoAuth { url, .. } => ElasticsearchBuilder::new(url).build()?,
         };

--- a/src/client/known_host.rs
+++ b/src/client/known_host.rs
@@ -14,12 +14,84 @@ use std::{
 };
 use url::Url;
 
+pub struct KnownHostBuilder {
+    accept_invalid_certs: bool,
+    apikey: Option<String>,
+    product: Product,
+    cloud_id: Option<String>,
+    password: Option<String>,
+    url: Url,
+    username: Option<String>,
+}
+
+impl KnownHostBuilder {
+    pub fn new(url: Url) -> Self {
+        KnownHostBuilder {
+            accept_invalid_certs: false,
+            apikey: None,
+            product: Product::Elasticsearch,
+            cloud_id: None,
+            password: None,
+            url,
+            username: None,
+        }
+    }
+
+    pub fn accept_invalid_certs(self, accept_invalid_certs: bool) -> Self {
+        Self {
+            accept_invalid_certs,
+            ..self
+        }
+    }
+
+    pub fn apikey(self, apikey: Option<String>) -> Self {
+        Self { apikey, ..self }
+    }
+
+    pub fn password(self, password: Option<String>) -> Self {
+        Self { password, ..self }
+    }
+
+    pub fn product(self, product: Product) -> Self {
+        Self { product, ..self }
+    }
+
+    pub fn username(self, username: Option<String>) -> Self {
+        Self { username, ..self }
+    }
+
+    pub fn build(self) -> Result<KnownHost> {
+        match (self.apikey, self.username, self.password) {
+            (None, Some(username), Some(password)) => Ok(KnownHost::Basic {
+                accept_invalid_certs: self.accept_invalid_certs,
+                app: self.product,
+                cloud_id: self.cloud_id,
+                password,
+                url: self.url,
+                username,
+            }),
+            (Some(apikey), None, None) => Ok(KnownHost::ApiKey {
+                accept_invalid_certs: self.accept_invalid_certs,
+                apikey,
+                app: self.product,
+                cloud_id: self.cloud_id,
+                url: self.url,
+            }),
+            (None, None, None) => Ok(KnownHost::NoAuth {
+                app: self.product,
+                url: self.url,
+            }),
+            _ => Err(eyre!("Invalid KnownHost configuration")),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "auth")]
 pub enum KnownHost {
     /// A host using API key authentication
     ApiKey {
-        accept_invalid_certs: Option<bool>,
+        accept_invalid_certs: bool,
         apikey: String,
         app: Product,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -28,7 +100,7 @@ pub enum KnownHost {
     },
     /// A host using basic username/password authentication
     Basic {
-        accept_invalid_certs: Option<bool>,
+        accept_invalid_certs: bool,
         app: Product,
         #[serde(skip_serializing_if = "Option::is_none")]
         cloud_id: Option<String>,
@@ -42,36 +114,11 @@ pub enum KnownHost {
 }
 
 impl KnownHost {
-    pub fn try_new(
-        url: Url,
-        app: String,
-        accept_invalid_certs: bool,
-        apikey: Option<String>,
-        cloud_id: Option<String>,
-        username: Option<String>,
-        password: Option<String>,
-    ) -> Result<Self> {
-        match (apikey, username, password) {
-            (Some(apikey), None, None) => Ok(KnownHost::ApiKey {
-                apikey,
-                app: Product::from_str(&app).expect("A valid application is required!"),
-                accept_invalid_certs: Some(accept_invalid_certs),
-                cloud_id,
-                url,
-            }),
-            (None, Some(username), Some(password)) => Ok(KnownHost::Basic {
-                app: Product::from_str(&app).expect("A valid application is required!"),
-                accept_invalid_certs: Some(accept_invalid_certs),
-                cloud_id,
-                password,
-                url,
-                username,
-            }),
-            (None, None, None) => Ok(KnownHost::NoAuth {
-                app: Product::from_str(&app).expect("A valid application is required!"),
-                url,
-            }),
-            _ => Err(eyre!("Invalid combination of authentication properties")),
+    pub fn app(&self) -> &Product {
+        match self {
+            Self::ApiKey { app, .. } => app,
+            Self::Basic { app, .. } => app,
+            Self::NoAuth { app, .. } => app,
         }
     }
 
@@ -178,7 +225,7 @@ impl KnownHost {
                         ))
                         .collect(),
                     )
-                    .danger_accept_invalid_certs(accept_invalid_certs.unwrap_or(false))
+                    .danger_accept_invalid_certs(*accept_invalid_certs)
                     .build()?;
                 log::trace!("Reqwest client: {:?}", client);
                 let response = client.get(url.as_str()).send().await;
@@ -198,7 +245,7 @@ impl KnownHost {
                 // test the connection
                 log::info!("Testing {} connection", &app);
                 let client = reqwest::Client::builder()
-                    .danger_accept_invalid_certs(accept_invalid_certs.unwrap_or(false))
+                    .danger_accept_invalid_certs(*accept_invalid_certs)
                     .build()?;
                 let response = client
                     .get(url.as_str())

--- a/src/exporter.rs
+++ b/src/exporter.rs
@@ -12,9 +12,12 @@ use elasticsearch::ElasticsearchExporter;
 use file::FileExporter;
 use stream::StreamExporter;
 
-use crate::data::{
-    diagnostic::{report::ProcessorSummary, DiagnosticReport},
-    Uri,
+use crate::{
+    client::KnownHost,
+    data::{
+        diagnostic::{report::ProcessorSummary, DiagnosticReport, Product},
+        Uri,
+    },
 };
 use color_eyre::eyre::{eyre, Result};
 use serde_json::Value;
@@ -102,6 +105,18 @@ impl std::fmt::Display for Exporter {
             Exporter::Elasticsearch(exporter) => write!(f, "Elasticsearch {}", exporter),
             Exporter::File(exporter) => write!(f, "File {}", exporter),
             Exporter::Stream(exporter) => write!(f, "Stream {}", exporter),
+        }
+    }
+}
+
+impl TryFrom<KnownHost> for Exporter {
+    type Error = color_eyre::Report;
+    fn try_from(host: KnownHost) -> std::result::Result<Self, Self::Error> {
+        match host.app() {
+            Product::Elasticsearch => Ok(Exporter::Elasticsearch(ElasticsearchExporter::try_from(
+                host,
+            )?)),
+            _ => Err(eyre!("Unsupported product")),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use clap::{Parser, Subcommand};
 use color_eyre::eyre::{eyre, Result};
 use esdiag::{
-    client::KnownHost,
-    data::{Collector, Uri},
+    client::{KnownHost, KnownHostBuilder},
+    data::{diagnostic::Product, Collector, Uri},
     env::LOG_LEVEL,
     exporter::{DirectoryExporter, Exporter},
     processor::Diagnostic,
@@ -38,7 +38,7 @@ enum Commands {
         name: String,
         /// Application of this host (elasticsearch, kibana, logstash, etc.)
         #[arg(help = "Application of this host (elasticsearch, kibana, logstash, etc.)")]
-        app: Option<String>,
+        app: Option<Product>,
         /// A host URL to connect to
         #[arg(help = "A host URL to connect to")]
         url: Option<Url>,
@@ -48,9 +48,6 @@ enum Commands {
         /// ApiKey for authentication
         #[arg(help = "ApiKey, passed as http header ", long, short, conflicts_with_all = &["username", "password"])]
         apikey: Option<String>,
-        /// Elastic Cloud ID (optional)
-        #[arg(help = "Elastic Cloud ID (optional)", long, short)]
-        cloud_id: Option<String>,
         /// Username for authentication
         #[arg(help = "Username for authentication", long, short)]
         username: Option<String>,
@@ -79,15 +76,15 @@ enum Commands {
     Process {
         /// Source to read diagnostic data from
         #[arg(
-            help = "Source to read diagnostic data from (archive, directory, known host or uploader URL)"
+            help = "Source to read diagnostic data from (archive, directory, known host or Elastic uploader URL)"
         )]
         input: String,
 
         /// Target to send processed diagnostic documents to
         #[arg(
-            help = "Target to send processed diagnostic documents to (known host, file, or stdout)"
+            long_help = "Target to send the processed diagnostic documents to (known host, file, stdout, or env). Strings will be checked against the known hosts stored in `~/.esdiag/hosts.yml` and will fallback to a filename if not found. Use `-` for stdout. If nothing is provided, the output will try using the environment variables: ESDIAG_OUTPUT_URL, ESDIAG_OUTPUT_APIKEY, ESDIAG_OUTPUT_USERNAME, and ESDIAG_OUTPUT_PASSWORD."
         )]
-        output: String,
+        output: Option<String>,
     },
     /// Import assets (templates, ingest pipelines, etc.) to a known Elasticsearch host
     Setup {
@@ -156,22 +153,19 @@ async fn run() -> Result<&'static str> {
             url,
             accept_invalid_certs,
             apikey,
-            cloud_id,
             username,
             password,
             nosave,
         } => {
             log::info!("Configuring host {name}");
             let host = if let (Some(app), Some(url)) = (app, url) {
-                KnownHost::try_new(
-                    url,
-                    app,
-                    accept_invalid_certs,
-                    apikey,
-                    cloud_id,
-                    username,
-                    password,
-                )?
+                KnownHostBuilder::new(url)
+                    .product(app)
+                    .accept_invalid_certs(accept_invalid_certs)
+                    .apikey(apikey)
+                    .username(username)
+                    .password(password)
+                    .build()?
             } else {
                 KnownHost::get_known(&name).ok_or(eyre!(
                     "Host {name} not found, must include `url` and `app` to setup a new host."
@@ -206,12 +200,30 @@ async fn run() -> Result<&'static str> {
         }
         Commands::Process { input, output } => {
             let input_uri = Uri::try_from(input)?;
-            let output_uri = Uri::try_from(output)?;
+            let output_uri = output.and_then(|o| Uri::try_from(o).ok());
+
             log::info!("input: {}", input_uri);
-            log::info!("output: {}", output_uri);
 
             let receiver = Receiver::try_from(input_uri)?;
-            let exporter = Exporter::try_from(output_uri)?;
+            let exporter = match output_uri {
+                Some(output_uri) => {
+                    log::info!("output: {}", output_uri);
+                    Exporter::try_from(output_uri)?
+                }
+                None => {
+                    let url = Url::parse(&std::env::var("ESDIAG_OUTPUT_URL")?)?;
+                    log::info!("output: Env {}", url);
+                    let apikey = std::env::var("ESDIAG_OUTPUT_APIKEY").ok();
+                    let username = std::env::var("ESDIAG_OUTPUT_USERNAME").ok();
+                    let password = std::env::var("ESDIAG_OUTPUT_PASSWORD").ok();
+                    let host = KnownHostBuilder::new(url)
+                        .apikey(apikey)
+                        .username(username)
+                        .password(password)
+                        .build()?;
+                    Exporter::try_from(host)?
+                }
+            };
 
             let manifest = receiver.try_get_manifest().await?;
             log::trace!("{}", serde_json::to_string(&manifest)?);


### PR DESCRIPTION
Refactor the known hosts to allow creation at runtime from `ESDIAG_OUTPUT_*` environment variables.

Resolves #100