### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:1.83 AS builder
+WORKDIR /usr/src/app
+COPY . .
+RUN cargo build --release
+
+FROM gcr.io/distroless/cc-debian12
+COPY --from=builder /usr/src/app/target/release/esdiag /usr/local/bin/esdiag
+
+ENTRYPOINT [ "/usr/local/bin/esdiag" ]


### PR DESCRIPTION
Use Google Distroless to build a minimal container image.

The resulting image size was only ~40MB (x86_64) to ~70MB (arm64). This is an excellent size for a Google Cloud Run job.

After defining the Cloud Run job (using environment variables from #100), tested against an archive in the uploader service:

```bash
gcloud run jobs execute esdiag --region=us-west2 --args="process,https://token:0123456789@upload.elastic.co/d/abcdefghijklmnopqrstuvwxyz"
```

Progress toward #82 as it is also possible to run this container locally:

```bash
docker run --rm -e ESDIAG_OUTPUT_URL="https://esdiag.es.us-west-2.aws.found.io/" -e ESDIAG_OUTPUT_APIKEY="{redacted}" esdiag:latest process "https://token:0123456789@upload.elastic.co/d/abcdefghijklmnopqrstuvwxyz"
```