### PR TITLE
Use creation date from archive and directory inputs

### DIFF
--- a/src/data/diagnostic/manifest.rs
+++ b/src/data/diagnostic/manifest.rs
@@ -23,9 +23,46 @@ pub struct Manifest {
     pub included_diagnostics: Option<Vec<DiagPath>>,
 }
 
-impl Manifest {
+pub struct ManifestBuilder {
+    diag_type: Option<String>,
+    diagnostic_inputs: Option<String>,
+    diag_version: Option<String>,
+    product: Product,
+    product_version: Option<ProductVersion>,
+    runner: Option<String>,
+    collection_date: String,
+    included_diagnostics: Option<Vec<DiagPath>>,
+}
+
+impl ManifestBuilder {
+    pub fn new() -> Self {
+        Self {
+            diag_type: None,
+            diagnostic_inputs: None,
+            diag_version: None,
+            product: Product::Elasticsearch,
+            product_version: None,
+            runner: None,
+            collection_date: chrono::Utc::now().to_rfc3339(),
+            included_diagnostics: None,
+        }
+    }
+
+    pub fn build(self) -> Manifest {
+        Manifest {
+            diag_type: self.diag_type,
+            diagnostic_inputs: self.diagnostic_inputs,
+            diag_version: self.diag_version,
+            product: self.product,
+            product_version: self.product_version,
+            runner: self.runner,
+            collection_date: self.collection_date,
+            included_diagnostics: self.included_diagnostics,
+        }
+    }
+
     /// Updates product based on diag_type
-    pub fn with_product(mut self) -> Self {
+    pub fn product(mut self) -> Self {
         log::debug!("Setting product from diag_type: {:?}", self.diag_type);
         self.product = match &self.diag_type {
             Some(diag_type) => match diag_type.as_str() {
@@ -48,7 +85,7 @@ impl Manifest {
     }
 
     /// Updates diag_type based on diagnostic_inputs
-    pub fn with_diag_type(mut self) -> Self {
+    pub fn diag_type(mut self) -> Self {
         if self.diag_type.is_some() {
             log::trace!("diag_type already set {:?}", self.diag_type);
             return self;
@@ -70,10 +107,28 @@ impl Manifest {
         }
     }
 
-    /// Updates runner with provided String
-    pub fn with_runner(mut self, runner: &str) -> Self {
+    /// The runner used to execute the diagnostic
+    pub fn runner(mut self, runner: &str) -> Self {
         self.runner = Some(runner.to_string());
         self
+    }
+
+    /// A collection date, used if the manifest does not have one
+    pub fn collection_date(mut self, date: String) -> Self {
+        self.collection_date = date;
+        self
+    }
+}
+
+impl From<elasticsearch::Cluster> for ManifestBuilder {
+    fn from(version: elasticsearch::Cluster) -> Self {
+        let builder = ManifestBuilder::new();
+        Self {
+            diag_type: Some("es-unknown".to_string()),
+            product_version: Some(ProductVersion::from(version.version)),
+            runner: Some("unknown".to_string()),
+            ..builder
+        }
     }
 }
 

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -13,7 +13,7 @@ use elastic_uploader::ElasticUploaderReceiver;
 pub use elasticsearch::ElasticsearchReceiver;
 
 use crate::data::{
-    diagnostic::{DataSource, DiagnosticManifest, Manifest},
+    diagnostic::{manifest::ManifestBuilder, DataSource, DiagnosticManifest, Manifest},
     elasticsearch::Cluster,
     Uri,
 };
@@ -22,6 +22,7 @@ use serde::de::DeserializeOwned;
 
 trait Receive {
     async fn is_connected(&self) -> bool;
+    async fn collection_date(&self) -> String;
     async fn get<T>(&self) -> Result<T>
     where
         T: DataSource + DeserializeOwned;
@@ -106,6 +107,15 @@ impl Receiver {
         Ok(receiver)
     }
 
+    pub async fn collection_date(&self) -> String {
+        match self {
+            Receiver::Archive(receiver) => receiver.collection_date().await,
+            Receiver::Directory(receiver) => receiver.collection_date().await,
+            Receiver::Elasticsearch(receiver) => receiver.collection_date().await,
+            Receiver::ElasticUploader(receiver) => receiver.collection_date().await,
+        }
+    }
+
     pub async fn try_get_manifest(&self) -> Result<DiagnosticManifest> {
         if let Ok(manifest) = self.get::<DiagnosticManifest>().await {
             log::debug!("Using diagnostic_manifest.json");
@@ -114,11 +124,13 @@ impl Receiver {
             log::warn!("Falling back to manifest.json");
             Ok(manifest.try_into()?)
         } else {
-            log::warn!("Falling back to version.json");
-            let version = self.get::<Cluster>().await?;
+            let cluster = self.get::<Cluster>().await?;
+            let manifest_builder = ManifestBuilder::from(cluster);
+            let collection_date = self.collection_date().await;
+            log::warn!("Falling back to version.json with collection date {collection_date}");
             let manifest = match self {
-                Receiver::Elasticsearch(_) => Manifest::try_from(version)?.with_runner("esdiag"),
-                _ => Manifest::try_from(version)?,
+                Receiver::Elasticsearch(_) => manifest_builder.runner("esdiag").build(),
+                _ => manifest_builder.collection_date(collection_date).build(),
             };
             Ok(manifest.try_into()?)
         }

--- a/src/receiver/archive.rs
+++ b/src/receiver/archive.rs
@@ -7,6 +7,7 @@ use std::{
     io::{BufReader, Read},
     path::PathBuf,
     sync::Arc,
+    time::SystemTime,
 };
 use tokio::sync::RwLock;
 use zip::ZipArchive;
@@ -16,6 +17,7 @@ pub struct ArchiveReceiver {
     archive: Arc<RwLock<ZipArchive<File>>>,
     filename: String,
     subdir: Option<PathBuf>,
+    created_date: SystemTime,
 }
 
 impl ArchiveReceiver {
@@ -37,8 +39,12 @@ impl TryFrom<PathBuf> for ArchiveReceiver {
         match path.is_file() {
             true => {
                 log::debug!("File is valid: {}", path.display());
+                let file = File::open(path)?;
+                let created_date = file.metadata()?.created()?;
+                let archive = ZipArchive::new(file)?;
                 Ok(Self {
-                    archive: Arc::new(RwLock::new(ZipArchive::new(File::open(path)?)?)),
+                    archive: Arc::new(RwLock::new(archive)),
+                    created_date,
                     filename,
                     subdir: None,
                 })
@@ -52,6 +58,10 @@ impl TryFrom<PathBuf> for ArchiveReceiver {
 }
 
 impl Receive for ArchiveReceiver {
+    async fn collection_date(&self) -> String {
+        chrono::DateTime::<chrono::Utc>::from(self.created_date).to_rfc3339()
+    }
+
     async fn is_connected(&self) -> bool {
         let archive = self.archive.read().await;
         let is_empty = archive.is_empty();

--- a/src/receiver/directory.rs
+++ b/src/receiver/directory.rs
@@ -6,12 +6,14 @@ use std::{
     fs::File,
     io::{BufReader, Read},
     path::PathBuf,
+    time::SystemTime,
 };
 
 #[derive(Clone)]
 pub struct DirectoryReceiver {
     path: PathBuf,
     work_dir: String,
+    created_date: SystemTime,
 }
 
 impl TryFrom<PathBuf> for DirectoryReceiver {
@@ -24,6 +26,7 @@ impl TryFrom<PathBuf> for DirectoryReceiver {
                 Ok(Self {
                     path: path.clone(),
                     work_dir: String::from(""),
+                    created_date: path.metadata()?.created()?,
                 })
             }
             false => {
@@ -38,6 +41,10 @@ impl TryFrom<PathBuf> for DirectoryReceiver {
 }
 
 impl Receive for DirectoryReceiver {
+    async fn collection_date(&self) -> String {
+        chrono::DateTime::<chrono::Utc>::from(self.created_date).to_rfc3339()
+    }
+
     async fn is_connected(&self) -> bool {
         let is_dir = self.path.is_dir();
         let directory_name = self.path.to_str().unwrap_or("");

--- a/src/receiver/elastic_uploader.rs
+++ b/src/receiver/elastic_uploader.rs
@@ -25,6 +25,10 @@ pub struct ElasticUploaderReceiver {
 /// A receiver for the Elastic Uploader service (https://upload.elastic.co).
 /// This will download the archive on first use and cache it in memory.
 impl Receive for ElasticUploaderReceiver {
+    async fn collection_date(&self) -> String {
+        chrono::Utc::now().to_rfc3339()
+    }
+
     async fn is_connected(&self) -> bool {
         let client = reqwest::Client::new();
         let request = client.head(self.url.clone());

--- a/src/receiver/elasticsearch.rs
+++ b/src/receiver/elasticsearch.rs
@@ -32,6 +32,10 @@ impl TryFrom<KnownHost> for ElasticsearchReceiver {
 }
 
 impl Receive for ElasticsearchReceiver {
+    async fn collection_date(&self) -> String {
+        chrono::Utc::now().to_rfc3339()
+    }
+
     async fn is_connected(&self) -> bool {
         log::debug!("Testing Elasticsearch client connection");
         // An empty request to `/`


### PR DESCRIPTION
Falling back to `chrono::Utc::now()` was not desirable when failing back to a `version.json` with no valid collection date. Using the archive or directory metadata is much more helpful.