### PR TITLE
Update to index.mapping.source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "esdiag"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esdiag"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 rust-version = "1.86"
 

--- a/assets/elasticsearch/component_template/esdiag@mappings.json
+++ b/assets/elasticsearch/component_template/esdiag@mappings.json
@@ -11,11 +11,6 @@
         "strict_date_optional_time",
         "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"
       ],
-      "_source": {
-        "excludes": [],
-        "includes": [],
-        "mode": "synthetic"
-      },
       "dynamic": true,
       "dynamic_templates": [
         {

--- a/assets/elasticsearch/component_template/esdiag@settings.json
+++ b/assets/elasticsearch/component_template/esdiag@settings.json
@@ -14,6 +14,9 @@
         "mapping": {
           "total_fields": {
             "ignore_dynamic_beyond_limit": "true"
+          },
+          "source": {
+            "mode": "synthetic"
           }
         },
         "query": {


### PR DESCRIPTION
Removes deprecated synthetic source configuration: https://www.elastic.co/guide/en/elasticsearch/reference/current/troubleshoot-migrate-source-mode.html