### PR TITLE
Update indices_settings.rs

### DIFF
--- a/src/data/elasticsearch/indices_settings.rs
+++ b/src/data/elasticsearch/indices_settings.rs
@@ -67,7 +67,7 @@ pub struct StoreSnapshot {
     pub index_uuid: String,
     pub repository_uuid: String,
     pub index_name: String,
-    pub partial: String,
+    pub partial: Option<String>,
     pub repository_name: String,
     pub snapshot_uuid: String,
 }


### PR DESCRIPTION
adding partial: Option<String>

This prevents the error 

```
todd@Todd-M1max-Work ~/Documents/work/liveperson/va_cluster_june9 $ esdiag process diagnostic-e9f8e7-2025-Jun-09--15_26_02.zip cloud-esdiag
[2025-06-09T20:26:41.002Z INFO  esdiag] input: diagnostic-e9f8e7-2025-Jun-09--15_26_02.zip
[2025-06-09T20:26:41.009Z INFO  esdiag::processor] Processing Elasticsearch diagnostic
[2025-06-09T20:26:41.019Z WARN  esdiag::processor::elasticsearch::lookup::index_settings] Failed to parse IndicesSettings: missing field `partial` at line 1 column 5234
[2025-06-09T20:26:41.387Z WARN  esdiag::processor::elasticsearch] No indices_settings data found: missing field `partial` at line 1 column 5234
```