### PR TITLE
Add GitHub token support for version checks/updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env*
 /target
 /output
 /assets/kibana/*.ndjson

--- a/assets/kibana/readme.md
+++ b/assets/kibana/readme.md
@@ -1,1 +1,5 @@
-Before running the `bin/stack-local-setup.sh` script, download the latest ESDiag dashboards `.ndjson` into this directory from [https://github.com/elastic/esdiag-dashboards/releases/latest](https://github.com/elastic/esdiag-dashboards/releases/latest)
+Use this directory for the `esdiag-dashboards-*.ndjson` files for the `bin/stack-local-setup.sh` script. Release downloads are from: https://github.com/elastic/esdiag-dashboards/releases/latest
+
+These files can be downloaded automatically or manually:
+1. Automated: Add a [personal access token](../../docs/github_token.md) to the `.env` as `export GITHUB_TOKEN=<your_token>`.
+2. Manual: Go to the ESDiag Dashboard [latest release](https://github.com/elastic/esdiag-dashboards/releases/latest) page in your web browser and save to this directory.

--- a/bin/esdiag-docker.sh
+++ b/bin/esdiag-docker.sh
@@ -75,6 +75,7 @@ function docker_run() {
 
     docker run --rm ${diag_mount:+--volume ${input}:${diag_mount}} \
         --env ESDIAG_OUTPUT_URL="${ESDIAG_OUTPUT_URL}" \
+        ${LOG_LEVEL:+--env LOG_LEVEL="${LOG_LEVEL}"} \
         ${ESDIAG_OUTPUT_APIKEY:+--env ESDIAG_OUTPUT_APIKEY="${ESDIAG_OUTPUT_APIKEY}"} \
         ${ESDIAG_OUTPUT_USERNAME:+--env ESDIAG_OUTPUT_USERNAME="${ESDIAG_OUTPUT_USERNAME}"} \
         ${ESDIAG_OUTPUT_PASSWORD:+--env ESDIAG_OUTPUT_PASSWORD="${ESDIAG_OUTPUT_PASSWORD}"} \

--- a/bin/readme.md
+++ b/bin/readme.md
@@ -92,20 +92,27 @@ Setup a complete, local, Docker container-powered Elastic Stack for ESDiag.
 4. Imports Kibana saved objects from an `.ndjson` file
 5. Opens Kibana in your web browser
 
-### Usage:
+### Dependencies
 
-```sh
-./bin/stack-local-setup.sh [path/to/dashboards.ndjson]
-```
+This script will check for the following dependencies:
 
-If no dashboard file is provided, the script will attempt to use the newest dashboard file in `assets/kibana/esdiag-dashboards*.ndjson`. Dashboard files can be downloaded from the [esdiag-dashboards](https://github.com/elastic/esdiag-dashboards/releases/latest) GitHub repository.
-
-### Dependencies:
-
-This script has the following dependencies:
-
-1. Docker with `docker compose` support
+1. `docker` - for containers, must include `docker compose` support
 2. `jq` - for json parsing
 3. `curl` - for http requests
 4. `grep` - for pattern matching
 5. `sed` - for text manipulation
+
+### Usage
+
+Before running the script, you'll need to either:
+1. Create a [GitHub personal access token](../docs/github_token.md) and add a line to a `.env` file in the repository root:
+   ```sh
+   export GITHUB_TOKEN="github_pat_123..."
+   ```
+2. Manually download the latest dashboard file from the [esdiag-dashboards](https://github.com/elastic/esdiag-dashboards/releases/latest) GitHub repository and place it in the `assets/kibana` directory.
+
+```sh
+./bin/stack-local-setup.sh
+```
+
+If you provide a GitHub token, the script will do a version check, and download the latest dashboard release if compatible. Without a GitHub token, the script will use the current repository clone and rely on the manual download.

--- a/bin/stack-local-setup.sh
+++ b/bin/stack-local-setup.sh
@@ -7,15 +7,22 @@
 # 4. Imports Kibana saved objects from an `.ndjson` file
 # 5. Opens Kibana in your web browser
 
+# ----- Load Dotenv File -----
+
+if [[ -f ".env" ]]; then
+    source ".env"
+fi
+
 # ----- User Configuration -----
 
 declare kibana_url="http://localhost:5601"
 declare elasticsearch_url="http://localhost:9200"
+declare github_token=${GITHUB_TOKEN}
+declare assets_path="assets/kibana"
 
 # ----- Advanced Configuration -----
 
-# Use ESDIAG_OUTPUT* environment variables to configure authentication
-
+# Use ESDIAG_OUTPUT* environment variables to configure Elastic Stack authentication
 declare apikey=${ESDIAG_OUTPUT_APIKEY}
 declare username=${ESDIAG_OUTPUT_USERNAME}
 declare password=${ESDIAG_OUTPUT_PASSWORD}
@@ -23,12 +30,16 @@ declare password=${ESDIAG_OUTPUT_PASSWORD}
 # Landing page when opening the web browser
 declare kibana_homepage="/app/dashboards#/view/2c8cd284-79ef-4787-8b79-0030e0df467b"
 
-# The `export.ndjson` file to import into Kibana, provided as the first argument to the script
+# The `export.ndjson` file to import into Kibana, can be provided as the only argument to the script
 # Defaults to the newest dashboard file in `assets/kibana/esdiag-dashboards*.ndjson`
+# Is overwritten by `dashboards_latest_release_download()` if a GITHUB_TOKEN is defined
 declare dashboard_file=${1:-$(ls -tr assets/kibana/esdiag-dashboards*.ndjson 2>/dev/null | tail -n 1)}
 
-# URL to download the latest dashboards release file
-declare esdiag_dashboards_url="https://github.com/elastic/esdiag-dashboards/releases/latest"
+# Git repository information
+declare esdiag_dashboards_url="https://api.github.com/repos/elastic/esdiag-dashboards"
+declare esdiag_url="https://api.github.com/repos/elastic/esdiag"
+declare esdiag_branch=${ESDIAG_BRANCH:-"main"}
+declare esdiag_version=$(grep -o '^version = ".*"' Cargo.toml | sed -E 's/^version = "(.*)"/\1/')
 
 # ----- Logging Functions -----
 
@@ -53,6 +64,94 @@ function log_debug() {
     if [[ $LOG_LEVEL == "debug" ]]; then
         echo "[$(timestamp) $(blue Debug) ${log_name}] ${1}"
     fi
+}
+
+# ----- GitHub Functions -----
+
+function github_token_check() {
+    local token_status=$(curl --silent --location \
+        --header "Accept: application/vnd.github+json" \
+        --header "Authorization: token ${github_token}" \
+        --header "X-GitHub-Api-Version: 2022-11-28" \
+        --write-out "%{http_code}" --output /dev/null \
+        "${esdiag_url}" )
+
+    if [[ $token_status == "200" ]]; then
+        log_info "GitHub token is $(green valid): http ${token_status}"
+    else
+        log_error "GitHub token is $(red invalid): http ${token_status}"
+        exit 1
+    fi
+}
+
+function esdiag_version_check() {
+    local local_branch=$(git branch --show-current)
+    if [[ "$local_branch" != "$esdiag_branch" ]]; then
+        log_warn "You are on branch $(yellow ${local_branch}) and checking against $(cyan ${esdiag_branch})"
+    fi
+
+    local esdiag_latest=$(curl --silent --location \
+        --header "Accept: application/vnd.github+json" \
+        --header "Authorization: token ${github_token}" \
+        --header "X-GitHub-Api-Version: 2022-11-28" \
+          "${esdiag_url}/contents/Cargo.toml?ref=${esdiag_branch}" \
+          | jq -r '.content' | base64 -d | grep "^version = " | sed 's/version = "\(.*\)"/\1/')
+
+    log_info "latest version: $(cyan ${esdiag_latest}) on $(gray ${esdiag_branch})"
+
+    if [[ "$esdiag_latest" == "$esdiag_version" ]]; then
+        log_info "local version:  $(green ${esdiag_version}) on $(gray ${local_branch})"
+    else
+        log_warn "local version:  $(yellow ${esdiag_version}) on $(gray ${local_branch})"
+        log_warn "Please run $(white "git pull") to update local repository and ensure dashboard compatibility"
+        if [[ "$local_branch" != "$esdiag_branch" ]]; then
+            log_warn "And be sure the $(yellow ${local_branch}) branch is compatible with $(cyan ${esdiag_branch})"
+        fi
+        exit 1
+    fi
+}
+
+function dashboards_latest_release_download() {
+    log_info "Fetching latest ESDiag Dashboards release"
+
+    # Get the latest release metadata
+    local latest_release_json=$(curl --silent --location \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: token ${github_token}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${esdiag_dashboards_url}/releases/latest")
+
+    # Find the .ndjson asset download URL
+    local download_url=$(echo "${latest_release_json}" | jq -r '.assets[] | select(.name | endswith(".ndjson")) | .url' | head -1)
+    local file_name=$(echo "${latest_release_json}" | jq -r '.assets[] | select(.name | endswith(".ndjson")) | .name' | head -1)
+
+    if [[ -z "$download_url" || -z "$file_name" ]]; then
+        log_error "Latest ESDiag Dashboards release $(red not found), no $(gray .ndjson) in assets"
+        return 1
+    else
+        log_info "Latest ESDiag Dashboards release $(green found): $(gray ${file_name})"
+    fi
+
+    if [[ ! -f "${assets_path}/${file_name}" ]]; then
+        # Download the asset using the GitHub API
+        curl --silent --location \
+                --header "Authorization: token ${github_token}" \
+                --header "Accept: application/octet-stream" \
+                --output "${assets_path}/${file_name}" \
+                "${download_url}"
+
+        if [[ $? -ne 0 || ! -f "${assets_path}/${file_name}" ]]; then
+            log_error "Failed to download dashboard file"
+            return 1
+        fi
+
+        log_info "Dashboard file $(green successfully) downloaded to $(gray "${assets_path}/${file_name}")"
+    else
+        # Skip download if we already have the latest release file
+        log_info "File $(gray "${assets_path}/${file_name}") $(green exists), skipping download"
+    fi
+
+    export dashboard_file="${assets_path}/${file_name}"
 }
 
 # ----- Kibana Functions -----
@@ -134,17 +233,16 @@ function stack_containers_run() {
 
 function containers_build_and_run() {
     stack_containers_run &
-    local esdiag_version=$(grep -o '^version = ".*"' Cargo.toml | sed -E 's/^version = "(.*)"/\1/')
     if [[ $(docker images -q esdiag:${esdiag_version} 2> /dev/null) == "" ]]; then
         log_info "Building $(cyan "esdiag:${esdiag_version}") container image"
     else
-        log_info "Found container image $(cyan "esdiag:${esdiag_version}"), skipping build"
+        log_info "Skipping $(white "docker build"), found container image $(cyan "esdiag:${esdiag_version}")"
         return
     fi
 
     docker build --tag esdiag:${esdiag_version} .
     if [[ $? -eq 0 ]]; then
-        log_info "$(white "docker build") completed $(green successfully)"
+        log_info "$(white "docker build") is $(green complete)"
         docker tag esdiag:${esdiag_version} esdiag:latest
     else
         log_error "$(white "docker build") $(red failed) with exit status ${?}"
@@ -165,12 +263,12 @@ function elasticsearch_templates_setup() {
     done
     log_info "$(blue Elasticsearch) is $(green ready)!"
 
-    bin/esdiag-docker.sh setup
+    LOG_LEVEL=${LOG_LEVEL:-warn} bin/esdiag-docker.sh setup
 
     if [[ $? -eq 0 ]]; then
-        log_info "$(white "esdiag setup") completed $(green "successfully")"
+        log_info "$(white "esdiag setup") is $(green complete)!"
     else
-        log_error "$(cyan ESDiag) setup $(red failed) with exit status ${?}"
+        log_error "$(white "esdiag setup") $(red failed) with exit status ${?}"
         exit $?
     fi
 }
@@ -217,12 +315,9 @@ function dependencies_validate() {
         failures=$((failures + 1))
     fi
 
-    if [[ ! -f $dashboard_file ]]; then
-        log_error "Dashboard file $(gray "${dashboard_file}") does not exist"
-        echo "ESDiag $(white "${0}") requires a dashboards import file. Download the latest $(gray .ndjson) file from:"
-        echo "  $(blue "${esdiag_dashboards_url}")"
-        echo "Then provide a valid dashboard file path as an argument:"
-        echo "  $(gray "./bin/stack-local-setup.sh ~/Downloads/esdiag-dashboards_2025-04-20.ndjson")"
+    if [[ -z $github_token && ! -f $dashboard_file ]]; then
+        # Skip this check if $github_token is set, we will download the file from GitHub
+        log_error "ESDiag Dashboards file $(gray "${dashboard_file}") $(red "not found")"
         failures=$((failures + 1))
     fi
 
@@ -239,8 +334,25 @@ function dependencies_validate() {
 
 # ----- Main -----
 
-dependencies_validate \
-&& containers_build_and_run \
-&& elasticsearch_templates_setup \
-&& kibana_objects_import \
-&& browser_homepage_open
+dependencies_validate
+
+# If we have a GitHub token, try to download the latest dashboard file
+if [[ -z $github_token ]]; then
+    log_warn "No GitHub token, $(yellow skipping) version checks and building with local version $(cyan ${esdiag_version})"
+else
+    github_token_check \
+    && esdiag_version_check \
+    && dashboards_latest_release_download
+fi
+
+# If we have a dashboard file, proceed with setup
+if [[ -f $dashboard_file ]]; then
+    containers_build_and_run \
+    && elasticsearch_templates_setup \
+    && kibana_objects_import \
+    && browser_homepage_open \
+    && log_info "$(white ${0}) is $(green complete)!"
+else
+    log_error "ESDiag Dashboards file $(red "not found")"
+    exit 1
+fi

--- a/docs/github_token.md
+++ b/docs/github_token.md
@@ -1,0 +1,36 @@
+Creating a GitHub Personal Access Token
+----------------------------------------
+
+Step-by-step instructions:
+
+1. Click on the top-right user icon, pick `⚙️ Settings` from the list (lower middle)
+
+2. From the left menu, scroll to the very bottom, pick the last entry: `<> Developer settings`
+
+3. From the left menu, expand `Personal access tokens` and click `Fine-grained tokens`
+
+4. To the right of the page header, click the `Generate new token` button
+
+5. GitHub may ask for multi-factor authentication
+
+6. In `Token name` put `esdiag` or something descriptive
+
+7. For `Resource owner`, pick the `elastic` organization
+
+8. For `Expiration` use 90 days or custom; InfoSec recommends no more than 1 year
+
+9. For `Repository Access`, pick `Only selected repositires`
+
+10. In the `Select repositories` search box, type `esdiag` and pick two results: `esdiag` and `esdiag-dashboards`
+
+11. Expand `Repository Permissions` and find `Contents`, update `Access: No access` to `Access: Read-only`
+
+12. Scroll to the bottom and click `Generate token`
+
+Now copy the token and save it somewhere safe, you will have to regenerate it if you lose it.
+
+For this repository, add it to the root `.env` file:
+
+```sh
+export GITHUB_TOKEN="github_pat_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+```

--- a/docs/github_token.md
+++ b/docs/github_token.md
@@ -19,7 +19,7 @@ Step-by-step instructions:
 
 8. For `Expiration` use 90 days or custom; InfoSec recommends no more than 1 year
 
-9. For `Repository Access`, pick `Only selected repositires`
+9. For `Repository Access`, pick `Only selected repositories`
 
 10. In the `Select repositories` search box, type `esdiag` and pick two results: `esdiag` and `esdiag-dashboards`
 

--- a/readme.md
+++ b/readme.md
@@ -3,27 +3,59 @@ Elastic Stack Diagnostics
 
 The Elastic Stack Diagnostics (`esdiag`) tool simplifies processing and importing diagnostic bundles into Elasticsearch. It pre-processes, split and enriches the raw API outputs into Elasticsearch-friendly documents. This makes building diagnostic Kibana dashboards, ES|QL queries, and more, easy.
 
-Running locally with Docker Desktop
-------------------------------------
+Running locally within containers
+----------------------------------
+
+### 1. Preparation
 
 Use the `bin/stack-local-setup.sh` to quickly spin up a fully-local environment.
 
 1. Clone this repository to your local machine using either `git` or [GitHub Desktop](https://desktop.github.com/download/)
 2. Be sure you have the dependencies installed: `docker`, `jq`, `curl`, `grep`, and `sed`.
-3. Download the latest version of `esdiag-dashboards.ndjson` from the [GitHub releases page](https://github.com/elastic/esdiag-dashboards/releases/latest) to the `assets/kibana` directory.
-4. Run the script from this repository's root directory:
+3. Pick either the **Automated** or **Manual** dashboard update method
+
+> ℹ️ Note: You can use any container runtime, as long as it supports the `docker compose` subcommand.
+
+### 2a. Automated dashboard updates
+
+To automate version checks and dashboard updates, you will need a GitHub personal access token.
+
+Detailed instructions are in [docs/github_token.md](docs/github_token.md).
+
+Once you've generated the token, add it to the `.env` file in the repository root:
+
+```sh
+export GITHUB_TOKEN="github_pat_123..."
+```
+
+This will allow the `esdiag` scripts like `bin/stack-local-setup.sh` to use your permissions to read directly from the private GitHub repositories.
+
+### 2b. Manual dashboard updates
+
+Each time you want to update the dashboards, you will have to download the latest [`esdiag-dashboards.ndjson release`](https://github.com/elastic/esdiag-dashboards/releases/latest) and move it to the `assets/kibana` directory.
+
+Without the GitHub token the script also cannot check the version of ESDiag itself. There will be a warning message about skipping version checks in the logs.
+
+You can add the GitHub token later at any time.
+
+### 3. Running
+
+Now run the script from this repository's root directory:
 
 ```sh
 ./bin/stack-local-setup.sh
 ```
 
-Once the script is done, you will have:
+Once the script is complete, you will have:
 1. A single Elasticsearch node with all index templates installed.
 2. A fully-configured Kibana instance with dashboards, data views, and saved searches imported.
 3. A Docker container image to use with `bin/esdiag-docker.sh` for processing diagnostic bundles.
 4. A web browser opened to http://localhost:5601
+5. If you configured `automated` dashboard updates, re-running the script will update and re-import the dashboards.
 
-Then import your first diagnostic with:
+### 4. Processing diagnostics
+
+Now import your first diagnostic with:
 
 ```sh
 ./bin/esdiag-docker.sh process ~/Downloads/diagnostic-abc123-2025-Jun-20--12_30_01.zip


### PR DESCRIPTION
Adds support for generating a GitHub personal access token, and saving it to a `.env` file. Allowing for automated version checks and dashboards release updates.