### PR TITLE
Fix daily rate estimates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "esdiag"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esdiag"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 rust-version = "1.86"
 

--- a/src/processor/elasticsearch/index_stats.rs
+++ b/src/processor/elasticsearch/index_stats.rs
@@ -176,19 +176,26 @@ impl IndexDocument {
         stats.primaries.indexing.est_bytes_per_day = match stats.write_phase_sec {
             None => None,
             Some(0) => Some(0),
-            Some(seconds) => Some(stats.primaries.store.size_in_bytes * (86_400 / seconds)),
+            Some(seconds) => Some(
+                (stats.primaries.store.size_in_bytes as f64 * (86_400.0 / seconds as f64)) as u64,
+            ),
         };
 
         stats.total.indexing.est_bytes_per_day = match stats.write_phase_sec {
             None => None,
             Some(0) => Some(0),
-            Some(seconds) => Some(stats.total.store.size_in_bytes * (86_400 / seconds)),
+            Some(seconds) => {
+                Some((stats.total.store.size_in_bytes as f64 * (86_400.0 / seconds as f64)) as u64)
+            }
         };
 
         stats.primaries.bulk.est_bytes_per_day = match stats.write_phase_sec {
             None => None,
             Some(0) => Some(0),
-            Some(seconds) => Some(stats.primaries.bulk.total_size_in_bytes * (86_400 / seconds)),
+            Some(seconds) => Some(
+                (stats.primaries.bulk.total_size_in_bytes as f64 * (86_400.0 / seconds as f64))
+                    as u64,
+            ),
         };
 
         // Determine average index time per shard


### PR DESCRIPTION
This bug was under-estimating ingest rates in a lot of cases, _especially_ on the current partial day. By casting the intermediate values to floating point we stop rounding to integers and losing a lot of accuracy. 🤦‍♂️