### PR TITLE
Add license information to diagnostic report

### DIFF
--- a/assets/elasticsearch/ingest_pipeline/esdiag.json
+++ b/assets/elasticsearch/ingest_pipeline/esdiag.json
@@ -9,6 +9,14 @@
       }
     },
     {
+      "set": {
+        "ignore_failure": true,
+        "if": "ctx?.diagnostic?.account == null",
+        "field": "diagnostic.account",
+        "value": "{{diagnostic.license.issued_to}}"
+      }
+    },
+    {
       "reroute": {}
     }
   ]

--- a/src/processor/diagnostic/mod.rs
+++ b/src/processor/diagnostic/mod.rs
@@ -13,7 +13,7 @@ pub mod manifest;
 /// Diagnostic job report
 pub mod report;
 
-pub use data_source::DataSource;
+pub use data_source::{DataSource, PathType};
 pub use data_stream_name::DataStreamName;
 pub use diagnostic_manifest::DiagnosticManifest;
 pub use doc::DiagnosticMetadata;

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -1,3 +1,4 @@
+use super::super::elasticsearch::License as ElasticsearchLicense;
 use super::{DiagnosticManifest, DiagnosticMetadata, Lookup, Product};
 use eyre::{OptionExt, Report, Result, eyre};
 use serde::Serialize;
@@ -77,10 +78,17 @@ impl Default for Identifiers {
 }
 
 #[derive(Serialize, Clone)]
+#[serde(untagged)]
+pub enum License {
+    Elasticsearch(ElasticsearchLicense),
+}
+
+#[derive(Serialize, Clone)]
 pub struct DiagnosticReport {
     pub product: Product,
     origin: Origin,
     pub docs: Docs,
+    pub license: Option<License>,
     lookup: NestedStats<LookupSummary>,
     processor: NestedStats<ProcessorSummary>,
     #[serde(flatten)]
@@ -97,6 +105,10 @@ impl DiagnosticReport {
 
     pub fn add_identifiers(&mut self, identifiers: Identifiers) {
         self.identifiers = identifiers;
+    }
+
+    pub fn add_license(&mut self, license: Option<ElasticsearchLicense>) {
+        self.license = license.map(License::Elasticsearch);
     }
 }
 
@@ -156,6 +168,7 @@ impl TryFrom<DiagnosticReportBuilder> for DiagnosticReport {
                 errors: 0,
                 total: 0,
             },
+            license: None,
             lookup: NestedStats::<LookupSummary> {
                 count: 0,
                 errors: 0,

--- a/src/processor/elasticsearch/collector.rs
+++ b/src/processor/elasticsearch/collector.rs
@@ -1,17 +1,14 @@
-use super::super::collector::CollectionResult;
+use super::super::{collector::CollectionResult, diagnostic::PathType};
 use super::{
-    alias::AliasList, cluster_settings::ClusterSettings, data_stream::DataStreams,
-    ilm_explain::IlmExplain, ilm_policies::IlmPolicies, indices_settings::IndicesSettings,
-    indices_stats::IndicesStats, nodes::Nodes, nodes_stats::NodesStats,
+    DataSource, DiagnosticManifest, Product, alias::AliasList, cluster_settings::ClusterSettings,
+    data_stream::DataStreams, ilm_explain::IlmExplain, ilm_policies::IlmPolicies,
+    indices_settings::IndicesSettings, indices_stats::IndicesStats, licenses::Licenses,
+    nodes::Nodes, nodes_stats::NodesStats,
     searchable_snapshots_cache_stats::SearchableSnapshotsCacheStats,
     searchable_snapshots_stats::SearchableSnapshotsStats, slm_policies::SlmPolicies, tasks::Tasks,
     version::Cluster,
 };
-use crate::{
-    exporter::DirectoryExporter,
-    processor::diagnostic::{DataSource, DiagnosticManifest, Product, data_source::PathType},
-    receiver::Receiver,
-};
+use crate::{exporter::DirectoryExporter, receiver::Receiver};
 use eyre::Result;
 use std::path::PathBuf;
 
@@ -41,6 +38,7 @@ impl ElasticsearchCollector {
         result.success += self.save::<IlmPolicies>().await?;
         result.success += self.save::<IndicesSettings>().await?;
         result.success += self.save::<IndicesStats>().await?;
+        result.success += self.save::<Licenses>().await?;
         result.success += self.save::<Nodes>().await?;
         result.success += self.save::<NodesStats>().await?;
         result.success += self.save::<SearchableSnapshotsCacheStats>().await?;

--- a/src/processor/elasticsearch/licenses/data.rs
+++ b/src/processor/elasticsearch/licenses/data.rs
@@ -1,0 +1,41 @@
+use super::super::super::diagnostic::data_source::PathType;
+use super::super::DataSource;
+use eyre::Result;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+#[skip_serializing_none]
+#[derive(Deserialize)]
+pub struct Licenses {
+    pub license: License,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Deserialize, Serialize)]
+pub struct License {
+    status: String,
+    uid: String,
+    r#type: String,
+    //issue_date: String,
+    issue_date_in_millis: i64,
+    //expiry_date: String,
+    expiry_date_in_millis: i64,
+    max_nodes: Option<i32>,
+    max_resource_units: i32,
+    issued_to: String,
+    issuer: String,
+    start_date_in_millis: i64,
+}
+
+impl DataSource for Licenses {
+    fn source(kind: PathType) -> Result<&'static str> {
+        match kind {
+            PathType::File => Ok("licenses.json"),
+            PathType::Url => Ok("_license"),
+        }
+    }
+
+    fn name() -> String {
+        "licenses".to_string()
+    }
+}

--- a/src/processor/elasticsearch/licenses/mod.rs
+++ b/src/processor/elasticsearch/licenses/mod.rs
@@ -1,0 +1,3 @@
+mod data;
+
+pub use data::*;

--- a/src/processor/elasticsearch/mod.rs
+++ b/src/processor/elasticsearch/mod.rs
@@ -14,6 +14,8 @@ mod ilm_policies;
 mod indices_settings;
 /// The `_stats` API
 mod indices_stats;
+/// The `_license` API
+mod licenses;
 /// Elasticsearch diagnostics metadata
 mod metadata;
 /// The `_nodes` API
@@ -32,7 +34,10 @@ mod tasks;
 mod version;
 
 pub use metadata::{ElasticsearchMetadata, ElasticsearchVersion};
-pub use version::{Cluster, Version};
+pub use {
+    licenses::License,
+    version::{Cluster, Version},
+};
 
 use super::{
     DataProcessor, DiagnosticProcessor, Metadata,
@@ -48,6 +53,21 @@ use serde::{Serialize, de::DeserializeOwned};
 use serde_json::Value;
 use std::{pin::Pin, sync::Arc};
 use tokio::{sync::RwLock, task::JoinHandle};
+use {
+    alias::{Alias, AliasList},
+    cluster_settings::ClusterSettings,
+    data_stream::{DataStream, DataStreams},
+    ilm_explain::{IlmExplain, IlmStats},
+    ilm_policies::IlmPolicies,
+    indices_settings::{IndexSettings, IndicesSettings},
+    indices_stats::IndicesStats,
+    licenses::Licenses,
+    nodes::{NodeDocument, Nodes},
+    nodes_stats::NodesStats,
+    searchable_snapshots_cache_stats::{SearchableSnapshotsCacheStats, SharedCacheStats},
+    slm_policies::SlmPolicies,
+    tasks::Tasks,
+};
 
 type ExporterDocumentQueue = Arc<RwLock<Vec<(String, Vec<Value>)>>>;
 
@@ -104,18 +124,20 @@ impl DiagnosticProcessor for ElasticsearchDiagnostic {
             .build()?;
 
         let lookups = Lookups {
-            alias: Lookup::from(receiver.get::<alias::AliasList>().await),
-            data_stream: Lookup::from(receiver.get::<data_stream::DataStreams>().await),
-            index_settings: Lookup::from(receiver.get::<indices_settings::IndicesSettings>().await),
-            node: Lookup::from(receiver.get::<nodes::Nodes>().await),
-            ilm_explain: Lookup::from(receiver.get::<ilm_explain::IlmExplain>().await),
-            shared_cache: Lookup::from(
-                receiver
-                    .get::<searchable_snapshots_cache_stats::SearchableSnapshotsCacheStats>()
-                    .await,
-            ),
+            alias: Lookup::from(receiver.get::<AliasList>().await),
+            data_stream: Lookup::from(receiver.get::<DataStreams>().await),
+            index_settings: Lookup::from(receiver.get::<IndicesSettings>().await),
+            node: Lookup::from(receiver.get::<Nodes>().await),
+            ilm_explain: Lookup::from(receiver.get::<IlmExplain>().await),
+            shared_cache: Lookup::from(receiver.get::<SearchableSnapshotsCacheStats>().await),
         };
+        let license = receiver
+            .get::<Licenses>()
+            .await
+            .map(|licenses| licenses.license)
+            .ok();
 
+        report.add_license(license);
         report.add_lookup("alias", &lookups.alias);
         report.add_lookup("data_stream", &lookups.data_stream);
         report.add_lookup("index_settings", &lookups.index_settings);
@@ -147,17 +169,17 @@ impl DiagnosticProcessor for ElasticsearchDiagnostic {
 
         let futures = FuturesUnordered::new();
         let mut tasks = vec![
-            spawn_processor::<cluster_settings::ClusterSettings>(diag.clone()),
-            spawn_processor::<indices_settings::IndicesSettings>(diag.clone()),
-            spawn_processor::<indices_stats::IndicesStats>(diag.clone()),
-            spawn_processor::<nodes::Nodes>(diag.clone()),
-            spawn_processor::<nodes_stats::NodesStats>(diag.clone()),
-            spawn_processor::<ilm_policies::IlmPolicies>(diag.clone()),
-            spawn_processor::<slm_policies::SlmPolicies>(diag.clone()),
+            spawn_processor::<ClusterSettings>(diag.clone()),
+            spawn_processor::<IndicesSettings>(diag.clone()),
+            spawn_processor::<IndicesStats>(diag.clone()),
+            spawn_processor::<Nodes>(diag.clone()),
+            spawn_processor::<NodesStats>(diag.clone()),
+            spawn_processor::<IlmPolicies>(diag.clone()),
+            spawn_processor::<SlmPolicies>(diag.clone()),
             // Temporarily omitting in favor of an include/exclude/diag_type filter to
             // prevent the expected error
             // spawn_processor::<SearchableSnapshotsStats>(diag.clone()),
-            spawn_processor::<tasks::Tasks>(diag.clone()),
+            spawn_processor::<Tasks>(diag.clone()),
         ];
         tasks.drain(..).map(|task| futures.push(task)).count();
 
@@ -205,10 +227,10 @@ where
 
 #[derive(Serialize)]
 pub struct Lookups {
-    pub alias: Lookup<alias::Alias>,
-    pub data_stream: Lookup<data_stream::DataStream>,
-    pub index_settings: Lookup<indices_settings::IndexSettings>,
-    pub node: Lookup<nodes::NodeDocument>,
-    pub ilm_explain: Lookup<ilm_explain::IlmStats>,
-    pub shared_cache: Lookup<searchable_snapshots_cache_stats::SharedCacheStats>,
+    pub alias: Lookup<Alias>,
+    pub data_stream: Lookup<DataStream>,
+    pub ilm_explain: Lookup<IlmStats>,
+    pub index_settings: Lookup<IndexSettings>,
+    pub node: Lookup<NodeDocument>,
+    pub shared_cache: Lookup<SharedCacheStats>,
 }


### PR DESCRIPTION
Resolves #152 

Also defaults `diagnostic.account` to the `issue_to` field from the license, if it is not already provided.