### PR TITLE
Cloud api

### DIFF
--- a/src/client/known_host.rs
+++ b/src/client/known_host.rs
@@ -1,6 +1,9 @@
 use crate::processor::Product;
 use eyre::{Result, eyre};
-use reqwest;
+use reqwest::{
+    Error, Response,
+    header::{ACCEPT, AUTHORIZATION, HeaderMap},
+};
 use serde::{Deserialize, Serialize};
 use serde_yaml;
 use std::{
@@ -130,6 +133,56 @@ impl KnownHost {
         }
     }
 
+    pub fn update_cloud_api_path(self) -> Self {
+        // Desired URL format is https://{domain}/api/v1/deployments/{deployment_id}/elasticsearch/elasticsearch/proxy/
+        match self {
+            Self::Basic { .. } | Self::NoAuth { .. } => self,
+            Self::ApiKey {
+                mut url,
+                app,
+                accept_invalid_certs,
+                apikey,
+                cloud_id,
+            } => {
+                let deployment_id = url.clone();
+                let deployment_id = deployment_id
+                    .path()
+                    .split('/')
+                    .skip_while(|segment| *segment != "deployments")
+                    .nth(1)
+                    .unwrap_or("");
+                let new_segments: Vec<&str> = match app {
+                    Product::Elasticsearch => vec![
+                        "api",
+                        "v1",
+                        "deployments",
+                        deployment_id,
+                        "elasticsearch",
+                        "elasticsearch",
+                        "proxy",
+                    ],
+                    _ => Vec::new(),
+                };
+                // Only modify the path if we have new segments
+                if new_segments.len() > 0 {
+                    let mut path_segments = url
+                        .path_segments_mut()
+                        .expect("Failed to get path segments");
+                    path_segments.clear().extend(new_segments);
+                }
+
+                log::debug!("Updated Cloud API URL: {}", url);
+                KnownHost::ApiKey {
+                    accept_invalid_certs,
+                    apikey,
+                    app,
+                    cloud_id,
+                    url,
+                }
+            }
+        }
+    }
+
     pub fn save(self, name: &String) -> Result<String> {
         // parse the ~/.esdiag/hosts.yml file into a HashMap<String, Host>
         let mut hosts = match KnownHost::parse_hosts_yml() {
@@ -181,13 +234,14 @@ impl KnownHost {
         }
     }
 
-    async fn validate_application(&self, response: reqwest::Response) -> (bool, String) {
+    async fn validate_application(&self, response: Response) -> (bool, String) {
         let status = response.status();
         let body = response.text().await.expect("Failed to read test body");
         let json = serde_json::from_str(&body).unwrap_or(serde_json::Value::Null);
         let app = match self {
             Self::ApiKey { app, .. } | Self::Basic { app, .. } | Self::NoAuth { app, .. } => app,
         };
+        log::debug!("Validation response {} ", json);
         match app {
             Product::Elasticsearch => match json.get("tagline") {
                 Some(_) => (true, format!("{} ✅ Elasticsearch", status)),
@@ -203,7 +257,7 @@ impl KnownHost {
         }
     }
 
-    pub async fn test(&self) -> Result<(bool, String), reqwest::Error> {
+    pub async fn test(&self) -> Result<(bool, String), Error> {
         match self {
             Self::ApiKey {
                 apikey,
@@ -215,16 +269,13 @@ impl KnownHost {
                 // test the connection
                 log::info!("Testing {} connection", &app);
                 // create a client with the API key
+                let mut default_headers = HeaderMap::new();
+                default_headers.append("X-Management-Request", "true".parse().unwrap());
+                default_headers.append(ACCEPT, "application/json".parse().unwrap());
+                default_headers
+                    .append(AUTHORIZATION, format!("ApiKey {}", apikey).parse().unwrap());
                 let client = reqwest::Client::builder()
-                    .default_headers(
-                        std::iter::once((
-                            reqwest::header::AUTHORIZATION,
-                            format!("ApiKey {}", apikey)
-                                .parse()
-                                .expect("Failed to parse apikey"),
-                        ))
-                        .collect(),
-                    )
+                    .default_headers(default_headers)
                     .danger_accept_invalid_certs(*accept_invalid_certs)
                     .build()?;
                 log::trace!("Reqwest client: {:?}", client);

--- a/src/data.rs
+++ b/src/data.rs
@@ -33,6 +33,12 @@ pub fn save_file<T: Serialize>(filename: &str, content: &T) -> Result<()> {
 pub enum Uri {
     /// Known host saved in the ~/.esdiag/hosts.yml by default
     KnownHost(KnownHost),
+    /// An Elastic Cloud URL for the Elasticsearch API proxy
+    ElasticCloud(KnownHost),
+    /// An Elastic Cloud Admin URL for the Elasticsearch API proxy
+    ElasticCloudAdmin(KnownHost),
+    /// An Elastic Cloud GovCloud Admin URL for the Elasticsearch API proxy
+    ElasticGovCloudAdmin(KnownHost),
     /// An Elastic Uploader service URL, embed the auth token as `token:<value>@` instead of `username:password` in the URL
     ServiceLink(Url),
     /// An Elastic Uploader service URL, without authentication
@@ -66,14 +72,48 @@ impl Default for Uri {
 impl From<Uri> for Url {
     fn from(uri: Uri) -> Self {
         match uri {
-            Uri::Stream => Url::parse("stdin://").unwrap(),
+            Uri::Directory(path) => Url::from_directory_path(path).unwrap(),
+            Uri::ElasticCloud(host) => host.into(),
+            Uri::ElasticCloudAdmin(host) => host.into(),
+            Uri::ElasticGovCloudAdmin(host) => host.into(),
+            Uri::File(path) => Url::from_file_path(path).unwrap(),
             Uri::KnownHost(host) => host.into(),
             Uri::ServiceLink(url) => url,
             Uri::ServiceLinkNoAuth(url) => url,
+            Uri::Stream => Url::parse("stdin://").unwrap(),
             Uri::Url(url) => url,
-            Uri::Directory(path) => Url::from_directory_path(path).unwrap(),
-            Uri::File(path) => Url::from_file_path(path).unwrap(),
         }
+    }
+}
+
+fn identify_elastic_host(host: KnownHost) -> Uri {
+    // https://admin.us-gov-east-1.aws.elastic-cloud.com/api/v1/deployments/2492c05b8d1f4c4d8c1ecb05ec59e4c0/elasticsearch/elasticsearch/proxy/
+    // https://admin.us-gov-east-1.aws.elastic-cloud.com/deployments/2492c05b8d1f4c4d8c1ecb05ec59e4c0
+    match host.get_url().as_str() {
+        url if url.contains("admin.us-gov-east-1.aws.elastic-cloud.com") => {
+            log::debug!("Creating Uri::ElasticGovCloudAdmin");
+            Uri::ElasticGovCloudAdmin(host.update_cloud_api_path())
+        }
+        url if url.contains("admin.found.no") => {
+            log::debug!("Creating Uri::ElasticCloudAdmin");
+            Uri::ElasticCloudAdmin(host.update_cloud_api_path())
+        }
+        url if url.contains("cloud.elastic.co") => {
+            log::debug!("Creating Uri::ElasticCloud");
+            Uri::ElasticCloud(host.update_cloud_api_path())
+        }
+        _ => {
+            log::debug!("Creating Uri::KnownHost");
+            Uri::KnownHost(host)
+        }
+    }
+}
+
+impl TryFrom<KnownHost> for Uri {
+    type Error = eyre::Report;
+
+    fn try_from(host: KnownHost) -> Result<Self> {
+        Ok(identify_elastic_host(host))
     }
 }
 
@@ -87,10 +127,9 @@ impl TryFrom<&str> for Uri {
         }
 
         if let Ok(host) = KnownHost::from_str(&uri) {
-            log::debug!("Creating Uri::KnownHost");
-            return Ok(Uri::KnownHost(host));
+            return Ok(identify_elastic_host(host));
         }
-        log::debug!("No known host {uri}");
+        log::debug!("No known host for {uri}");
 
         if let Ok(url) = Url::parse(&uri) {
             let domain = url.domain().ok_or_eyre("URL is missing a domain")?;
@@ -148,6 +187,11 @@ impl TryFrom<String> for Uri {
 impl std::fmt::Display for Uri {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
+            Uri::Directory(path) => write!(f, "{}", path.display()),
+            Uri::ElasticCloud(host) => write!(f, "{}", host),
+            Uri::ElasticCloudAdmin(host) => write!(f, "{}", host),
+            Uri::ElasticGovCloudAdmin(host) => write!(f, "{}", host),
+            Uri::File(path) => write!(f, "{}", path.display()),
             Uri::KnownHost(host) => write!(f, "{}", host),
             Uri::ServiceLink(url) => {
                 write!(f, "{}{}", url.domain().expect("No domain"), url.path())
@@ -155,10 +199,8 @@ impl std::fmt::Display for Uri {
             Uri::ServiceLinkNoAuth(url) => {
                 write!(f, "{}{}", url.domain().expect("No domain"), url.path())
             }
-            Uri::Url(url) => write!(f, "{}", url),
-            Uri::Directory(path) => write!(f, "{}", path.display()),
-            Uri::File(path) => write!(f, "{}", path.display()),
             Uri::Stream => write!(f, "-"),
+            Uri::Url(url) => write!(f, "{}", url),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,7 @@ async fn run(cli: Cli) -> Result<&'static str> {
             let known_host = Uri::try_from(host)?;
             let output = Uri::try_from(output)?;
             match known_host {
-                Uri::KnownHost(_) => {
+                Uri::KnownHost(_) | Uri::ElasticCloudAdmin(_) | Uri::ElasticGovCloudAdmin(_) => {
                     log::info!("Collecting diagnostic from {known_host}");
                     log::info!("Saving diagnostic to {output}");
                     let receiver = Receiver::try_from(known_host)?;
@@ -216,6 +216,9 @@ async fn run(cli: Cli) -> Result<&'static str> {
                     let collector = Collector::try_new(receiver, exporter).await?;
                     collector.collect().await?;
                     Ok("collect")
+                }
+                Uri::ElasticCloud(_) => {
+                    Err(eyre!("Elastic Cloud API collection not yet implemented"))
                 }
                 _ => Err(eyre!("Collect requires a known host")),
             }

--- a/src/processor/collector.rs
+++ b/src/processor/collector.rs
@@ -11,6 +11,9 @@ impl Collector {
         if let Receiver::Elasticsearch(_) = &receiver {
             let collector = ElasticsearchCollector::new(receiver, exporter).await?;
             Ok(Self::Elasticsearch(collector))
+        } else if let Receiver::ElasticCloudAdmin(_) = &receiver {
+            let collector = ElasticsearchCollector::new(receiver, exporter).await?;
+            Ok(Self::Elasticsearch(collector))
         } else {
             Err(eyre!(
                 "Collect is only implemented from Elasticsearch to a Directory"

--- a/src/processor/elastic_cloud_kubernetes/mod.rs
+++ b/src/processor/elastic_cloud_kubernetes/mod.rs
@@ -92,6 +92,9 @@ impl DiagnosticProcessor for ElasticCloudKubernetesDiagnostic {
         self.exporter.save_report(&*report).await?;
         // For now, we will return only the Elasticsearch report for the UI
         // TODO: Implement processor iterators - https://github.com/elastic/esdiag/issues/148#issuecomment-3172865628
+        if reports.is_empty() {
+            return Err(eyre::eyre!("No reports were collected. At least one diagnostic report is required."));
+        }
         Ok(reports[0].clone())
     }
 

--- a/src/processor/elastic_cloud_kubernetes/mod.rs
+++ b/src/processor/elastic_cloud_kubernetes/mod.rs
@@ -56,6 +56,7 @@ impl DiagnosticProcessor for ElasticCloudKubernetesDiagnostic {
 
     async fn run(self) -> Result<DiagnosticReport> {
         self.receiver.is_connected().await;
+        let mut reports: Vec<DiagnosticReport> = Vec::with_capacity(2);
         for diagnostic in self.included_diagnostics {
             match diagnostic.diag_type.as_str() {
                 "elasticsearch" => {
@@ -69,7 +70,7 @@ impl DiagnosticProcessor for ElasticCloudKubernetesDiagnostic {
                     let diagnostic =
                         ElasticsearchDiagnostic::new(manifest, receiver, self.exporter.cloned())
                             .await?;
-                    diagnostic.run().await?;
+                    reports.push(diagnostic.run().await?);
                 }
                 _ => {
                     log::warn!(
@@ -89,7 +90,9 @@ impl DiagnosticProcessor for ElasticCloudKubernetesDiagnostic {
             Some("orchestration".to_string()),
         );
         self.exporter.save_report(&*report).await?;
-        Ok(report.clone())
+        // For now, we will return only the Elasticsearch report for the UI
+        // TODO: Implement processor iterators - https://github.com/elastic/esdiag/issues/148#issuecomment-3172865628
+        Ok(reports[0].clone())
     }
 
     fn id(&self) -> &str {

--- a/src/processor/kubernetes_platform/mod.rs
+++ b/src/processor/kubernetes_platform/mod.rs
@@ -58,6 +58,7 @@ impl DiagnosticProcessor for KubernetesPlatformDiagnostic {
 
     async fn run(self) -> Result<DiagnosticReport> {
         self.receiver.is_connected().await;
+        let mut reports: Vec<DiagnosticReport> = Vec::with_capacity(2);
         for diagnostic in self.included_diagnostics {
             let diag_type = diagnostic.diag_type.as_str().trim_end_matches("appconfig");
             match diag_type {
@@ -72,7 +73,7 @@ impl DiagnosticProcessor for KubernetesPlatformDiagnostic {
                     let diagnostic =
                         ElasticsearchDiagnostic::new(manifest, receiver, self.exporter.cloned())
                             .await?;
-                    diagnostic.run().await?;
+                    reports.push(diagnostic.run().await?);
                 }
                 _ => {
                     log::warn!(
@@ -92,7 +93,9 @@ impl DiagnosticProcessor for KubernetesPlatformDiagnostic {
             Some("orchestration".to_string()),
         );
         self.exporter.save_report(&*report).await?;
-        Ok(report.clone())
+        // For now, we will return only the Elasticsearch report for the UI
+        // TODO: Implement processor iterators - https://github.com/elastic/esdiag/issues/148#issuecomment-3172865628
+        Ok(reports[0].clone())
     }
 
     fn id(&self) -> &str {

--- a/src/processor/kubernetes_platform/mod.rs
+++ b/src/processor/kubernetes_platform/mod.rs
@@ -95,6 +95,9 @@ impl DiagnosticProcessor for KubernetesPlatformDiagnostic {
         self.exporter.save_report(&*report).await?;
         // For now, we will return only the Elasticsearch report for the UI
         // TODO: Implement processor iterators - https://github.com/elastic/esdiag/issues/148#issuecomment-3172865628
+        if reports.is_empty() {
+            return Err(eyre::eyre!("No reports were collected. No diagnostics matched the expected types."));
+        }
         Ok(reports[0].clone())
     }
 

--- a/src/receiver/elastic_cloud_admin.rs
+++ b/src/receiver/elastic_cloud_admin.rs
@@ -107,11 +107,13 @@ impl ReceiveRaw for ElasticCloudAdminReceiver {
     {
         // Get the API URL path for the provided type
         let path = T::source(PathType::Url)?;
-        log::debug!("Getting API: {}", &path);
+        // Prepend the API proxy base path
+        let path = format!("{}/{}", self.url.path(), path);
+        let url = self.url.join(&path)?;
+        log::debug!("Getting API: {}", url);
+        let response = self.client.get(url).send().await?;
 
-        // Send a simple GET request to the API path
-        let response = self.client.get(self.url.as_str()).send().await?;
-
+        // Return raw text
         response.text().await.map_err(Into::into)
     }
 }

--- a/src/receiver/elastic_cloud_admin.rs
+++ b/src/receiver/elastic_cloud_admin.rs
@@ -1,0 +1,123 @@
+use super::super::processor::{
+    DataSource, DiagnosticManifest, ElasticsearchCluster, ManifestBuilder, PathType,
+};
+use super::{Receive, ReceiveRaw};
+use crate::client::KnownHost;
+use eyre::Result;
+use reqwest::header::{ACCEPT, ACCEPT_ENCODING, AUTHORIZATION};
+use reqwest::{Client, ClientBuilder, header::HeaderMap};
+use serde::de::DeserializeOwned;
+use url::Url;
+
+#[derive(Clone)]
+pub struct ElasticCloudAdminReceiver {
+    client: Client,
+    url: Url,
+}
+
+impl ElasticCloudAdminReceiver {
+    pub fn new(url: Url, api_key: String) -> Result<Self> {
+        //std::env::var("APIKEY_GOVCLOUD")?.clone()
+        let mut default_headers = HeaderMap::new();
+        default_headers.append("X-Management-Request", "true".parse().unwrap());
+        default_headers.append(ACCEPT, "application/json".parse().unwrap());
+        default_headers.append(ACCEPT_ENCODING, "gzip, deflate".parse().unwrap());
+        default_headers.append(
+            AUTHORIZATION,
+            format!("ApiKey {}", api_key).parse().unwrap(),
+        );
+        let client = ClientBuilder::new()
+            .default_headers(default_headers)
+            .build()?;
+        Ok(Self { client, url })
+    }
+}
+
+impl TryFrom<KnownHost> for ElasticCloudAdminReceiver {
+    type Error = eyre::Report;
+
+    fn try_from(host: KnownHost) -> Result<Self> {
+        match host {
+            KnownHost::ApiKey { apikey, url, .. } => {
+                Ok(ElasticCloudAdminReceiver::new(url, apikey)?)
+            }
+            _ => Err(eyre::eyre!("Elastic Cloud Admin requires a URL and ApiKey")),
+        }
+    }
+}
+
+impl Receive for ElasticCloudAdminReceiver {
+    async fn collection_date(&self) -> String {
+        chrono::Utc::now().to_rfc3339()
+    }
+
+    async fn is_connected(&self) -> bool {
+        log::debug!(
+            "Testing Elastic Cloud Admin connection to {}",
+            self.url.as_str()
+        );
+        // An empty request to `/`
+        let response = self.client.get(self.url.as_str()).send().await;
+
+        match response {
+            Ok(response) => {
+                log::debug!("Elastic Cloud connection successful: {}", response.status());
+                true
+            }
+            Err(e) => {
+                log::error!("Elastic Cloud connection failed: {e}");
+                false
+            }
+        }
+    }
+
+    async fn get<T>(&self) -> Result<T>
+    where
+        T: DataSource + DeserializeOwned,
+    {
+        // Get the API URL path for the provided type
+        let path = T::source(PathType::Url)?;
+        // Prepend the API proxy base path
+        let path = format!("{}/{}", self.url.path(), path);
+        let url = self.url.join(&path)?;
+        log::debug!("Getting API: {}", url);
+        let response = self.client.get(url).send().await?;
+
+        log::debug!("Get Response: {:?}", response);
+
+        response.json::<T>().await.map_err(Into::into)
+    }
+
+    async fn try_get_manifest(&self) -> Result<DiagnosticManifest> {
+        let collection_date = chrono::Utc::now().to_rfc3339();
+        log::info!("Creating diagnostic manifest with collection date {collection_date}");
+        let cluster = self.get::<ElasticsearchCluster>().await?;
+        let manifest = ManifestBuilder::from(cluster)
+            .runner("esdiag")
+            .collection_date(collection_date)
+            .build();
+        Ok(manifest.try_into()?)
+    }
+}
+
+impl ReceiveRaw for ElasticCloudAdminReceiver {
+    async fn get_raw<T>(&self) -> Result<String>
+    where
+        T: DataSource,
+    {
+        // Get the API URL path for the provided type
+        let path = T::source(PathType::Url)?;
+        log::debug!("Getting API: {}", &path);
+
+        // Send a simple GET request to the API path
+        let response = self.client.get(self.url.as_str()).send().await?;
+
+        response.text().await.map_err(Into::into)
+    }
+}
+
+impl std::fmt::Display for ElasticCloudAdminReceiver {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Elastic Cloud {}", self.url)
+    }
+}

--- a/src/receiver/elastic_cloud_admin.rs
+++ b/src/receiver/elastic_cloud_admin.rs
@@ -17,7 +17,6 @@ pub struct ElasticCloudAdminReceiver {
 
 impl ElasticCloudAdminReceiver {
     pub fn new(url: Url, api_key: String) -> Result<Self> {
-        //std::env::var("APIKEY_GOVCLOUD")?.clone()
         let mut default_headers = HeaderMap::new();
         default_headers.append("X-Management-Request", "true".parse().unwrap());
         default_headers.append(ACCEPT, "application/json".parse().unwrap());

--- a/src/receiver/mod.rs
+++ b/src/receiver/mod.rs
@@ -2,6 +2,8 @@
 mod archive;
 /// Read from a direcotry in the local file system
 mod directory;
+/// Request API calls from the Elastic Cloud API proxy
+mod elastic_cloud_admin;
 /// Request API calls from Elasticsearch
 mod elasticsearch;
 /// Get file from https://upload.elastic.co/
@@ -9,6 +11,7 @@ mod upload_service;
 
 use archive::{ArchiveBytesReceiver, ArchiveFileReceiver};
 use directory::DirectoryReceiver;
+use elastic_cloud_admin::ElasticCloudAdminReceiver;
 pub use elasticsearch::ElasticsearchReceiver;
 use upload_service::UploadServiceDownloader;
 
@@ -84,6 +87,8 @@ pub enum Receiver {
     Directory(DirectoryReceiver),
     /// Request API calls from Elasticsearch
     Elasticsearch(ElasticsearchReceiver),
+    /// Request API calls from Elastic Cloud admin
+    ElasticCloudAdmin(ElasticCloudAdminReceiver),
 }
 
 impl Receiver {
@@ -96,6 +101,7 @@ impl Receiver {
             Receiver::ArchiveFile(receiver) => receiver.get::<T>().await,
             Receiver::Directory(receiver) => receiver.get::<T>().await,
             Receiver::Elasticsearch(receiver) => receiver.get::<T>().await,
+            Receiver::ElasticCloudAdmin(receiver) => receiver.get::<T>().await,
         }
     }
 
@@ -105,6 +111,7 @@ impl Receiver {
     {
         match self {
             Receiver::Elasticsearch(receiver) => receiver.get_raw::<T>().await,
+            Receiver::ElasticCloudAdmin(receiver) => receiver.get_raw::<T>().await,
             _ => Err(eyre!("Raw data is not supported for this receiver")),
         }
     }
@@ -115,6 +122,7 @@ impl Receiver {
             Receiver::ArchiveFile(receiver) => receiver.is_connected().await,
             Receiver::Directory(receiver) => receiver.is_connected().await,
             Receiver::Elasticsearch(receiver) => receiver.is_connected().await,
+            Receiver::ElasticCloudAdmin(receiver) => receiver.is_connected().await,
         }
     }
 
@@ -139,6 +147,7 @@ impl Receiver {
             Receiver::ArchiveFile(receiver) => receiver.collection_date().await,
             Receiver::Directory(receiver) => receiver.collection_date().await,
             Receiver::Elasticsearch(receiver) => receiver.collection_date().await,
+            Receiver::ElasticCloudAdmin(receiver) => receiver.collection_date().await,
         }
     }
 
@@ -148,6 +157,7 @@ impl Receiver {
             Receiver::ArchiveFile(receiver) => receiver.try_get_manifest().await,
             Receiver::Directory(receiver) => receiver.try_get_manifest().await,
             Receiver::Elasticsearch(receiver) => receiver.try_get_manifest().await,
+            Receiver::ElasticCloudAdmin(receiver) => receiver.try_get_manifest().await,
         }
     }
 }
@@ -157,6 +167,12 @@ impl TryFrom<Uri> for Receiver {
     fn try_from(uri: Uri) -> std::result::Result<Self, Self::Error> {
         let receiver = match uri {
             Uri::Directory(dir) => Receiver::Directory(DirectoryReceiver::try_from(dir)?),
+            Uri::ElasticCloud(host) => {
+                return Err(eyre!("Elastic Cloud API not yet implemented. {host}"));
+            }
+            Uri::ElasticCloudAdmin(host) | Uri::ElasticGovCloudAdmin(host) => {
+                Receiver::ElasticCloudAdmin(ElasticCloudAdminReceiver::try_from(host)?)
+            }
             Uri::File(file) => Receiver::ArchiveFile(ArchiveFileReceiver::try_from(file)?),
             Uri::KnownHost(host) => Receiver::Elasticsearch(ElasticsearchReceiver::try_from(host)?),
             Uri::ServiceLink(url) => {
@@ -171,9 +187,8 @@ impl TryFrom<Uri> for Receiver {
 impl TryFrom<KnownHost> for Receiver {
     type Error = eyre::Report;
     fn try_from(host: KnownHost) -> std::result::Result<Self, Self::Error> {
-        Ok(Receiver::Elasticsearch(ElasticsearchReceiver::try_from(
-            host,
-        )?))
+        let uri = Uri::try_from(host)?;
+        Receiver::try_from(uri)
     }
 }
 
@@ -193,6 +208,9 @@ impl std::fmt::Display for Receiver {
             Receiver::ArchiveFile(receiver) => write!(f, "Archive File {receiver}"),
             Receiver::Directory(receiver) => write!(f, "Directory {receiver}"),
             Receiver::Elasticsearch(receiver) => write!(f, "Elasticsearch {receiver}"),
+            Receiver::ElasticCloudAdmin(receiver) => {
+                write!(f, "ElasticCloudAdmin {receiver}")
+            }
         }
     }
 }

--- a/src/receiver/upload_service.rs
+++ b/src/receiver/upload_service.rs
@@ -25,7 +25,10 @@ impl UploadServiceDownloader {
             let response = request.send()?;
             let bytes = response.bytes()?;
             log::debug!("Downloaded archive size: {} bytes", bytes.len());
-            Ok(ArchiveBytesReceiver::try_from(bytes)?)
+            match bytes.len() {
+                0 => Err(eyre!("Downloaded empty file, check upload link expiration")),
+                _ => Ok(ArchiveBytesReceiver::try_from(bytes)?),
+            }
         })
     }
 }

--- a/src/server/api_key.rs
+++ b/src/server/api_key.rs
@@ -70,7 +70,7 @@ pub async fn handler(
                     job_id: job.id,
                     filename: job.filename.as_deref().unwrap_or(""),
                 });
-                yield patch_signals(r#"{"uploading":false,"processing":true}"#);
+                yield patch_signals(r#"{"loading":false,"processing":true}"#);
 
                 match job.process().await {
                     Ok(job) => {

--- a/src/server/api_key.rs
+++ b/src/server/api_key.rs
@@ -39,7 +39,10 @@ pub async fn handler(
             };
 
         let receiver = match Receiver::try_from(host) {
-            Ok(receiver) => receiver,
+            Ok(receiver) => {
+                log::info!("Created receiver: {}", receiver);
+                receiver
+            }
             Err(e) => {
                 state.record_failure().await;
                 let error_msg = format!("Failed to create receiver: {}", e);

--- a/src/server/assets/style.css
+++ b/src/server/assets/style.css
@@ -147,7 +147,7 @@ h3 {
     }
 }
 
-.uploading {
+.loading {
     background-color: #e3e8f2;
     color: #516381;
     font-weight: 500;

--- a/src/server/file_upload.rs
+++ b/src/server/file_upload.rs
@@ -50,7 +50,7 @@ pub async fn submit_handler(
             let upload_file_element = format!(
                 r#"<div id="job-{job_id}"
                     class="status-box history-item processing"
-                    data-on-load="$uploading=false; $file_upload.job_id={job_id}; @post('upload/process')"
+                    data-on-load="$loading=false; $file_upload.job_id={job_id}; @post('upload/process')"
                 >
                     <div class="spinner"></div> Processing diagnostic
                         <p><b>Filename:</b> {filename}</p>

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -282,7 +282,8 @@ pub struct JobStats {
 pub struct Signals {
     pub auth: Auth,
     pub processing: bool,
-    pub uploading: bool,
+    pub loading: bool,
+    pub message: String,
     pub metadata: Identifiers,
     pub file_upload: FileUpload,
     pub service_link: ServiceLink,
@@ -295,7 +296,8 @@ impl Default for Signals {
         Signals {
             auth: Auth { header: false },
             processing: false,
-            uploading: false,
+            loading: false,
+            message: String::new(),
             metadata: Identifiers::default(),
             file_upload: FileUpload { job_id: 0 },
             service_link: ServiceLink {

--- a/src/server/service_link.rs
+++ b/src/server/service_link.rs
@@ -25,7 +25,7 @@ pub async fn handler(
 
     Sse::new(stream! {
         let service_link = &signals.service_link;
-        yield patch_signals(r#"{"uploading":true}"#);
+        yield patch_signals(r#"{"loading":true}"#);
 
         let tokenized_uri = if let Uri::ServiceLinkNoAuth(mut url) = service_link.url.clone() {
             // Set username to "token" and password to the actual token
@@ -52,7 +52,7 @@ pub async fn handler(
                 error: "Upload Service",
                 message: &error_msg
             });
-            yield patch_signals(r#"{"uploading":false}"#);
+            yield patch_signals(r#"{"loading":false}"#);
             return
         };
 
@@ -70,7 +70,7 @@ pub async fn handler(
                     error: &error_msg,
                     source: &signals.service_link.filename,
                 });
-                yield patch_signals(r#"{"uploading":false}"#);
+                yield patch_signals(r#"{"loading":false}"#);
                 return
             }
         };
@@ -90,7 +90,7 @@ pub async fn handler(
                     filename: job.filename.as_deref().unwrap_or(""),
                 });
                 yield patch_signals(
-                    r#"{"uploading":false,"processing":true,"service_link":{"_curl":"","token":"","url":"","filename":""}}"#
+                    r#"{"loading":false,"processing":true,"service_link":{"_curl":"","token":"","url":"","filename":""}}"#
                 );
 
                 match job.process().await {
@@ -150,7 +150,7 @@ pub async fn job_handler(
                     error: &format!("Link id {} not found", id),
                     source: "Forwarded service link job"
                 });
-                yield patch_signals(r#"{"uploading":false}"#);
+                yield patch_signals(r#"{"loading":false}"#);
                 return
             }
         };
@@ -167,12 +167,12 @@ pub async fn job_handler(
                     error: &error_msg,
                     source: &identifiers.filename.unwrap_or("None".to_string())
                 });
-                yield patch_signals(r#"{"uploading":false}"#);
+                yield patch_signals(r#"{"loading":false}"#);
                 return
             }
         };
 
-        yield patch_signals(r#"{"uploading":false,"processing":true}"#);
+        yield patch_signals(r#"{"loading":false,"processing":true}"#);
 
         let exporter = {
             state.exporter.read().await.clone().with_identifiers(identifiers)
@@ -185,7 +185,7 @@ pub async fn job_handler(
                     job_id: job.id,
                     filename: job.filename.as_deref().unwrap_or(""),
                 });
-                yield patch_signals(r#"{"uploading":false,"processing":true}"#);
+                yield patch_signals(r#"{"loading":false,"processing":true}"#);
 
                 match job.process().await {
                     Ok(job) => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -90,7 +90,7 @@
 
         <div class="content">
             <h2>Process Diagnostics</h2>
-            <div class="input-form" id="input-form" data-signals-uploading="false" data-signals-processing="false">
+            <div class="input-form" id="input-form" data-signals-loading="false" data-signals-processing="false">
                 <div id="diagnostic-form" class="diagnostic-form">
                     <div class="tabs" data-signals-_tab="'file-upload'">
                         <button
@@ -122,7 +122,7 @@
                         <form
                             id="upload-form"
                             data-show="$_tab === 'file-upload'"
-                            data-signals-uploading="false"
+                            data-signals-loading="false"
                             data-signals-file_upload.job_id="0"
                             enctype="multipart/form-data"
                         >
@@ -407,8 +407,8 @@
                                 class="button"
                                 type="button"
                                 value="Process"
-                                data-on-click="$uploading = true; @post('/service_link')"
-                                data-attr-disabled="$uploading || !$service_link.url || !$service_link.token"
+                                data-on-click="$loading = true; $message = 'Connecting to Elastic Upload service...'; @post('/service_link')"
+                                data-attr-disabled="$loading || !$service_link.url || !$service_link.token"
                             />
                             <script>
                                 // Extract token from Authorization header
@@ -470,8 +470,8 @@
                                 class="button"
                                 type="button"
                                 value="Process"
-                                data-on-click="$processing = true; @post('/api_key')"
-                                data-attr-disabled="$uploading || !$es_api.url || !$es_api.key"
+                                data-on-click="$loading = true; $message = 'Connecting with API key...'; @post('/api_key')"
+                                data-attr-disabled="$loading || !$es_api.url || !$es_api.key"
                             />
                         </form>
                     </div>
@@ -488,7 +488,7 @@
                             placeholder="Username"
                             autocomplete="username"
                             class="form-input"
-                            data-attr-disabled="$auth.header || $processing || $uploading"
+                            data-attr-disabled="$auth.header || $processing || $loading"
                         />
                     </div>
                     <div class="form-group">
@@ -500,7 +500,7 @@
                             data-bind-metadata.account
                             placeholder="Account"
                             class="form-input"
-                            data-attr-disabled="$uploading || $processing"
+                            data-attr-disabled="$loading || $processing"
                         />
                     </div>
                     <div class="form-group">
@@ -512,7 +512,7 @@
                             data-bind-metadata.case_number
                             placeholder="Case Number"
                             class="form-input"
-                            data-attr-disabled="$uploading || $processing"
+                            data-attr-disabled="$loading || $processing"
                         />
                     </div>
                     <div class="form-group">
@@ -524,7 +524,7 @@
                             data-bind-metadata.opportunity
                             placeholder="Opportunity"
                             class="form-input"
-                            data-attr-disabled="$uploading || $processing"
+                            data-attr-disabled="$loading || $processing"
                         />
                     </div>
                     <div
@@ -545,21 +545,21 @@
 
             <div
                 id="current-status"
-                data-show="$uploading && $_job_id === '' "
-                class="status-box uploading"
+                data-show="$loading && $_job_id === '' "
+                class="status-box loading"
                 style="display: none"
             >
                 <div class="spinner"></div>
-                Uploading...
+                <span id="status-message" data-text="$message">Uploading...</span>
             </div>
             <div id="job-feed"></div>
             {% if let Some(link_id) = link_id %}
             <div
                 id="job-{{ link_id }}"
-                data-show="$uploading"
+                data-show="$loading"
                 data-signals-_job_id="true"
-                data-on-load="$uploading = true && @post('/service_link/{{ link_id }}')"
-                class="status-box uploading"
+                data-on-load="$loading = true && $message = 'Forwarding service link {{ link_id }}' && @post('/service_link/{{ link_id }}')"
+                class="status-box loading"
                 style="display: none"
             >
                 <div class="spinner"></div>
@@ -568,10 +568,10 @@
             {% else if let Some(upload_id) = upload_id %}
             <div
                 id="job-{{ upload_id }}"
-                data-show="$uploading"
+                data-show="$loading"
                 data-signals-_job_id="true"
-                data-on-load="$uploading = true && @post('/file_upload/{{ upload_id }}')"
-                class="status-box uploading"
+                data-on-load="$loading = true && $message = 'Processing file upload {{ upload_id }}' && @post('/file_upload/{{ upload_id }}')"
+                class="status-box loading"
                 style="display: none"
             >
                 <div class="spinner"></div>
@@ -599,9 +599,7 @@
             </span>
             <span id="exporter" class="text-center">Output: {{ exporter }}</span>
             <span class="text-right" data-signals="{ 'stats': {{ stats }} }">
-                <span id="status" data-text="$uploading ? 'Uploading' : $processing ? 'Processing' : 'Ready'">
-                    Ready
-                </span>
+                <span id="status" data-text="$loading ? 'Loading' : $processing ? 'Processing' : 'Ready'">Ready </span>
                 | <span data-text="Intl.NumberFormat().format($stats.jobs.total)">0</span> diags |
                 <span data-text="Intl.NumberFormat().format($stats.docs.total)">0</span> docs
             </span>


### PR DESCRIPTION
Adds support for collecting with Elastic Cloud API Keys through the Elasticsearch API Proxy. This requires an active VPN connection and currently requires running locally.

Resolves #126 and #148 