### PR TITLE
feat: enrich failure store indices with data stream metadata

### DIFF
--- a/openspec/specs/data-stream-model/spec.md
+++ b/openspec/specs/data-stream-model/spec.md
@@ -1,0 +1,20 @@
+# Data Stream Model
+
+## Purpose
+Define the data model for Elasticsearch data streams, including the `DataStream` and `DataStreamDocument` structures, their fields (such as `failure_store`), and the conversion rules between in-memory representations and persisted document types.
+
+## Requirements
+
+### Requirement: Failure Store Support in DataStream
+The `DataStream` struct SHALL include a `failure_store` field that captures the failure store configuration and indices.
+
+#### Scenario: Parse failure store in DataStream
+- **WHEN** the Elasticsearch API returns a data stream with a `failure_store` object
+- **THEN** the `DataStream` struct SHALL correctly deserialize the `failure_store` field
+
+### Requirement: Failure Store Support in DataStreamDocument
+The `DataStreamDocument` struct SHALL include a `failure_store` field to persist failure store information.
+
+#### Scenario: Convert DataStream to DataStreamDocument
+- **WHEN** a `DataStream` is converted to a `DataStreamDocument`
+- **THEN** the `failure_store` information SHALL be preserved in the resulting document

--- a/openspec/specs/failure-store-enrichment/spec.md
+++ b/openspec/specs/failure-store-enrichment/spec.md
@@ -1,0 +1,20 @@
+# Failure Store Enrichment
+
+## Purpose
+The purpose of this spec is to define how failure store indices are identified and enriched with metadata.
+
+## Requirements
+
+### Requirement: Failure Store Index Identification
+The system SHALL identify indices belonging to a data stream's failure store by checking the `failure_store.indices` field in the data stream response.
+
+#### Scenario: Identify failure store index
+- **WHEN** a data stream has a `failure_store` with an index named `.fs-metrics-index-esdiag-2026.02.07-000012`
+- **THEN** the system SHALL recognize this index as part of the failure store
+
+### Requirement: Failure Store Index Enrichment
+The system SHALL enrich failure store indices with the same metadata as regular backing indices, including `type`, `dataset`, and `namespace`.
+
+#### Scenario: Enrich failure store index
+- **WHEN** a failure store index is identified for data stream `metrics-index-esdiag`
+- **THEN** the system SHALL assign `type: metrics`, `dataset: index`, and `namespace: esdiag` to that index

--- a/src/processor/elasticsearch/data_stream/data.rs
+++ b/src/processor/elasticsearch/data_stream/data.rs
@@ -33,6 +33,7 @@ pub struct DataStream {
     pub system: Option<bool>,
     pub template: Option<String>,
     pub timestamp_field: TimestampField,
+    pub failure_store: Option<FailureStore>,
     #[serde(skip_deserializing)]
     pub dataset: String,
     #[serde(default)]
@@ -119,6 +120,7 @@ pub struct DataStreamDocument {
     pub system: Option<bool>,
     pub template: Option<String>,
     pub timestamp_field: TimestampField,
+    pub failure_store: Option<FailureStore>,
     pub dataset: String,
     pub is_write_index: bool,
     pub namespace: String,
@@ -141,6 +143,7 @@ impl From<DataStream> for DataStreamDocument {
             system: data_stream.system,
             template: data_stream.template,
             timestamp_field: data_stream.timestamp_field,
+            failure_store: data_stream.failure_store,
             dataset: data_stream.dataset,
             is_write_index: data_stream.is_write_index,
             namespace: data_stream.namespace,
@@ -162,6 +165,23 @@ pub struct IndexEntry {
     pub prefer_ilm: Option<bool>,
     pub ilm_policy: Option<String>,
     pub managed_by: Option<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FailureStore {
+    pub enabled: bool,
+    pub rollover_on_write: Option<bool>,
+    pub indices: Vec<IndexEntry>,
+    pub lifecycle: Option<FailureStoreLifecycle>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FailureStoreLifecycle {
+    pub enabled: bool,
+    pub effective_retention: Option<String>,
+    pub retention_determined_by: Option<String>,
 }
 
 impl DataSource for DataStreams {

--- a/src/processor/elasticsearch/data_stream/lookup.rs
+++ b/src/processor/elasticsearch/data_stream/lookup.rs
@@ -26,20 +26,28 @@ impl From<DataStreams> for Lookup<DataStreamDocument> {
                 let mut indices: Indices = data_stream.indices.drain(..).collect();
                 let write_index = indices.len() - 1;
                 let write_data_stream = data_stream.clone().set_write_index(true);
-                if write_index > 0 {
-                    lookup
-                        .add(DataStreamDocument::from(data_stream))
-                        .with_name(&name);
-                }
+
+                // Add base document once for all non-write indices (including failure store)
+                let base_doc = DataStreamDocument::from(data_stream.clone());
+                lookup.add(base_doc).with_name(&name);
 
                 for (i, index) in indices.drain(..).enumerate() {
                     if i == write_index {
                         lookup
                             .add(DataStreamDocument::from(write_data_stream.clone()))
                             .with_name(&name)
-                            .with_id(&index.index_name.clone());
+                            .with_id(&index.index_name);
                     } else {
-                        lookup.with_id(&index.index_name.clone());
+                        lookup.with_id(&index.index_name);
+                    }
+                }
+
+                if let Some(failure_store) = &data_stream.failure_store {
+                    // Re-add/re-activate base document context for failure store indices
+                    let base_doc = DataStreamDocument::from(data_stream.clone());
+                    lookup.add(base_doc);
+                    for index in &failure_store.indices {
+                        lookup.with_id(&index.index_name);
                     }
                 }
             });
@@ -58,5 +66,76 @@ impl From<Result<DataStreams>> for Lookup<DataStreamDocument> {
                 Lookup::new()
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::processor::elasticsearch::data_stream::data::DataStreams;
+    use crate::processor::elasticsearch::data_stream::DataStreamDocument;
+    use crate::processor::elasticsearch::Lookup;
+
+    #[test]
+    fn test_failure_store_enrichment() {
+        let json = r#"{
+          "data_streams": [
+            {
+              "name": "metrics-index-esdiag",
+              "timestamp_field": { "name": "@timestamp" },
+              "indices": [
+                {
+                  "index_name": ".ds-metrics-index-esdiag-2025.11.20-000004",
+                  "index_uuid": "uuid1"
+                },
+                {
+                  "index_name": ".ds-metrics-index-esdiag-2025.11.21-000005",
+                  "index_uuid": "uuid2"
+                }
+              ],
+              "generation": 1,
+              "status": "GREEN",
+              "failure_store": {
+                "enabled": true,
+                "indices": [
+                  {
+                    "index_name": ".fs-metrics-index-esdiag-2026.02.07-000012",
+                    "index_uuid": "uuid-fs"
+                  }
+                ]
+              }
+            }
+          ]
+        }"#;
+
+        let data_streams: DataStreams = serde_json::from_str(json).unwrap();
+        let lookup = Lookup::<DataStreamDocument>::from(data_streams);
+
+        // Check non-write backing index
+        let doc_base = lookup
+            .by_id(".ds-metrics-index-esdiag-2025.11.20-000004")
+            .unwrap();
+        assert_eq!(doc_base.name, "metrics-index-esdiag");
+        assert_eq!(doc_base.is_write_index, false);
+
+        // Check write backing index (last in the list)
+        let doc_write = lookup
+            .by_id(".ds-metrics-index-esdiag-2025.11.21-000005")
+            .unwrap();
+        assert_eq!(doc_write.name, "metrics-index-esdiag");
+        assert_eq!(doc_write.is_write_index, true);
+
+        // Check failure store index
+        let doc_fs = lookup
+            .by_id(".fs-metrics-index-esdiag-2026.02.07-000012")
+            .unwrap();
+        assert_eq!(doc_fs.name, "metrics-index-esdiag");
+        assert_eq!(doc_fs.r#type, "metrics");
+        assert_eq!(doc_fs.dataset, "index");
+        assert_eq!(doc_fs.namespace, "esdiag");
+        assert_eq!(doc_fs.is_write_index, false);
+
+        // Check by_name returns the write document (the last one mapped to the name)
+        let doc_name = lookup.by_name("metrics-index-esdiag").unwrap();
+        assert_eq!(doc_name.is_write_index, true);
     }
 }


### PR DESCRIPTION
## Summary
- Added `FailureStore` and related structs to the `DataStream` model to support Elasticsearch's failure store feature.
- Updated `DataStreamDocument` to persist failure store information.
- Enhanced the data stream lookup logic to correctly identify and enrich failure store indices with metadata (`type`, `dataset`, `namespace`).
- Added a unit test to verify correct enrichment of failure store indices.

This change ensures that failure store indices (starting with `.fs-`) are correctly associated with their parent data streams, making them easier to analyze in the context of the Elastic Stack.

Fixes #238