### PR TITLE
feat: record parsed status and failures for lookups

### DIFF
--- a/src/processor/diagnostic/lookup.rs
+++ b/src/processor/diagnostic/lookup.rs
@@ -6,11 +6,12 @@ use serde::Serialize;
 use std::collections::HashMap;
 
 /// A lookup table that allows for retrieving by four different keys: host, id, ip, and name
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct Lookup<T> {
     by_id: HashMap<String, usize>,
     by_name: HashMap<String, usize>,
     entries: Vec<T>,
+    pub parsed: bool,
 }
 
 impl<T> Lookup<T>
@@ -22,9 +23,29 @@ where
             by_id: HashMap::new(),
             by_name: HashMap::new(),
             entries: Vec::new(),
+            parsed: false,
         }
     }
 
+    pub fn was_parsed(mut self) -> Self {
+        self.parsed = true;
+        self
+    }
+}
+
+impl<T> Default for Lookup<T>
+where
+    T: Clone + Serialize,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Lookup<T>
+where
+    T: Clone + Serialize,
+{
     /// Retrieve a lookup entry by name
     pub fn by_name(&self, name: &str) -> Option<&T> {
         match self.by_name.get(name) {

--- a/src/processor/diagnostic/lookup.rs
+++ b/src/processor/diagnostic/lookup.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 
 /// A lookup table that allows for retrieving by four different keys: host, id, ip, and name
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Lookup<T> {
     by_id: HashMap<String, usize>,
     by_name: HashMap<String, usize>,

--- a/src/processor/diagnostic/lookup.rs
+++ b/src/processor/diagnostic/lookup.rs
@@ -31,6 +31,13 @@ where
         self.parsed = true;
         self
     }
+
+    pub fn from_parsed<U>(value: U) -> Self
+    where
+        Self: From<U>,
+    {
+        Self::from(value).was_parsed()
+    }
 }
 
 impl<T> Default for Lookup<T>

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -5,7 +5,7 @@
 use super::super::elasticsearch::{ClusterMetadata, License as ElasticsearchLicense};
 use super::{DiagnosticManifest, DiagnosticMetadata, Lookup};
 use crate::data::Product;
-use eyre::{OptionExt, Report, Result, eyre};
+use eyre::{eyre, OptionExt, Report, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -263,10 +263,16 @@ impl DiagnosticReport {
     where
         T: Clone + Serialize,
     {
+        if !lookup.parsed {
+            self.diagnostic.lookup.errors += 1;
+            self.diagnostic.lookup.failures.push(name.to_string());
+        }
+
         self.diagnostic.lookup.push(
             name.to_string(),
             LookupSummary {
                 docs: lookup.len() as u32,
+                parsed: lookup.parsed,
             },
         );
     }
@@ -349,6 +355,7 @@ impl std::fmt::Display for BatchResponse {
 #[derive(Serialize, Clone)]
 pub struct LookupSummary {
     docs: u32,
+    pub parsed: bool,
 }
 
 #[derive(Serialize, Clone)]
@@ -489,5 +496,58 @@ impl TryFrom<String> for Origin {
             id: None,
             scope: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lookup_parsed_status() {
+        let metadata = DiagnosticMetadata {
+            id: "test".to_string(),
+            collection_date: 0,
+            runner: "test".to_string(),
+            uuid: "test".to_string(),
+        };
+        let mut report = DiagnosticReport::try_from(
+            DiagnosticReportBuilder::from(metadata).receiver("file path".to_string()),
+        )
+        .unwrap();
+
+        let mut lookup = Lookup::<String>::new();
+        lookup = lookup.was_parsed();
+        lookup.add("data".to_string());
+
+        report.add_lookup("my_lookup", &lookup);
+
+        let stats = &report.diagnostic.lookup;
+        assert!(stats.stats.contains_key("my_lookup"));
+        assert!(stats.stats.get("my_lookup").unwrap().parsed);
+        assert_eq!(stats.errors, 0);
+    }
+
+    #[test]
+    fn test_lookup_failure_recording() {
+        let metadata = DiagnosticMetadata {
+            id: "test".to_string(),
+            collection_date: 0,
+            runner: "test".to_string(),
+            uuid: "test".to_string(),
+        };
+        let mut report = DiagnosticReport::try_from(
+            DiagnosticReportBuilder::from(metadata).receiver("file path".to_string()),
+        )
+        .unwrap();
+
+        let lookup = Lookup::<String>::new(); // parsed is false by default
+
+        report.add_lookup("failed_lookup", &lookup);
+
+        let stats = &report.diagnostic.lookup;
+        assert_eq!(stats.errors, 1);
+        assert!(stats.failures.contains(&"failed_lookup".to_string()));
+        assert!(!stats.stats.get("failed_lookup").unwrap().parsed);
     }
 }

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -517,7 +517,7 @@ mod tests {
         .unwrap();
 
         let mut lookup = Lookup::<String>::new();
-        lookup = lookup.was_parsed();
+        lookup.parsed = true;
         lookup.add("data".to_string());
 
         report.add_lookup("my_lookup", &lookup);

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -263,7 +263,7 @@ impl DiagnosticReport {
     where
         T: Clone + Serialize,
     {
-        if !lookup.parsed {
+        if !lookup.parsed && !self.diagnostic.lookup.failures.iter().any(|f| f == name) {
             self.diagnostic.lookup.errors += 1;
             self.diagnostic.lookup.failures.push(name.to_string());
         }

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -544,9 +544,11 @@ mod tests {
         let lookup = Lookup::<String>::new(); // parsed is false by default
 
         report.add_lookup("failed_lookup", &lookup);
+        report.add_lookup("failed_lookup", &lookup); // Deduplication check
 
         let stats = &report.diagnostic.lookup;
         assert_eq!(stats.errors, 1);
+        assert_eq!(stats.failures.len(), 1);
         assert!(stats.failures.contains(&"failed_lookup".to_string()));
         assert!(!stats.stats.get("failed_lookup").unwrap().parsed);
     }

--- a/src/processor/elasticsearch/alias/lookup.rs
+++ b/src/processor/elasticsearch/alias/lookup.rs
@@ -33,7 +33,7 @@ impl From<AliasList> for Lookup<Alias> {
 impl From<Result<AliasList>> for Lookup<Alias> {
     fn from(alias_list: Result<AliasList>) -> Self {
         match alias_list {
-            Ok(alias_list) => Lookup::<Alias>::from(alias_list),
+            Ok(alias_list) => Lookup::<Alias>::from(alias_list).was_parsed(),
             Err(e) => {
                 log::warn!("Failed to parse AliasList: {}", e);
                 Lookup::new()

--- a/src/processor/elasticsearch/alias/lookup.rs
+++ b/src/processor/elasticsearch/alias/lookup.rs
@@ -33,7 +33,7 @@ impl From<AliasList> for Lookup<Alias> {
 impl From<Result<AliasList>> for Lookup<Alias> {
     fn from(alias_list: Result<AliasList>) -> Self {
         match alias_list {
-            Ok(alias_list) => Lookup::<Alias>::from(alias_list).was_parsed(),
+            Ok(alias_list) => Lookup::<Alias>::from_parsed(alias_list),
             Err(e) => {
                 log::warn!("Failed to parse AliasList: {}", e);
                 Lookup::new()

--- a/src/processor/elasticsearch/data_stream/lookup.rs
+++ b/src/processor/elasticsearch/data_stream/lookup.rs
@@ -8,9 +8,13 @@ use eyre::Result;
 
 impl From<&String> for Lookup<DataStreamDocument> {
     fn from(string: &String) -> Self {
-        let data_streams: DataStreams =
-            serde_json::from_str(string).expect("Failed to parse DataStreamData");
-        Lookup::<DataStreamDocument>::from(data_streams)
+        match serde_json::from_str::<DataStreams>(string) {
+            Ok(data_streams) => Lookup::<DataStreamDocument>::from(data_streams).was_parsed(),
+            Err(e) => {
+                log::warn!("Failed to parse DataStreams: {}", e);
+                Lookup::new()
+            }
+        }
     }
 }
 

--- a/src/processor/elasticsearch/data_stream/lookup.rs
+++ b/src/processor/elasticsearch/data_stream/lookup.rs
@@ -9,7 +9,7 @@ use eyre::Result;
 impl From<&String> for Lookup<DataStreamDocument> {
     fn from(string: &String) -> Self {
         let data_streams: DataStreams =
-            serde_json::from_str(&string).expect("Failed to parse DataStreamData");
+            serde_json::from_str(string).expect("Failed to parse DataStreamData");
         Lookup::<DataStreamDocument>::from(data_streams)
     }
 }
@@ -60,7 +60,7 @@ impl From<DataStreams> for Lookup<DataStreamDocument> {
 impl From<Result<DataStreams>> for Lookup<DataStreamDocument> {
     fn from(data_streams: Result<DataStreams>) -> Self {
         match data_streams {
-            Ok(data_streams) => Lookup::<DataStreamDocument>::from(data_streams),
+            Ok(data_streams) => Lookup::<DataStreamDocument>::from(data_streams).was_parsed(),
             Err(e) => {
                 log::warn!("Failed to parse DataStreams: {}", e);
                 Lookup::new()

--- a/src/processor/elasticsearch/data_stream/lookup.rs
+++ b/src/processor/elasticsearch/data_stream/lookup.rs
@@ -9,7 +9,7 @@ use eyre::Result;
 impl From<&String> for Lookup<DataStreamDocument> {
     fn from(string: &String) -> Self {
         match serde_json::from_str::<DataStreams>(string) {
-            Ok(data_streams) => Lookup::<DataStreamDocument>::from(data_streams).was_parsed(),
+            Ok(data_streams) => Lookup::<DataStreamDocument>::from_parsed(data_streams),
             Err(e) => {
                 log::warn!("Failed to parse DataStreams: {}", e);
                 Lookup::new()
@@ -64,7 +64,7 @@ impl From<DataStreams> for Lookup<DataStreamDocument> {
 impl From<Result<DataStreams>> for Lookup<DataStreamDocument> {
     fn from(data_streams: Result<DataStreams>) -> Self {
         match data_streams {
-            Ok(data_streams) => Lookup::<DataStreamDocument>::from(data_streams).was_parsed(),
+            Ok(data_streams) => Lookup::<DataStreamDocument>::from_parsed(data_streams),
             Err(e) => {
                 log::warn!("Failed to parse DataStreams: {}", e);
                 Lookup::new()

--- a/src/processor/elasticsearch/ilm_explain/lookup.rs
+++ b/src/processor/elasticsearch/ilm_explain/lookup.rs
@@ -28,7 +28,7 @@ impl From<IlmExplain> for Lookup<IlmStats> {
 impl From<Result<IlmExplain>> for Lookup<IlmStats> {
     fn from(ilm_explain_result: Result<IlmExplain>) -> Self {
         match ilm_explain_result {
-            Ok(ilm_explain) => Lookup::<IlmStats>::from(ilm_explain).was_parsed(),
+            Ok(ilm_explain) => Lookup::<IlmStats>::from_parsed(ilm_explain),
             Err(e) => {
                 log::warn!("Failed to parse IlmExplain: {}", e);
                 Lookup::new()

--- a/src/processor/elasticsearch/ilm_explain/lookup.rs
+++ b/src/processor/elasticsearch/ilm_explain/lookup.rs
@@ -28,7 +28,7 @@ impl From<IlmExplain> for Lookup<IlmStats> {
 impl From<Result<IlmExplain>> for Lookup<IlmStats> {
     fn from(ilm_explain_result: Result<IlmExplain>) -> Self {
         match ilm_explain_result {
-            Ok(ilm_explain) => Lookup::<IlmStats>::from(ilm_explain),
+            Ok(ilm_explain) => Lookup::<IlmStats>::from(ilm_explain).was_parsed(),
             Err(e) => {
                 log::warn!("Failed to parse IlmExplain: {}", e);
                 Lookup::new()

--- a/src/processor/elasticsearch/indices_settings/lookup.rs
+++ b/src/processor/elasticsearch/indices_settings/lookup.rs
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use super::{
-    super::{Lookup, data_stream::DataStreamDocument, ilm_explain::IlmStats},
+    super::{data_stream::DataStreamDocument, ilm_explain::IlmStats, Lookup},
     IndexSettings, IndicesSettings, StoreSettings,
 };
 use eyre::Result;
@@ -25,7 +25,7 @@ impl From<IndicesSettings> for Lookup<IndexSettings> {
 impl From<Result<IndicesSettings>> for Lookup<IndexSettings> {
     fn from(indices_settings: Result<IndicesSettings>) -> Self {
         match indices_settings {
-            Ok(indices_settings) => Lookup::<IndexSettings>::from(indices_settings),
+            Ok(indices_settings) => Lookup::<IndexSettings>::from(indices_settings).was_parsed(),
             Err(e) => {
                 log::warn!("Failed to parse IndicesSettings: {}", e);
                 Lookup::new()

--- a/src/processor/elasticsearch/indices_settings/lookup.rs
+++ b/src/processor/elasticsearch/indices_settings/lookup.rs
@@ -25,7 +25,7 @@ impl From<IndicesSettings> for Lookup<IndexSettings> {
 impl From<Result<IndicesSettings>> for Lookup<IndexSettings> {
     fn from(indices_settings: Result<IndicesSettings>) -> Self {
         match indices_settings {
-            Ok(indices_settings) => Lookup::<IndexSettings>::from(indices_settings).was_parsed(),
+            Ok(indices_settings) => Lookup::<IndexSettings>::from_parsed(indices_settings),
             Err(e) => {
                 log::warn!("Failed to parse IndicesSettings: {}", e);
                 Lookup::new()

--- a/src/processor/elasticsearch/mod.rs
+++ b/src/processor/elasticsearch/mod.rs
@@ -113,7 +113,11 @@ impl ElasticsearchDiagnostic {
             }
             Err(err) => {
                 log::warn!("{}", err);
-                Ok(())
+                let summary = ProcessorSummary::new(T::name());
+                summary_tx.send(summary).await.map_err(|err| {
+                    log::error!("Failed to send summary: {}", err);
+                    eyre!(err)
+                })
             }
         }
     }

--- a/src/processor/elasticsearch/mod.rs
+++ b/src/processor/elasticsearch/mod.rs
@@ -100,20 +100,22 @@ impl ElasticsearchDiagnostic {
             + Send
             + Sync,
     {
-        let summary = match self.receiver.get::<T>().await {
-            Ok(data) => data
-                .documents_export(&self.exporter, &self.lookups, &self.metadata)
-                .await
-                .was_parsed(),
+        match self.receiver.get::<T>().await {
+            Ok(data) => {
+                let summary = data
+                    .documents_export(&self.exporter, &self.lookups, &self.metadata)
+                    .await
+                    .was_parsed();
+                summary_tx.send(summary).await.map_err(|err| {
+                    log::error!("Failed to send summary: {}", err);
+                    eyre!(err)
+                })
+            }
             Err(err) => {
                 log::warn!("{}", err);
-                ProcessorSummary::new(T::name())
+                Ok(())
             }
-        };
-        summary_tx.send(summary).await.map_err(|err| {
-            log::error!("Failed to send summary: {}", err);
-            eyre!(err)
-        })
+        }
     }
 }
 
@@ -172,7 +174,7 @@ impl DiagnosticProcessor for ElasticsearchDiagnostic {
 
     async fn process(self, summary_tx: mpsc::Sender<ProcessorSummary>) -> Result<()> {
         log::debug!("Running Elasticsearch diagnostic processors");
-        if self.exporter.is_connected().await == false {
+        if !self.exporter.is_connected().await {
             return Err(eyre!("Exporter is not connected"));
         }
 

--- a/src/processor/elasticsearch/nodes/data.rs
+++ b/src/processor/elasticsearch/nodes/data.rs
@@ -8,7 +8,7 @@ use eyre::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::skip_serializing_none;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[skip_serializing_none]
 #[derive(Clone, Deserialize, Serialize)]
@@ -31,7 +31,7 @@ pub struct Node {
     plugins: Option<Value>,
     process: Value,
     pub role: Option<String>,
-    pub roles: Vec<String>,
+    pub roles: HashSet<String>,
     settings: Option<Value>,
     thread_pool: Value,
     total_indexing_buffer: Option<Value>,

--- a/src/processor/elasticsearch/nodes/lookup.rs
+++ b/src/processor/elasticsearch/nodes/lookup.rs
@@ -25,16 +25,16 @@ pub struct NodeDocument {
 }
 
 impl NodeDocument {
-    pub fn rename(self, name: &String) -> Self {
+    pub fn rename(self, name: &str) -> Self {
         NodeDocument {
-            name: name.clone(),
+            name: name.to_string(),
             ..self
         }
     }
 
-    pub fn with_id(self, id: &String) -> Self {
+    pub fn with_id(self, id: &str) -> Self {
         NodeDocument {
-            id: Some(id.clone()),
+            id: Some(id.to_string()),
             ..self
         }
     }
@@ -79,7 +79,7 @@ impl From<Nodes> for Lookup<NodeDocument> {
 impl From<Result<Nodes>> for Lookup<NodeDocument> {
     fn from(nodes_result: Result<Nodes>) -> Self {
         match nodes_result {
-            Ok(nodes) => Lookup::<NodeDocument>::from(nodes),
+            Ok(nodes) => Lookup::<NodeDocument>::from(nodes).was_parsed(),
             Err(e) => {
                 log::warn!("Failed to parse Nodes: {}", e);
                 Lookup::new()
@@ -95,7 +95,7 @@ impl std::fmt::Display for Node {
 }
 
 /// Determines a node's tier based on a precedence of assigned roles.
-fn get_tier(roles: &Vec<String>) -> String {
+fn get_tier(roles: &[String]) -> String {
     match () {
         _ if roles.contains(&"index".to_string()) => "index",
         _ if roles.contains(&"search".to_string()) => "search",
@@ -152,7 +152,7 @@ fn get_tier_node_name(node_name: String, tier: &str) -> String {
 }
 
 /// Collects single-character abbreviations for roles into a string.
-fn get_roles_abbreviation(role_list: &Vec<String>) -> String {
+fn get_roles_abbreviation(role_list: &[String]) -> String {
     let char_for = |role| {
         let c = match role {
             "data" => 'd',

--- a/src/processor/elasticsearch/nodes/lookup.rs
+++ b/src/processor/elasticsearch/nodes/lookup.rs
@@ -7,6 +7,7 @@ use eyre::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::skip_serializing_none;
+use std::collections::HashSet;
 
 #[skip_serializing_none]
 #[derive(Clone, Deserialize, Serialize)]
@@ -18,7 +19,7 @@ pub struct NodeDocument {
     pub name: String,
     pub os: OsDetails,
     pub role: String,
-    pub roles: Vec<String>,
+    pub roles: HashSet<String>,
     pub tier: String,
     pub tier_order: usize,
     pub version: Option<String>,
@@ -95,24 +96,22 @@ impl std::fmt::Display for Node {
 }
 
 /// Determines a node's tier based on a precedence of assigned roles.
-fn get_tier(roles: &[String]) -> String {
-    let has = |role: &str| roles.iter().any(|r| r == role);
-
+fn get_tier(roles: &HashSet<String>) -> String {
     match () {
-        _ if has("index") => "index",
-        _ if has("search") => "search",
-        _ if has("data_hot") => "hot",
-        _ if has("data_warm") => "warm",
-        _ if has("data_cold") => "cold",
-        _ if has("data_frozen") => "frozen",
-        _ if has("data_content") => "content",
-        _ if has("data") => "data",
-        _ if has("ingest") => "ingest",
-        _ if has("ml") => "ml",
-        _ if has("transform") => "transform",
-        _ if has("voting_only") => "tiebreaker",
-        _ if has("master") => "master",
-        _ if has("remote_cluster_client") => "remote",
+        _ if roles.contains("index") => "index",
+        _ if roles.contains("search") => "search",
+        _ if roles.contains("data_hot") => "hot",
+        _ if roles.contains("data_warm") => "warm",
+        _ if roles.contains("data_cold") => "cold",
+        _ if roles.contains("data_frozen") => "frozen",
+        _ if roles.contains("data_content") => "content",
+        _ if roles.contains("data") => "data",
+        _ if roles.contains("ingest") => "ingest",
+        _ if roles.contains("ml") => "ml",
+        _ if roles.contains("transform") => "transform",
+        _ if roles.contains("voting_only") => "tiebreaker",
+        _ if roles.contains("master") => "master",
+        _ if roles.contains("remote_cluster_client") => "remote",
         _ if roles.is_empty() => "coord",
         _ => "node",
     }
@@ -154,8 +153,8 @@ fn get_tier_node_name(node_name: String, tier: &str) -> String {
 }
 
 /// Collects single-character abbreviations for roles into a string.
-fn get_roles_abbreviation(role_list: &[String]) -> String {
-    let char_for = |role| {
+fn get_roles_abbreviation(role_list: &HashSet<String>) -> String {
+    let char_for = |role: &str| {
         let c = match role {
             "data" => 'd',
             "data_content" => 's',

--- a/src/processor/elasticsearch/nodes/lookup.rs
+++ b/src/processor/elasticsearch/nodes/lookup.rs
@@ -96,21 +96,23 @@ impl std::fmt::Display for Node {
 
 /// Determines a node's tier based on a precedence of assigned roles.
 fn get_tier(roles: &[String]) -> String {
+    let has = |role: &str| roles.iter().any(|r| r == role);
+
     match () {
-        _ if roles.contains(&"index".to_string()) => "index",
-        _ if roles.contains(&"search".to_string()) => "search",
-        _ if roles.contains(&"data_hot".to_string()) => "hot",
-        _ if roles.contains(&"data_warm".to_string()) => "warm",
-        _ if roles.contains(&"data_cold".to_string()) => "cold",
-        _ if roles.contains(&"data_frozen".to_string()) => "frozen",
-        _ if roles.contains(&"data_content".to_string()) => "content",
-        _ if roles.contains(&"data".to_string()) => "data",
-        _ if roles.contains(&"ingest".to_string()) => "ingest",
-        _ if roles.contains(&"ml".to_string()) => "ml",
-        _ if roles.contains(&"transform".to_string()) => "transform",
-        _ if roles.contains(&"voting_only".to_string()) => "tiebreaker",
-        _ if roles.contains(&"master".to_string()) => "master",
-        _ if roles.contains(&"remote_cluster_client".to_string()) => "remote",
+        _ if has("index") => "index",
+        _ if has("search") => "search",
+        _ if has("data_hot") => "hot",
+        _ if has("data_warm") => "warm",
+        _ if has("data_cold") => "cold",
+        _ if has("data_frozen") => "frozen",
+        _ if has("data_content") => "content",
+        _ if has("data") => "data",
+        _ if has("ingest") => "ingest",
+        _ if has("ml") => "ml",
+        _ if has("transform") => "transform",
+        _ if has("voting_only") => "tiebreaker",
+        _ if has("master") => "master",
+        _ if has("remote_cluster_client") => "remote",
         _ if roles.is_empty() => "coord",
         _ => "node",
     }

--- a/src/processor/elasticsearch/nodes/lookup.rs
+++ b/src/processor/elasticsearch/nodes/lookup.rs
@@ -79,7 +79,7 @@ impl From<Nodes> for Lookup<NodeDocument> {
 impl From<Result<Nodes>> for Lookup<NodeDocument> {
     fn from(nodes_result: Result<Nodes>) -> Self {
         match nodes_result {
-            Ok(nodes) => Lookup::<NodeDocument>::from(nodes).was_parsed(),
+            Ok(nodes) => Lookup::<NodeDocument>::from_parsed(nodes),
             Err(e) => {
                 log::warn!("Failed to parse Nodes: {}", e);
                 Lookup::new()

--- a/src/processor/elasticsearch/nodes_stats/data.rs
+++ b/src/processor/elasticsearch/nodes_stats/data.rs
@@ -9,7 +9,7 @@ use eyre::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::skip_serializing_none;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Deserialize, Serialize)]
 pub struct NodesStats {
@@ -46,7 +46,7 @@ pub struct NodeStats {
     os: OsStats,
     process: Value,
     repositories: Option<Value>,
-    pub roles: Vec<String>,
+    pub roles: HashSet<String>,
     script: Value,
     script_cache: Value,
     thread_pool: Value,

--- a/src/processor/elasticsearch/searchable_snapshots_cache_stats/lookup.rs
+++ b/src/processor/elasticsearch/searchable_snapshots_cache_stats/lookup.rs
@@ -10,7 +10,7 @@ impl From<&String> for Lookup<SharedCacheStats> {
         match serde_json::from_str::<SearchableSnapshotsCacheStats>(string) {
             Ok(nodes) => Lookup::<SharedCacheStats>::from(nodes).was_parsed(),
             Err(e) => {
-                log::warn!("Failed to parse SharedCacheStats: {}", e);
+                log::warn!("Failed to parse SearchableSnapshotsCacheStats: {}", e);
                 Lookup::new()
             }
         }

--- a/src/processor/elasticsearch/searchable_snapshots_cache_stats/lookup.rs
+++ b/src/processor/elasticsearch/searchable_snapshots_cache_stats/lookup.rs
@@ -8,7 +8,7 @@ use eyre::Result;
 impl From<&String> for Lookup<SharedCacheStats> {
     fn from(string: &String) -> Self {
         match serde_json::from_str::<SearchableSnapshotsCacheStats>(string) {
-            Ok(nodes) => Lookup::<SharedCacheStats>::from(nodes).was_parsed(),
+            Ok(nodes) => Lookup::<SharedCacheStats>::from_parsed(nodes),
             Err(e) => {
                 log::warn!("Failed to parse SearchableSnapshotsCacheStats: {}", e);
                 Lookup::new()
@@ -36,7 +36,7 @@ impl From<SearchableSnapshotsCacheStats> for Lookup<SharedCacheStats> {
 impl From<Result<SearchableSnapshotsCacheStats>> for Lookup<SharedCacheStats> {
     fn from(stats_result: Result<SearchableSnapshotsCacheStats>) -> Self {
         match stats_result {
-            Ok(stats) => Lookup::<SharedCacheStats>::from(stats).was_parsed(),
+            Ok(stats) => Lookup::<SharedCacheStats>::from_parsed(stats),
             Err(e) => {
                 log::warn!("Failed to parse SearchableSnapshotsCacheStats: {}", e);
                 Lookup::new()

--- a/src/processor/elasticsearch/searchable_snapshots_cache_stats/lookup.rs
+++ b/src/processor/elasticsearch/searchable_snapshots_cache_stats/lookup.rs
@@ -7,9 +7,13 @@ use eyre::Result;
 
 impl From<&String> for Lookup<SharedCacheStats> {
     fn from(string: &String) -> Self {
-        let nodes: SearchableSnapshotsCacheStats =
-            serde_json::from_str(string).expect("Failed to parse SharedCacheStats");
-        Lookup::<SharedCacheStats>::from(nodes)
+        match serde_json::from_str::<SearchableSnapshotsCacheStats>(string) {
+            Ok(nodes) => Lookup::<SharedCacheStats>::from(nodes).was_parsed(),
+            Err(e) => {
+                log::warn!("Failed to parse SharedCacheStats: {}", e);
+                Lookup::new()
+            }
+        }
     }
 }
 

--- a/src/processor/elasticsearch/searchable_snapshots_cache_stats/lookup.rs
+++ b/src/processor/elasticsearch/searchable_snapshots_cache_stats/lookup.rs
@@ -8,7 +8,7 @@ use eyre::Result;
 impl From<&String> for Lookup<SharedCacheStats> {
     fn from(string: &String) -> Self {
         let nodes: SearchableSnapshotsCacheStats =
-            serde_json::from_str(&string).expect("Failed to parse SharedCacheStats");
+            serde_json::from_str(string).expect("Failed to parse SharedCacheStats");
         Lookup::<SharedCacheStats>::from(nodes)
     }
 }
@@ -32,7 +32,7 @@ impl From<SearchableSnapshotsCacheStats> for Lookup<SharedCacheStats> {
 impl From<Result<SearchableSnapshotsCacheStats>> for Lookup<SharedCacheStats> {
     fn from(stats_result: Result<SearchableSnapshotsCacheStats>) -> Self {
         match stats_result {
-            Ok(stats) => Lookup::<SharedCacheStats>::from(stats),
+            Ok(stats) => Lookup::<SharedCacheStats>::from(stats).was_parsed(),
             Err(e) => {
                 log::warn!("Failed to parse SearchableSnapshotsCacheStats: {}", e);
                 Lookup::new()


### PR DESCRIPTION
## Summary
- Adds `parsed: bool` to `LookupSummary` and `Lookup<T>` to track initialization status of enrichment tables.
- Updates `DiagnosticReport::add_lookup` to record failures in `diagnostic.lookup.failures` and increment the error count when a lookup fails to parse.
- Ensures visibility into failed enrichment lookups in the final diagnostic report.

Resolves issue #237