### PR TITLE
Fix tasks processor panic on missing node metadata

### DIFF
--- a/openspec/changes/archive/2026-02-07-fix-tasks-processor-panic/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-07-fix-tasks-processor-panic/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-07

--- a/openspec/changes/archive/2026-02-07-fix-tasks-processor-panic/design.md
+++ b/openspec/changes/archive/2026-02-07-fix-tasks-processor-panic/design.md
@@ -1,0 +1,36 @@
+## Context
+
+The `Tasks` processor in `esdiag` enriches raw task data from Elasticsearch with node metadata. This enrichment is currently performed using an `.expect()` call on the node lookup. If the node ID provided in the tasks response is not present in the nodes lookup (which can happen in environments like Elasticsearch Serverless or due to inconsistent diagnostic capture), the processor panics.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate the panic in the tasks processor when node metadata is missing.
+- Maintain the ability to export task data even when it cannot be enriched with node details.
+- Provide clear logging when enrichment fails to assist in debugging diagnostic capture issues.
+
+**Non-Goals:**
+- Implementing a retry mechanism for node lookups.
+- Changing the fundamental structure of the `EnrichedTask` beyond making the node optional.
+
+## Decisions
+
+### 1. Make `EnrichedTask.node` optional
+Instead of requiring a `NodeDocument`, the `EnrichedTask` struct will be updated to hold an `Option<NodeDocument>`.
+- **Rationale**: This is the most idiomatic way in Rust to handle potentially missing data. It allows `serde` to handle the field (omitting it if `None`) and avoids the need for placeholder data.
+
+### 2. Use `Option.cloned()` for node lookup
+The lookup in the parallel iterator will be updated to use `cloned()` instead of `cloned().expect()`.
+- **Rationale**: This allows the map operation to continue regardless of whether the node was found.
+
+### 3. Log a warning on missing node
+A `log::warn!` or `log::error!` message will be added when a node ID cannot be found in the lookup.
+- **Rationale**: While we want to continue processing, it's important to record that the enrichment was incomplete, as this might indicate a bug in the diagnostic collector or an unsupported environment configuration.
+
+## Risks / Trade-offs
+
+- **Risk**: Downstream consumers of the exported data might expect the `node` field to always be present.
+- **Mitigation**: Elasticsearch data streams are generally resilient to missing fields, and the `metrics-task-esdiag` data stream mapping should already handle optional fields.
+
+- **Risk**: Excessive logging if many tasks are missing node metadata.
+- **Mitigation**: We could consider rate-limiting the log message or logging it once per node ID per processing run. However, given the typical scale of diagnostics, a simple log message is likely sufficient for now.

--- a/openspec/changes/archive/2026-02-07-fix-tasks-processor-panic/proposal.md
+++ b/openspec/changes/archive/2026-02-07-fix-tasks-processor-panic/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+The tasks processor in `esdiag` currently uses `.expect()` when retrieving node metadata for a task. In certain environments, such as Elasticsearch Serverless, node metadata might be missing or structured differently, leading to a panic that terminates the diagnostic processing prematurely.
+
+## What Changes
+
+- Modified the task enrichment logic to gracefully handle cases where node metadata is missing.
+- Replaced `.expect("Node not found for task")` with safe `Option` handling.
+- Added error logging when node metadata is missing, while allowing the processing of the task document to continue.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `diagnostic-reporting`: Strengthened the robustness of the processing pipeline to handle missing metadata without panicking.
+
+## Impact
+
+- `src/processor/elasticsearch/tasks/processor.rs`: Updated the `documents_export` method and `EnrichedTask` struct to support optional node metadata.
+- Processing logic: Increased resilience to environment-specific metadata variations.

--- a/openspec/changes/archive/2026-02-07-fix-tasks-processor-panic/specs/diagnostic-reporting/spec.md
+++ b/openspec/changes/archive/2026-02-07-fix-tasks-processor-panic/specs/diagnostic-reporting/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Graceful handling of missing enrichment metadata
+The processing pipeline SHALL handle missing enrichment metadata (such as node information for tasks) gracefully, without causing the application to panic or terminate diagnostic processing.
+
+#### Scenario: Missing node metadata for a task
+- **WHEN** the task processor attempts to enrich a task with node metadata
+- **AND** the node ID for that task is not found in the node lookup table
+- **THEN** the system SHALL log an error or warning message
+- **AND** the system SHALL continue to process and export the task document without node metadata

--- a/openspec/changes/archive/2026-02-07-fix-tasks-processor-panic/tasks.md
+++ b/openspec/changes/archive/2026-02-07-fix-tasks-processor-panic/tasks.md
@@ -1,0 +1,12 @@
+## 1. Struct and Logic Updates
+
+- [x] 1.1 Update `EnrichedTask` struct in `src/processor/elasticsearch/tasks/processor.rs` to make the `node` field `Option<NodeDocument>`.
+- [x] 1.2 Update the `EnrichedTask::new` constructor signature and implementation to accept `Option<NodeDocument>`.
+- [x] 1.3 Modify the `documents_export` implementation in `src/processor/elasticsearch/tasks/processor.rs` to remove the `.expect()` call and handle the missing node case.
+- [x] 1.4 Add a warning log message in `documents_export` when a node ID cannot be found in the lookup table.
+
+## 2. Verification
+
+- [x] 2.1 Run `cargo clippy` to ensure code quality and adherence to idioms.
+- [x] 2.2 Run `cargo test` to verify that existing tests pass and no regressions were introduced.
+- [x] 2.3 Verify that the changes compile and handle missing node metadata correctly (can be tested manually or by adding a new unit test if feasible).

--- a/openspec/specs/diagnostic-reporting/spec.md
+++ b/openspec/specs/diagnostic-reporting/spec.md
@@ -18,3 +18,12 @@ The system SHALL track the total number of lookup failures and the names of fail
 - **WHEN** `add_lookup` is called with a lookup that was not successfully parsed
 - **THEN** `diagnostic.lookup.errors` is incremented
 - **AND** the lookup name is added to `diagnostic.lookup.failures`
+
+### Requirement: Graceful handling of missing enrichment metadata
+The processing pipeline SHALL handle missing enrichment metadata (such as node information for tasks) gracefully, without causing the application to panic or terminate diagnostic processing.
+
+#### Scenario: Missing node metadata for a task
+- **WHEN** the task processor attempts to enrich a task with node metadata
+- **AND** the node ID for that task is not found in the node lookup table
+- **THEN** the system SHALL log an error or warning message
+- **AND** the system SHALL continue to process and export the task document without node metadata

--- a/src/processor/elasticsearch/tasks/data.rs
+++ b/src/processor/elasticsearch/tasks/data.rs
@@ -28,7 +28,7 @@ pub struct Task {
     cancelled: Option<bool>,
     pub description: Option<String>,
     headers: Option<Value>,
-    id: u64,
+    pub id: u64,
     //node: Option<String>, // omitted in favor of enriched node field
     #[serde(skip_serializing)] // skipped in favor of subobject field
     pub parent_task_id: Option<String>,

--- a/src/processor/elasticsearch/tasks/processor.rs
+++ b/src/processor/elasticsearch/tasks/processor.rs
@@ -34,6 +34,9 @@ impl DocumentExporter<Lookups, ElasticsearchMetadata> for Tasks {
                     .par_drain()
                     .map(|(_, task)| {
                         let node = lookup_node.by_id(node_id.as_str()).cloned();
+                        if node.is_none() {
+                            log::warn!("Node not found for task (node_id: {})", node_id);
+                        }
                         serde_json::to_value(EnrichedTask::new(task, task_metadata.clone(), node))
                             .unwrap_or_default()
                     })

--- a/src/processor/elasticsearch/tasks/processor.rs
+++ b/src/processor/elasticsearch/tasks/processor.rs
@@ -35,7 +35,7 @@ impl DocumentExporter<Lookups, ElasticsearchMetadata> for Tasks {
                     .map(|(_, task)| {
                         let node = lookup_node.by_id(node_id.as_str()).cloned();
                         if node.is_none() {
-                            log::warn!("Node not found for task (node_id: {})", node_id);
+                            log::warn!("Node [{}] not found for task [{}]", node_id, task.id);
                         }
                         serde_json::to_value(EnrichedTask::new(task, task_metadata.clone(), node))
                             .unwrap_or_default()


### PR DESCRIPTION
## Summary
This PR fixes a panic in the tasks processor that occurs when node metadata is missing for a task (common in Elasticsearch Serverless environments).

### Changes
- **Graceful Error Handling**: Replaced `.expect("Node not found for task")` with safe `Option` handling in the task enrichment loop.
- **Data Model Update**: Updated `EnrichedTask` struct to make the `node` field optional, allowing tasks to be exported even if node details are unavailable.
- **Logging**: Added a warning log message when a node ID cannot be found in the lookup table to aid in debugging diagnostic capture issues.
- **OpenSpec**: Synced the `diagnostic-reporting` specification with the new robustness requirement and archived the corresponding change proposal.

### Verification
- Ran `cargo clippy` and `cargo test`.
- Manually verified the logic prevents panics when a node ID is missing from `Lookups`.

@github-copilot review