### PR TITLE
feat: enrich index statistics with mapping summaries

### DIFF
--- a/assets/elasticsearch/index_templates/metrics-index.json
+++ b/assets/elasticsearch/index_templates/metrics-index.json
@@ -361,6 +361,56 @@
                 }
               }
             },
+            "mappings": {
+              "properties": {
+                "dynamic": {
+                  "type": "keyword"
+                },
+                "date_detection": {
+                  "type": "boolean"
+                },
+                "numeric_detection": {
+                  "type": "boolean"
+                },
+                "dynamic_date_formats": {
+                  "type": "keyword"
+                },
+                "dynamic_templates": {
+                  "type": "long"
+                },
+                "_data_stream_timestamp": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "_source": {
+                  "properties": {
+                    "mode": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "_meta": {
+                  "type": "object",
+                  "enabled": false
+                },
+                "field": {
+                  "properties": {
+                    "fields": {
+                      "type": "object",
+                      "dynamic": true,
+                      "properties": {
+                        "total": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "mode": {
               "type": "keyword"
             },

--- a/assets/elasticsearch/index_templates/metrics-index.json
+++ b/assets/elasticsearch/index_templates/metrics-index.json
@@ -396,16 +396,12 @@
                   "type": "object",
                   "enabled": false
                 },
-                "field": {
+                "fields": {
+                  "type": "object",
+                  "dynamic": true,
                   "properties": {
-                    "fields": {
-                      "type": "object",
-                      "dynamic": true,
-                      "properties": {
-                        "total": {
-                          "type": "long"
-                        }
-                      }
+                    "total": {
+                      "type": "long"
                     }
                   }
                 }

--- a/assets/elasticsearch/index_templates/metrics-index.json
+++ b/assets/elasticsearch/index_templates/metrics-index.json
@@ -404,6 +404,13 @@
                       "type": "long"
                     }
                   }
+                },
+                "multi-fields": {
+                  "properties": {
+                    "total": {
+                      "type": "long"
+                    }
+                  }
                 }
               }
             },

--- a/assets/elasticsearch/index_templates/metrics-index.json
+++ b/assets/elasticsearch/index_templates/metrics-index.json
@@ -409,6 +409,9 @@
                   "properties": {
                     "total": {
                       "type": "long"
+                    },
+                    "names": {
+                      "type": "keyword"
                     }
                   }
                 }

--- a/openspec/changes/mapping-summaries/.openspec.yaml
+++ b/openspec/changes/mapping-summaries/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-07

--- a/openspec/changes/mapping-summaries/design.md
+++ b/openspec/changes/mapping-summaries/design.md
@@ -17,7 +17,7 @@ Currently, `esdiag` collects index statistics via the `IndicesStats` processor, 
 
 ## Decisions
 
-- **New `MappingStats` Module**: Create `src/processor/elasticsearch/mapping_stats/` with `data.rs` and `processor.rs`.
+- **New `MappingStats` Module**: Create `src/processor/elasticsearch/mapping_stats/` with `data.rs` and `lookup.rs`.
 - **`DataSource` Implementation**: `MappingStats` will implement `DataSource`, reading from `mapping.json`.
 - **Struct-based Deserialization**: To handle large mapping files efficiently, we will define a set of structs for deserialization instead of using `serde_json::Value`. The deserializer will be configured with `#[serde(flatten)]` or `#[serde(other)]` where appropriate, or simply by not defining fields we don't need (permissive parsing).
 - **Mappings Data Model**:

--- a/openspec/changes/mapping-summaries/design.md
+++ b/openspec/changes/mapping-summaries/design.md
@@ -55,6 +55,7 @@ pub struct MappingSummary {
 }
 pub struct MultiFieldSummary {
     pub total: u64,
+    pub names: Vec<String>,
 }
 
 pub struct FieldSummary {

--- a/openspec/changes/mapping-summaries/design.md
+++ b/openspec/changes/mapping-summaries/design.md
@@ -1,0 +1,97 @@
+## Context
+
+Currently, `esdiag` collects index statistics via the `IndicesStats` processor, but it does not include information about the index mappings. Analyzing mappings is crucial for understanding the data structure and field type distribution, which helps in identifying mapping explosions or inefficient field usage.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Implement a `MappingStats` processor to parse `mapping.json`.
+- Summarize field types (counts per type) for each index.
+- Extract `dynamic` and `_meta` from mappings.
+- Enrich `IndexStatsDocument` with this summarized mapping data.
+- Ensure the summarization logic is efficient and handles nested fields/multi-fields.
+
+**Non-Goals:**
+- Importing the full mapping JSON into Elasticsearch.
+- Supporting complex mapping features like `runtime` fields or `transform` in the summary.
+
+## Decisions
+
+- **New `MappingStats` Module**: Create `src/processor/elasticsearch/mapping_stats/` with `data.rs` and `processor.rs`.
+- **`DataSource` Implementation**: `MappingStats` will implement `DataSource`, reading from `mapping.json`.
+- **Struct-based Deserialization**: To handle large mapping files efficiently, we will define a set of structs for deserialization instead of using `serde_json::Value`. The deserializer will be configured with `#[serde(flatten)]` or `#[serde(other)]` where appropriate, or simply by not defining fields we don't need (permissive parsing).
+- **Mappings Data Model**:
+  ```rust
+  struct MappingFile(HashMap<String, IndexMapping>);
+struct IndexMapping { mappings: Mappings }
+struct Mappings { 
+    dynamic: Option<serde_json::Value>, 
+    date_detection: Option<bool>,
+    numeric_detection: Option<bool>,
+    dynamic_date_formats: Option<Vec<String>>,
+    dynamic_templates: Option<Vec<serde_json::Value>>,
+    _data_stream_timestamp: Option<DataStreamTimestamp>,
+    _source: Option<SourceMode>,
+    _meta: Option<serde_json::Value>, 
+    properties: Option<HashMap<String, FieldDefinition>> 
+}
+struct SourceMode {
+    mode: Option<String>,
+}
+...
+pub struct MappingSummary {
+    pub dynamic: Option<serde_json::Value>,
+    pub date_detection: Option<bool>,
+    pub numeric_detection: Option<bool>,
+    pub dynamic_date_formats: Option<Vec<String>>,
+    pub dynamic_templates: Option<u32>,
+    pub _data_stream_timestamp: Option<DataStreamTimestamp>,
+    pub _source: Option<SourceMode>,
+    pub _meta: Option<serde_json::Value>,
+    pub field: FieldSummary,
+}
+pub struct FieldSummary {
+    pub fields: HashMap<String, u64>, // Renamed from count, includes "total"
+}
+
+struct DataStreamTimestamp {
+    enabled: bool,
+}
+#[derive(Deserialize)]
+...
+pub struct MappingSummary {
+    pub dynamic: Option<serde_json::Value>,
+    pub dynamic_date_formats: Option<Vec<String>>,
+    pub dynamic_templates: Option<u32>,
+    pub _data_stream_timestamp: Option<DataStreamTimestamp>,
+    pub _meta: Option<serde_json::Value>,
+    pub field: FieldSummary,
+}
+pub struct FieldSummary {
+    pub count: HashMap<String, u64>, // Includes "total" and type counts
+}
+
+  #[derive(Deserialize)]
+  #[serde(rename_all = "snake_case")]
+  struct FieldDefinition {
+      #[serde(rename = "type")]
+      field_type: Option<String>,
+      properties: Option<HashMap<String, FieldDefinition>>,
+      fields: Option<HashMap<String, FieldDefinition>>,
+      #[serde(flatten)]
+      _extra: HashMap<String, serde_json::Value>, // Permissive parsing
+  }
+  ```
+- **`Lookups` Integration**: Add `mapping_stats: Lookup<MappingSummary>` to the `Lookups` struct in `src/processor/elasticsearch/mod.rs`.
+- **Recursive Summarization**: Use a recursive function to traverse the `FieldDefinition` tree and increment counters for each field type.
+  - Multi-fields (`fields` property) will be counted as additional fields.
+  - Nested objects will be traversed via their `properties`.
+- **Enrichment in `IndicesStats`**: Update `EnrichedIndexStatsWithSettings` to include a `mappings: Option<MappingSummary>` field. The `IndicesStats::documents_export` method will perform the lookup by index name.
+
+## Risks / Trade-offs
+
+- **[Risk] Large Mapping Files** → Large `mapping.json` files could consume significant memory during parsing.
+  - *Mitigation*: The summary itself is compact. We will parse and summarize, then drop the full mapping representation.
+- **[Risk] Complex Mapping Structures** → Deeply nested or unusual mappings might cause recursion issues or inaccurate counts.
+  - *Mitigation*: Use a depth limit or iterative approach if necessary, though typical mappings should be fine with recursion. Multi-fields will be treated as separate fields to accurately reflect the indexing overhead.
+- **[Trade-off] Multi-fields Counting** → We will count each multi-field as a separate instance of its type. This accurately reflects the number of fields Elasticsearch has to index.

--- a/openspec/changes/mapping-summaries/design.md
+++ b/openspec/changes/mapping-summaries/design.md
@@ -23,59 +23,30 @@ Currently, `esdiag` collects index statistics via the `IndicesStats` processor, 
 - **Mappings Data Model**:
   ```rust
   struct MappingFile(HashMap<String, IndexMapping>);
-struct IndexMapping { mappings: Mappings }
-struct Mappings { 
-    dynamic: Option<serde_json::Value>, 
-    date_detection: Option<bool>,
-    numeric_detection: Option<bool>,
-    dynamic_date_formats: Option<Vec<String>>,
-    dynamic_templates: Option<Vec<serde_json::Value>>,
-    _data_stream_timestamp: Option<DataStreamTimestamp>,
-    _source: Option<SourceMode>,
-    _meta: Option<serde_json::Value>, 
-    properties: Option<HashMap<String, FieldDefinition>> 
-}
-struct SourceMode {
-    mode: Option<String>,
-}
-...
-pub struct MappingSummary {
-    pub dynamic: Option<String>,
-    pub date_detection: Option<bool>,
-    pub numeric_detection: Option<bool>,
-    pub dynamic_date_formats: Option<Vec<String>>,
-    pub dynamic_templates: Option<u32>,
-    pub _data_stream_timestamp: Option<DataStreamTimestamp>,
-    pub _source: Option<SourceMode>,
-    pub _meta: Option<serde_json::Value>,
-    pub fields: HashMap<String, u64>,
-    pub multi_fields: MultiFieldSummary,
-}
-pub struct MultiFieldSummary {
-    pub total: u64,
-    pub names: Vec<String>,
-}
 
-pub struct FieldSummary {
-    pub fields: HashMap<String, u64>, // Renamed from count, includes "total"
-}
+  struct IndexMapping {
+      mappings: Mappings
+  }
 
-struct DataStreamTimestamp {
-    enabled: bool,
-}
-#[derive(Deserialize)]
-...
-pub struct MappingSummary {
-    pub dynamic: Option<serde_json::Value>,
-    pub dynamic_date_formats: Option<Vec<String>>,
-    pub dynamic_templates: Option<u32>,
-    pub _data_stream_timestamp: Option<DataStreamTimestamp>,
-    pub _meta: Option<serde_json::Value>,
-    pub field: FieldSummary,
-}
-pub struct FieldSummary {
-    pub count: HashMap<String, u64>, // Includes "total" and type counts
-}
+  struct Mappings { 
+      dynamic: Option<serde_json::Value>, 
+      date_detection: Option<bool>,
+      numeric_detection: Option<bool>,
+      dynamic_date_formats: Option<Vec<String>>,
+      dynamic_templates: Option<Vec<serde_json::Value>>,
+      _data_stream_timestamp: Option<DataStreamTimestamp>,
+      _source: Option<SourceMode>,
+      _meta: Option<serde_json::Value>, 
+      properties: Option<HashMap<String, FieldDefinition>> 
+  }
+
+  struct DataStreamTimestamp {
+      enabled: bool,
+  }
+
+  struct SourceMode {
+      mode: Option<String>,
+  }
 
   #[derive(Deserialize)]
   #[serde(rename_all = "snake_case")]
@@ -86,6 +57,24 @@ pub struct FieldSummary {
       fields: Option<HashMap<String, FieldDefinition>>,
       #[serde(flatten)]
       _extra: HashMap<String, serde_json::Value>, // Permissive parsing
+  }
+
+  pub struct MappingSummary {
+      pub dynamic: Option<String>,
+      pub date_detection: Option<bool>,
+      pub numeric_detection: Option<bool>,
+      pub dynamic_date_formats: Option<Vec<String>>,
+      pub dynamic_templates: Option<u32>,
+      pub _data_stream_timestamp: Option<DataStreamTimestamp>,
+      pub _source: Option<SourceMode>,
+      pub _meta: Option<serde_json::Value>,
+      pub fields: HashMap<String, u64>, // Maps type name (or "total") to count
+      pub multi_fields: MultiFieldSummary,
+  }
+
+  pub struct MultiFieldSummary {
+      pub total: u64,
+      pub names: Vec<String>,
   }
   ```
 - **`Lookups` Integration**: Add `mapping_stats: Lookup<MappingSummary>` to the `Lookups` struct in `src/processor/elasticsearch/mod.rs`.

--- a/openspec/changes/mapping-summaries/design.md
+++ b/openspec/changes/mapping-summaries/design.md
@@ -48,9 +48,7 @@ pub struct MappingSummary {
     pub _data_stream_timestamp: Option<DataStreamTimestamp>,
     pub _source: Option<SourceMode>,
     pub _meta: Option<serde_json::Value>,
-    #[serde(flatten)]
     pub fields: HashMap<String, u64>,
-    #[serde(rename = "multi-fields")]
     pub multi_fields: MultiFieldSummary,
 }
 pub struct MultiFieldSummary {

--- a/openspec/changes/mapping-summaries/design.md
+++ b/openspec/changes/mapping-summaries/design.md
@@ -40,7 +40,7 @@ struct SourceMode {
 }
 ...
 pub struct MappingSummary {
-    pub dynamic: Option<serde_json::Value>,
+    pub dynamic: Option<String>,
     pub date_detection: Option<bool>,
     pub numeric_detection: Option<bool>,
     pub dynamic_date_formats: Option<Vec<String>>,
@@ -48,8 +48,15 @@ pub struct MappingSummary {
     pub _data_stream_timestamp: Option<DataStreamTimestamp>,
     pub _source: Option<SourceMode>,
     pub _meta: Option<serde_json::Value>,
-    pub field: FieldSummary,
+    #[serde(flatten)]
+    pub fields: HashMap<String, u64>,
+    #[serde(rename = "multi-fields")]
+    pub multi_fields: MultiFieldSummary,
 }
+pub struct MultiFieldSummary {
+    pub total: u64,
+}
+
 pub struct FieldSummary {
     pub fields: HashMap<String, u64>, // Renamed from count, includes "total"
 }

--- a/openspec/changes/mapping-summaries/proposal.md
+++ b/openspec/changes/mapping-summaries/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Bringing in full mapping files to Elasticsearch is inefficient and often unnecessary. However, a summary of field types per index is extremely useful for visualizations and diagnostic analysis, providing a clear breakdown of index structure without the overhead of the full mapping. To ensure efficiency even with large mapping files (thousands of fields), the implementation will use optimized Rust structs for deserialization instead of generic JSON values.
+
+## What Changes
+
+- **New Mapping Processor**: Create a `MappingStats` processor that parses `mapping.json` files from the diagnostic.
+- **Mapping Summarization**: Extract field type counts, `dynamic` setting, `dynamic_date_formats`, `dynamic_templates` count, `_data_stream_timestamp` status, and `_meta` information from mappings.
+- **Indices Stats Enrichment**: Update the `IndicesStats` exporter to perform a lookup against the collected `MappingStats` and include a summarized `mappings` object in the exported documents.
+- **Data Stream Update**: The `mappings` object will be persisted in the `metrics-index-esdiag` data stream.
+
+## Capabilities
+
+### New Capabilities
+- `mapping-summaries`: Defines the logic for parsing `mapping.json`, calculating field type distributions, and enriching index statistics with these summaries.
+
+### Modified Capabilities
+- None: Existing index stats processing remains functionally the same, but will now include enriched data if available.
+
+## Impact
+
+- **Affected Code**: 
+  - `src/processor/elasticsearch/indices_stats/`: Needs enrichment logic.
+  - New module `src/processor/elasticsearch/mapping_stats/`: To handle mapping parsing.
+- **APIs**: No changes to external APIs.
+- **Dependencies**: No new dependencies.

--- a/openspec/changes/mapping-summaries/proposal.md
+++ b/openspec/changes/mapping-summaries/proposal.md
@@ -5,7 +5,7 @@ Bringing in full mapping files to Elasticsearch is inefficient and often unneces
 ## What Changes
 
 - **New Mapping Processor**: Create a `MappingStats` processor that parses `mapping.json` files from the diagnostic.
-- **Mapping Summarization**: Extract field type counts, `dynamic` setting, `dynamic_date_formats`, `dynamic_templates` count, `_data_stream_timestamp` status, and `_meta` information from mappings.
+- **Mapping Summarization**: Extract field type counts, multi-field counts, `dynamic` setting, `dynamic_date_formats`, `dynamic_templates` count, `_data_stream_timestamp` status, and `_meta` information from mappings.
 - **Indices Stats Enrichment**: Update the `IndicesStats` exporter to perform a lookup against the collected `MappingStats` and include a summarized `mappings` object in the exported documents.
 - **Data Stream Update**: The `mappings` object will be persisted in the `metrics-index-esdiag` data stream.
 

--- a/openspec/changes/mapping-summaries/specs/mapping-summaries/spec.md
+++ b/openspec/changes/mapping-summaries/specs/mapping-summaries/spec.md
@@ -12,7 +12,7 @@ The `MappingStats` processor SHALL calculate a summary of field types for each i
 
 #### Scenario: Count field types in a mapping
 - **WHEN** an index mapping is processed with 5 text fields and 10 keyword fields
-- **THEN** the resulting summary SHALL report `total: 15`, `text: 5` and `keyword: 10` under the `field.fields` object
+- **THEN** the resulting summary SHALL report `total: 15`, `text: 5` and `keyword: 10` under the `fields` object
 
 ### Requirement: Index Stats Enrichment
 The `IndicesStats` exporter SHALL enrich its output with the mapping summary obtained from `MappingStats`.
@@ -20,4 +20,11 @@ The `IndicesStats` exporter SHALL enrich its output with the mapping summary obt
 #### Scenario: Enrich index stats with mapping summary
 - **WHEN** index statistics are being exported for an index named "logs-001"
 - **AND** a mapping summary exists for "logs-001"
-- **THEN** the exported document SHALL include a `mappings` object containing the summarized field counts, `dynamic` setting, and `_meta` information
+- **THEN** the exported document SHALL include a `mappings` object containing the summarized field counts, multi-field counts, `dynamic` setting, and `_meta` information
+
+### Requirement: Multi-Field Counting
+The `MappingStats` processor SHALL count the number of fields that have one or more multi-fields defined.
+
+#### Scenario: Count multi-fields in a mapping
+- **WHEN** an index mapping is processed with 3 fields, one of which has a `fields` property
+- **THEN** the resulting summary SHALL report `total: 1` under the `multi-fields` object

--- a/openspec/changes/mapping-summaries/specs/mapping-summaries/spec.md
+++ b/openspec/changes/mapping-summaries/specs/mapping-summaries/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Mapping Statistics Processing
+The system SHALL provide a `MappingStats` processor capable of reading index mapping files (e.g., `mapping.json`) and extracting structural metadata. The implementation SHALL use optimized data structures to minimize memory overhead when processing large mapping files.
+
+#### Scenario: Successfully parse mapping file
+- **WHEN** a mapping file containing index definitions is processed
+- **THEN** the system SHALL extract the `dynamic` setting, `dynamic_date_formats`, `dynamic_templates` count, `_data_stream_timestamp` status, and `_meta` object for each index
+
+### Requirement: Field Type Summarization
+The `MappingStats` processor SHALL calculate a summary of field types for each index, grouped under a `fields` object.
+
+#### Scenario: Count field types in a mapping
+- **WHEN** an index mapping is processed with 5 text fields and 10 keyword fields
+- **THEN** the resulting summary SHALL report `total: 15`, `text: 5` and `keyword: 10` under the `field.fields` object
+
+### Requirement: Index Stats Enrichment
+The `IndicesStats` exporter SHALL enrich its output with the mapping summary obtained from `MappingStats`.
+
+#### Scenario: Enrich index stats with mapping summary
+- **WHEN** index statistics are being exported for an index named "logs-001"
+- **AND** a mapping summary exists for "logs-001"
+- **THEN** the exported document SHALL include a `mappings` object containing the summarized field counts, `dynamic` setting, and `_meta` information

--- a/openspec/changes/mapping-summaries/tasks.md
+++ b/openspec/changes/mapping-summaries/tasks.md
@@ -38,3 +38,10 @@
 - [x] 6.3 Update summarization logic for new fields and renamed map
 - [x] 6.4 Update unit tests for final refinements
 - [x] 6.5 Update Elasticsearch index template `assets/elasticsearch/index_templates/metrics-index.json` for final refinements
+
+## 7. Multi-Field Counting
+
+- [x] 7.1 Update `MappingSummary` to include `multi_fields`
+- [x] 7.2 Implement multi-field counting logic in `FieldDefinition::summarize`
+- [x] 7.3 Update Elasticsearch index template with `multi-fields` mapping
+- [x] 7.4 Update unit tests for multi-field counting

--- a/openspec/changes/mapping-summaries/tasks.md
+++ b/openspec/changes/mapping-summaries/tasks.md
@@ -1,0 +1,40 @@
+## 1. Mapping Stats Processor
+
+- [x] 1.1 Create `src/processor/elasticsearch/mapping_stats/data.rs` with `MappingStats`, `MappingSummary`, and optimized `Mapping` structs for permissive deserialization
+- [x] 1.2 Implement `DataSource` for `MappingStats` to parse `mapping.json` using the new structs
+- [x] 1.3 Implement recursive summarization logic to count field types from the `FieldDefinition` tree
+- [x] 1.4 Implement `MappingStats::process` to generate the lookup map
+
+## 2. Integration and Lookups
+
+- [x] 2.1 Add `mapping_stats: Lookup<MappingSummary>` to `Lookups` struct in `src/processor/elasticsearch/mod.rs`
+- [x] 2.2 Update `Elasticsearch::process` in `src/processor/elasticsearch/mod.rs` to initialize the `mapping_stats` lookup
+- [x] 2.3 Register `MappingStats` in `src/processor/elasticsearch/collector.rs`
+
+## 3. Indices Stats Enrichment
+
+- [x] 3.1 Update `EnrichedIndexStatsWithSettings` in `src/processor/elasticsearch/indices_stats/processor.rs` to include a `mappings` field
+- [x] 3.2 Update `EnrichedIndexStats::with_settings` in `src/processor/elasticsearch/indices_stats/processor.rs` to accept and populate the `mappings` field
+- [x] 3.3 Update `IndicesStats::documents_export` in `src/processor/elasticsearch/indices_stats/processor.rs` to perform the lookup and pass it to `with_settings`
+
+## 4. Verification
+
+- [x] 4.1 Run `cargo clippy` to ensure code quality
+- [x] 4.2 Run `cargo test` to verify the implementation
+- [x] 4.3 Add a unit test for the mapping summarization logic in `src/processor/elasticsearch/mapping_stats/data.rs`
+
+## 5. Refinements
+
+- [x] 5.1 Update `MappingStats` structs to include `dynamic_date_formats`, `dynamic_templates`, and `_data_stream_timestamp`
+- [x] 5.2 Refactor `FieldSummary` to use a single `count` map for total and type counts
+- [x] 5.3 Update summarization logic to populate the new fields
+- [x] 5.4 Update Elasticsearch index template `assets/elasticsearch/index_templates/metrics-index.json`
+- [x] 5.5 Update unit tests for refinements
+
+## 6. Final Refinements
+
+- [x] 6.1 Add `date_detection`, `numeric_detection`, and `_source` (mode) to `MappingStats` structs
+- [x] 6.2 Rename `FieldSummary::count` to `FieldSummary::fields`
+- [x] 6.3 Update summarization logic for new fields and renamed map
+- [x] 6.4 Update unit tests for final refinements
+- [x] 6.5 Update Elasticsearch index template `assets/elasticsearch/index_templates/metrics-index.json` for final refinements

--- a/openspec/specs/mapping-summaries/spec.md
+++ b/openspec/specs/mapping-summaries/spec.md
@@ -1,0 +1,28 @@
+# Mapping Summaries
+
+## Purpose
+Provide concise summaries of index mappings (field type counts, settings, and metadata) to enrich index statistics without importing full mapping files. This enables efficient diagnostic analysis and visualization of index structures.
+
+## Requirements
+
+### Requirement: Mapping Statistics Processing
+The system SHALL provide a `MappingStats` processor capable of reading index mapping files (e.g., `mapping.json`) and extracting structural metadata. The implementation SHALL use optimized data structures to minimize memory overhead when processing large mapping files.
+
+#### Scenario: Successfully parse mapping file
+- **WHEN** a mapping file containing index definitions is processed
+- **THEN** the system SHALL extract the `dynamic` setting, `dynamic_date_formats`, `dynamic_templates` count, `_data_stream_timestamp` status, and `_meta` object for each index
+
+### Requirement: Field Type Summarization
+The `MappingStats` processor SHALL calculate a summary of field types for each index, grouped under a `fields` object.
+
+#### Scenario: Count field types in a mapping
+- **WHEN** an index mapping is processed with 5 text fields and 10 keyword fields
+- **THEN** the resulting summary SHALL report `total: 15`, `text: 5` and `keyword: 10` under the `field.fields` object
+
+### Requirement: Index Stats Enrichment
+The `IndicesStats` exporter SHALL enrich its output with the mapping summary obtained from `MappingStats`.
+
+#### Scenario: Enrich index stats with mapping summary
+- **WHEN** index statistics are being exported for an index named "logs-001"
+- **AND** a mapping summary exists for "logs-001"
+- **THEN** the exported document SHALL include a `mappings` object containing the summarized field counts, `dynamic` setting, and `_meta` information

--- a/openspec/specs/mapping-summaries/spec.md
+++ b/openspec/specs/mapping-summaries/spec.md
@@ -17,7 +17,7 @@ The `MappingStats` processor SHALL calculate a summary of field types for each i
 
 #### Scenario: Count field types in a mapping
 - **WHEN** an index mapping is processed with 5 text fields and 10 keyword fields
-- **THEN** the resulting summary SHALL report `total: 15`, `text: 5` and `keyword: 10` under the `field.fields` object
+- **THEN** the resulting summary SHALL report `total: 15`, `text: 5` and `keyword: 10` under the `fields` object
 
 ### Requirement: Index Stats Enrichment
 The `IndicesStats` exporter SHALL enrich its output with the mapping summary obtained from `MappingStats`.
@@ -25,4 +25,11 @@ The `IndicesStats` exporter SHALL enrich its output with the mapping summary obt
 #### Scenario: Enrich index stats with mapping summary
 - **WHEN** index statistics are being exported for an index named "logs-001"
 - **AND** a mapping summary exists for "logs-001"
-- **THEN** the exported document SHALL include a `mappings` object containing the summarized field counts, `dynamic` setting, and `_meta` information
+- **THEN** the exported document SHALL include a `mappings` object containing the summarized field counts, multi-field counts, `dynamic` setting, and `_meta` information
+
+### Requirement: Multi-Field Counting
+The `MappingStats` processor SHALL count the number of fields that have one or more multi-fields defined.
+
+#### Scenario: Count multi-fields in a mapping
+- **WHEN** an index mapping is processed with 3 fields, one of which has a `fields` property
+- **THEN** the resulting summary SHALL report `total: 1` under the `multi-fields` object

--- a/openspec/specs/mapping-summaries/spec.md
+++ b/openspec/specs/mapping-summaries/spec.md
@@ -28,8 +28,8 @@ The `IndicesStats` exporter SHALL enrich its output with the mapping summary obt
 - **THEN** the exported document SHALL include a `mappings` object containing the summarized field counts, multi-field counts, `dynamic` setting, and `_meta` information
 
 ### Requirement: Multi-Field Counting
-The `MappingStats` processor SHALL count the number of fields that have one or more multi-fields defined.
+The `MappingStats` processor SHALL count the number of fields that have one or more multi-fields defined, and collect their names.
 
 #### Scenario: Count multi-fields in a mapping
-- **WHEN** an index mapping is processed with 3 fields, one of which has a `fields` property
-- **THEN** the resulting summary SHALL report `total: 1` under the `multi-fields` object
+- **WHEN** an index mapping is processed with 3 fields, one of which named "message" has a `fields` property
+- **THEN** the resulting summary SHALL report `total: 1` and `names: ["message"]` under the `multi-fields` object

--- a/src/processor/elasticsearch/collector.rs
+++ b/src/processor/elasticsearch/collector.rs
@@ -5,7 +5,7 @@
 use super::super::{collector::CollectionResult, diagnostic::PathType};
 use super::{
     AliasList, Cluster, ClusterSettings, DataSource, DataStreams, DiagnosticManifest, HealthReport,
-    IlmExplain, IlmPolicies, IndicesSettings, IndicesStats, Licenses, Nodes, NodesStats,
+    IlmExplain, IlmPolicies, IndicesSettings, IndicesStats, Licenses, MappingStats, Nodes, NodesStats,
     PendingTasks, SearchableSnapshotsCacheStats, SearchableSnapshotsStats, SlmPolicies, Tasks,
 };
 use crate::{data::Product, exporter::DirectoryExporter, receiver::Receiver};
@@ -31,7 +31,7 @@ impl ElasticsearchCollector {
         let mut result = CollectionResult {
             path: self.exporter.to_string().clone(),
             success: 0,
-            total: 18,
+            total: 19,
         };
 
         result.success += self.save_diagnostic_manifest().await?;
@@ -45,6 +45,7 @@ impl ElasticsearchCollector {
         result.success += self.save::<IndicesSettings>().await?;
         result.success += self.save::<IndicesStats>().await?;
         result.success += self.save::<Licenses>().await?;
+        result.success += self.save::<MappingStats>().await?;
         result.success += self.save::<Nodes>().await?;
         result.success += self.save::<NodesStats>().await?;
         result.success += self.save::<PendingTasks>().await?;

--- a/src/processor/elasticsearch/indices_stats/processor.rs
+++ b/src/processor/elasticsearch/indices_stats/processor.rs
@@ -8,6 +8,7 @@ use super::super::{
     alias::Alias,
     data_stream::DataStreamDocument,
     indices_settings::{IndexSettingsDocument, StoreSettings},
+    mapping_stats::MappingSummary,
     metadata::MetadataDoc,
     nodes::NodeDocument,
 };
@@ -74,7 +75,10 @@ impl DocumentExporter<Lookups, ElasticsearchMetadata> for IndicesStats {
                     let stats = enriched_stats
                         .name(index_name.clone())
                         .alias(lookups.alias.by_name(&index_name).cloned())
-                        .with_settings(index_settings.clone());
+                        .with_settings(
+                            index_settings.clone(),
+                            lookups.mapping_stats.by_name(&index_name).cloned(),
+                        );
                     let index_document =
                         IndexStatsDocument::new(stats, index_metadata.clone()).calculate();
                     let write_phase_sec = index_document.index.write_phase_sec;
@@ -320,6 +324,7 @@ struct EnrichedIndexStatsWithSettings {
     pub ilm: Option<IlmStats>,
     pub is_write_index: bool,
     pub lifecycle: Option<serde_json::Value>,
+    pub mappings: Option<MappingSummary>,
     pub mode: Option<String>,
     pub name: Option<String>,
     pub number_of_replicas: Option<u64>,
@@ -349,6 +354,7 @@ impl EnrichedIndexStats {
     fn with_settings(
         self,
         settings: Option<IndexSettingsDocument>,
+        mappings: Option<MappingSummary>,
     ) -> EnrichedIndexStatsWithSettings {
         match settings {
             Some(settings) => EnrichedIndexStatsWithSettings {
@@ -361,6 +367,7 @@ impl EnrichedIndexStats {
                 ilm: settings.ilm,
                 is_write_index: settings.is_write_index.unwrap_or(false),
                 lifecycle: settings.lifecycle,
+                mappings,
                 mode: Some(settings.mode),
                 name: Some(settings.name),
                 number_of_replicas: settings.number_of_replicas,
@@ -384,6 +391,7 @@ impl EnrichedIndexStats {
                 ilm: None,
                 is_write_index: true,
                 lifecycle: None,
+                mappings,
                 mode: None,
                 name: self.name,
                 number_of_replicas: None,

--- a/src/processor/elasticsearch/mapping_stats/data.rs
+++ b/src/processor/elasticsearch/mapping_stats/data.rs
@@ -65,7 +65,6 @@ pub struct MappingSummary {
     pub _data_stream_timestamp: Option<DataStreamTimestamp>,
     pub _source: Option<SourceMode>,
     pub _meta: Option<serde_json::Value>,
-    #[serde(flatten)]
     pub fields: HashMap<String, u64>,
     #[serde(rename = "multi-fields")]
     pub multi_fields: MultiFieldSummary,

--- a/src/processor/elasticsearch/mapping_stats/data.rs
+++ b/src/processor/elasticsearch/mapping_stats/data.rs
@@ -73,6 +73,7 @@ pub struct MappingSummary {
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct MultiFieldSummary {
     pub total: u64,
+    pub names: Vec<String>,
 }
 
 impl MappingStats {
@@ -107,8 +108,8 @@ impl IndexMapping {
         };
 
         if let Some(properties) = &self.mappings.properties {
-            for field in properties.values() {
-                field.summarize(&mut summary.fields, &mut summary.multi_fields);
+            for (name, field) in properties {
+                field.summarize(name, &mut summary.fields, &mut summary.multi_fields);
             }
         }
 
@@ -119,6 +120,7 @@ impl IndexMapping {
 impl FieldDefinition {
     pub fn summarize(
         &self,
+        name: &str,
         fields: &mut HashMap<String, u64>,
         multi_fields: &mut MultiFieldSummary,
     ) {
@@ -140,6 +142,7 @@ impl FieldDefinition {
             // Check if it's a multi-field mapping (has type AND fields)
             if self.fields.is_some() {
                 multi_fields.total += 1;
+                multi_fields.names.push(name.to_string());
             }
         } else if self.properties.is_some() {
             // It's likely an 'object' or 'nested' type without explicit 'type' field
@@ -151,14 +154,16 @@ impl FieldDefinition {
         }
 
         if let Some(properties) = &self.properties {
-            for field in properties.values() {
-                field.summarize(fields, multi_fields);
+            for (sub_name, field) in properties {
+                let full_name = format!("{}.{}", name, sub_name);
+                field.summarize(&full_name, fields, multi_fields);
             }
         }
 
         if let Some(fields_map) = &self.fields {
-            for field in fields_map.values() {
-                field.summarize(fields, multi_fields);
+            for (sub_name, field) in fields_map {
+                let full_name = format!("{}.{}", name, sub_name);
+                field.summarize(&full_name, fields, multi_fields);
             }
         }
     }
@@ -229,6 +234,7 @@ mod tests {
         assert_eq!(summary.fields.get("long").unwrap(), &1);
         assert_eq!(summary.fields.get("object").unwrap(), &1);
         assert_eq!(summary.multi_fields.total, 0);
+        assert!(summary.multi_fields.names.is_empty());
     }
 
     #[test]
@@ -256,5 +262,6 @@ mod tests {
         assert_eq!(summary.fields.get("text").unwrap(), &1);
         assert_eq!(summary.fields.get("keyword").unwrap(), &1);
         assert_eq!(summary.multi_fields.total, 1); // field1 is a multi-field
+        assert_eq!(summary.multi_fields.names, vec!["field1".to_string()]);
     }
 }

--- a/src/processor/elasticsearch/mapping_stats/data.rs
+++ b/src/processor/elasticsearch/mapping_stats/data.rs
@@ -1,0 +1,231 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+use crate::processor::diagnostic::PathType;
+use crate::processor::elasticsearch::DataSource;
+use eyre::Result;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use std::collections::HashMap;
+
+#[derive(Default, Deserialize, Serialize)]
+pub struct MappingStats {
+    #[serde(flatten)]
+    pub indices: HashMap<String, IndexMapping>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct IndexMapping {
+    pub mappings: Mappings,
+}
+
+#[skip_serializing_none]
+#[derive(Deserialize, Serialize)]
+pub struct Mappings {
+    pub dynamic: Option<serde_json::Value>,
+    pub date_detection: Option<bool>,
+    pub numeric_detection: Option<bool>,
+    pub dynamic_date_formats: Option<Vec<String>>,
+    pub dynamic_templates: Option<Vec<serde_json::Value>>,
+    pub _data_stream_timestamp: Option<DataStreamTimestamp>,
+    pub _source: Option<SourceMode>,
+    pub _meta: Option<serde_json::Value>,
+    pub properties: Option<HashMap<String, FieldDefinition>>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct DataStreamTimestamp {
+    pub enabled: bool,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Deserialize, Serialize)]
+pub struct SourceMode {
+    pub mode: Option<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Deserialize, Serialize)]
+pub struct FieldDefinition {
+    #[serde(rename = "type")]
+    pub field_type: Option<String>,
+    pub properties: Option<HashMap<String, FieldDefinition>>,
+    pub fields: Option<HashMap<String, FieldDefinition>>,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Default, Deserialize, Serialize)]
+pub struct MappingSummary {
+    pub dynamic: Option<serde_json::Value>,
+    pub date_detection: Option<bool>,
+    pub numeric_detection: Option<bool>,
+    pub dynamic_date_formats: Option<Vec<String>>,
+    pub dynamic_templates: Option<u32>,
+    pub _data_stream_timestamp: Option<DataStreamTimestamp>,
+    pub _source: Option<SourceMode>,
+    pub _meta: Option<serde_json::Value>,
+    pub field: FieldSummary,
+}
+
+#[derive(Clone, Default, Deserialize, Serialize)]
+pub struct FieldSummary {
+    pub fields: HashMap<String, u64>,
+}
+
+impl MappingStats {
+    pub fn summaries(&self) -> HashMap<String, MappingSummary> {
+        self.indices
+            .iter()
+            .map(|(name, index_mapping)| (name.clone(), index_mapping.summarize()))
+            .collect()
+    }
+}
+
+impl IndexMapping {
+    pub fn summarize(&self) -> MappingSummary {
+        let mut summary = MappingSummary {
+            dynamic: self.mappings.dynamic.clone(),
+            date_detection: self.mappings.date_detection,
+            numeric_detection: self.mappings.numeric_detection,
+            dynamic_date_formats: self.mappings.dynamic_date_formats.clone(),
+            dynamic_templates: self
+                .mappings
+                .dynamic_templates
+                .as_ref()
+                .map(|t| t.len() as u32),
+            _data_stream_timestamp: self.mappings._data_stream_timestamp.clone(),
+            _source: self.mappings._source.clone(),
+            _meta: self.mappings._meta.clone(),
+            ..Default::default()
+        };
+
+        if let Some(properties) = &self.mappings.properties {
+            for field in properties.values() {
+                field.summarize(&mut summary.field);
+            }
+        }
+
+        summary
+    }
+}
+
+impl FieldDefinition {
+    pub fn summarize(&self, summary: &mut FieldSummary) {
+        *summary.fields.entry("total".to_string()).or_insert(0) += 1;
+        if let Some(field_type) = &self.field_type {
+            *summary.fields.entry(field_type.clone()).or_insert(0) += 1;
+        } else if self.properties.is_some() {
+            // It's likely an 'object' or 'nested' type without explicit 'type' field
+            *summary.fields.entry("object".to_string()).or_insert(0) += 1;
+        }
+
+        if let Some(properties) = &self.properties {
+            for field in properties.values() {
+                field.summarize(summary);
+            }
+        }
+
+        if let Some(fields) = &self.fields {
+            for field in fields.values() {
+                field.summarize(summary);
+            }
+        }
+    }
+}
+
+impl DataSource for MappingStats {
+    fn source(path: PathType) -> Result<&'static str> {
+        match path {
+            PathType::File => Ok("mapping.json"),
+            PathType::Url => Ok("_mapping"),
+        }
+    }
+
+    fn name() -> String {
+        "mapping".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_summarize_mapping() {
+        let json = r#"{
+            "test_index": {
+                "mappings": {
+                    "dynamic": "strict",
+                    "date_detection": false,
+                    "numeric_detection": true,
+                    "dynamic_date_formats": ["yyyy-MM-dd"],
+                    "dynamic_templates": [{}, {}],
+                    "_data_stream_timestamp": { "enabled": true },
+                    "_source": { "mode": "synthetic" },
+                    "properties": {
+                        "field1": { "type": "text" },
+                        "field2": { "type": "keyword" },
+                        "object1": {
+                            "properties": {
+                                "subfield1": { "type": "long" }
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let stats: MappingStats = serde_json::from_str(json).unwrap();
+        let summaries = stats.summaries();
+        let summary = summaries.get("test_index").unwrap();
+
+        assert_eq!(
+            summary.dynamic,
+            Some(serde_json::Value::String("strict".to_string()))
+        );
+        assert_eq!(summary.date_detection, Some(false));
+        assert_eq!(summary.numeric_detection, Some(true));
+        assert_eq!(
+            summary.dynamic_date_formats,
+            Some(vec!["yyyy-MM-dd".to_string()])
+        );
+        assert_eq!(summary.dynamic_templates, Some(2));
+        assert!(summary._data_stream_timestamp.as_ref().unwrap().enabled);
+        assert_eq!(
+            summary._source.as_ref().unwrap().mode,
+            Some("synthetic".to_string())
+        );
+        assert_eq!(summary.field.fields.get("total").unwrap(), &4); // field1, field2, object1, subfield1
+        assert_eq!(summary.field.fields.get("text").unwrap(), &1);
+        assert_eq!(summary.field.fields.get("keyword").unwrap(), &1);
+        assert_eq!(summary.field.fields.get("long").unwrap(), &1);
+        assert_eq!(summary.field.fields.get("object").unwrap(), &1);
+    }
+
+    #[test]
+    fn test_summarize_multi_fields() {
+        let json = r#"{
+            "test_index": {
+                "mappings": {
+                    "properties": {
+                        "field1": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": { "type": "keyword" }
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let stats: MappingStats = serde_json::from_str(json).unwrap();
+        let summaries = stats.summaries();
+        let summary = summaries.get("test_index").unwrap();
+
+        assert_eq!(summary.field.fields.get("total").unwrap(), &2); // field1, field1.keyword
+        assert_eq!(summary.field.fields.get("text").unwrap(), &1);
+        assert_eq!(summary.field.fields.get("keyword").unwrap(), &1);
+    }
+}

--- a/src/processor/elasticsearch/mapping_stats/data.rs
+++ b/src/processor/elasticsearch/mapping_stats/data.rs
@@ -57,7 +57,7 @@ pub struct FieldDefinition {
 #[skip_serializing_none]
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct MappingSummary {
-    pub dynamic: Option<serde_json::Value>,
+    pub dynamic: Option<String>,
     pub date_detection: Option<bool>,
     pub numeric_detection: Option<bool>,
     pub dynamic_date_formats: Option<Vec<String>>,
@@ -85,7 +85,11 @@ impl MappingStats {
 impl IndexMapping {
     pub fn summarize(&self) -> MappingSummary {
         let mut summary = MappingSummary {
-            dynamic: self.mappings.dynamic.clone(),
+            dynamic: self.mappings.dynamic.as_ref().map(|v| match v {
+                serde_json::Value::Bool(b) => b.to_string(),
+                serde_json::Value::String(s) => s.clone(),
+                _ => v.to_string(),
+            }),
             date_detection: self.mappings.date_detection,
             numeric_detection: self.mappings.numeric_detection,
             dynamic_date_formats: self.mappings.dynamic_date_formats.clone(),
@@ -112,12 +116,27 @@ impl IndexMapping {
 
 impl FieldDefinition {
     pub fn summarize(&self, summary: &mut FieldSummary) {
-        *summary.fields.entry("total".to_string()).or_insert(0) += 1;
+        // Increment total count, avoiding repeated String allocation
+        if let Some(count) = summary.fields.get_mut("total") {
+            *count += 1;
+        } else {
+            summary.fields.insert("total".to_string(), 1);
+        }
+
         if let Some(field_type) = &self.field_type {
-            *summary.fields.entry(field_type.clone()).or_insert(0) += 1;
+            // Increment count for this field type, cloning only on first insert
+            if let Some(count) = summary.fields.get_mut(field_type) {
+                *count += 1;
+            } else {
+                summary.fields.insert(field_type.clone(), 1);
+            }
         } else if self.properties.is_some() {
             // It's likely an 'object' or 'nested' type without explicit 'type' field
-            *summary.fields.entry("object".to_string()).or_insert(0) += 1;
+            if let Some(count) = summary.fields.get_mut("object") {
+                *count += 1;
+            } else {
+                summary.fields.insert("object".to_string(), 1);
+            }
         }
 
         if let Some(properties) = &self.properties {
@@ -180,10 +199,7 @@ mod tests {
         let summaries = stats.summaries();
         let summary = summaries.get("test_index").unwrap();
 
-        assert_eq!(
-            summary.dynamic,
-            Some(serde_json::Value::String("strict".to_string()))
-        );
+        assert_eq!(summary.dynamic, Some("strict".to_string()));
         assert_eq!(summary.date_detection, Some(false));
         assert_eq!(summary.numeric_detection, Some(true));
         assert_eq!(

--- a/src/processor/elasticsearch/mapping_stats/data.rs
+++ b/src/processor/elasticsearch/mapping_stats/data.rs
@@ -65,11 +65,7 @@ pub struct MappingSummary {
     pub _data_stream_timestamp: Option<DataStreamTimestamp>,
     pub _source: Option<SourceMode>,
     pub _meta: Option<serde_json::Value>,
-    pub field: FieldSummary,
-}
-
-#[derive(Clone, Default, Deserialize, Serialize)]
-pub struct FieldSummary {
+    #[serde(flatten)]
     pub fields: HashMap<String, u64>,
 }
 
@@ -106,7 +102,7 @@ impl IndexMapping {
 
         if let Some(properties) = &self.mappings.properties {
             for field in properties.values() {
-                field.summarize(&mut summary.field);
+                field.summarize(&mut summary.fields);
             }
         }
 
@@ -115,39 +111,39 @@ impl IndexMapping {
 }
 
 impl FieldDefinition {
-    pub fn summarize(&self, summary: &mut FieldSummary) {
+    pub fn summarize(&self, fields: &mut HashMap<String, u64>) {
         // Increment total count, avoiding repeated String allocation
-        if let Some(count) = summary.fields.get_mut("total") {
+        if let Some(count) = fields.get_mut("total") {
             *count += 1;
         } else {
-            summary.fields.insert("total".to_string(), 1);
+            fields.insert("total".to_string(), 1);
         }
 
         if let Some(field_type) = &self.field_type {
             // Increment count for this field type, cloning only on first insert
-            if let Some(count) = summary.fields.get_mut(field_type) {
+            if let Some(count) = fields.get_mut(field_type) {
                 *count += 1;
             } else {
-                summary.fields.insert(field_type.clone(), 1);
+                fields.insert(field_type.clone(), 1);
             }
         } else if self.properties.is_some() {
             // It's likely an 'object' or 'nested' type without explicit 'type' field
-            if let Some(count) = summary.fields.get_mut("object") {
+            if let Some(count) = fields.get_mut("object") {
                 *count += 1;
             } else {
-                summary.fields.insert("object".to_string(), 1);
+                fields.insert("object".to_string(), 1);
             }
         }
 
         if let Some(properties) = &self.properties {
             for field in properties.values() {
-                field.summarize(summary);
+                field.summarize(fields);
             }
         }
 
-        if let Some(fields) = &self.fields {
-            for field in fields.values() {
-                field.summarize(summary);
+        if let Some(fields_map) = &self.fields {
+            for field in fields_map.values() {
+                field.summarize(fields);
             }
         }
     }
@@ -212,11 +208,11 @@ mod tests {
             summary._source.as_ref().unwrap().mode,
             Some("synthetic".to_string())
         );
-        assert_eq!(summary.field.fields.get("total").unwrap(), &4); // field1, field2, object1, subfield1
-        assert_eq!(summary.field.fields.get("text").unwrap(), &1);
-        assert_eq!(summary.field.fields.get("keyword").unwrap(), &1);
-        assert_eq!(summary.field.fields.get("long").unwrap(), &1);
-        assert_eq!(summary.field.fields.get("object").unwrap(), &1);
+        assert_eq!(summary.fields.get("total").unwrap(), &4); // field1, field2, object1, subfield1
+        assert_eq!(summary.fields.get("text").unwrap(), &1);
+        assert_eq!(summary.fields.get("keyword").unwrap(), &1);
+        assert_eq!(summary.fields.get("long").unwrap(), &1);
+        assert_eq!(summary.fields.get("object").unwrap(), &1);
     }
 
     #[test]
@@ -240,8 +236,8 @@ mod tests {
         let summaries = stats.summaries();
         let summary = summaries.get("test_index").unwrap();
 
-        assert_eq!(summary.field.fields.get("total").unwrap(), &2); // field1, field1.keyword
-        assert_eq!(summary.field.fields.get("text").unwrap(), &1);
-        assert_eq!(summary.field.fields.get("keyword").unwrap(), &1);
+        assert_eq!(summary.fields.get("total").unwrap(), &2); // field1, field1.keyword
+        assert_eq!(summary.fields.get("text").unwrap(), &1);
+        assert_eq!(summary.fields.get("keyword").unwrap(), &1);
     }
 }

--- a/src/processor/elasticsearch/mapping_stats/data.rs
+++ b/src/processor/elasticsearch/mapping_stats/data.rs
@@ -138,12 +138,6 @@ impl FieldDefinition {
             } else {
                 fields.insert(field_type.clone(), 1);
             }
-
-            // Check if it's a multi-field mapping (has type AND fields)
-            if self.fields.is_some() {
-                multi_fields.total += 1;
-                multi_fields.names.push(name.to_string());
-            }
         } else if self.properties.is_some() {
             // It's likely an 'object' or 'nested' type without explicit 'type' field
             if let Some(count) = fields.get_mut("object") {
@@ -153,16 +147,30 @@ impl FieldDefinition {
             }
         }
 
+        // Check if it's a multi-field mapping (has fields property)
+        if let Some(fields_map) = &self.fields {
+            if !fields_map.is_empty() {
+                multi_fields.total += 1;
+                multi_fields.names.push(name.to_string());
+            }
+        }
+
         if let Some(properties) = &self.properties {
             for (sub_name, field) in properties {
-                let full_name = format!("{}.{}", name, sub_name);
+                let mut full_name = String::with_capacity(name.len() + 1 + sub_name.len());
+                full_name.push_str(name);
+                full_name.push('.');
+                full_name.push_str(sub_name);
                 field.summarize(&full_name, fields, multi_fields);
             }
         }
 
         if let Some(fields_map) = &self.fields {
             for (sub_name, field) in fields_map {
-                let full_name = format!("{}.{}", name, sub_name);
+                let mut full_name = String::with_capacity(name.len() + 1 + sub_name.len());
+                full_name.push_str(name);
+                full_name.push('.');
+                full_name.push_str(sub_name);
                 field.summarize(&full_name, fields, multi_fields);
             }
         }
@@ -263,5 +271,45 @@ mod tests {
         assert_eq!(summary.fields.get("keyword").unwrap(), &1);
         assert_eq!(summary.multi_fields.total, 1); // field1 is a multi-field
         assert_eq!(summary.multi_fields.names, vec!["field1".to_string()]);
+    }
+
+    #[test]
+    fn test_summarize_edge_cases() {
+        let json = r#"{
+            "test_index": {
+                "mappings": {
+                    "properties": {
+                        "empty_fields": {
+                            "type": "text",
+                            "fields": {}
+                        },
+                        "no_type_with_fields": {
+                            "fields": {
+                                "keyword": { "type": "keyword" }
+                            }
+                        },
+                        "object_with_no_type": {
+                            "properties": {
+                                "sub": { "type": "keyword" }
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let stats: MappingStats = serde_json::from_str(json).unwrap();
+        let summaries = stats.summaries();
+        let summary = summaries.get("test_index").unwrap();
+
+        // empty_fields should NOT count as multi-field because map is empty
+        // no_type_with_fields SHOULD count as multi-field even without explicit 'type' (Elasticsearch default)
+        // object_with_no_type should count as 'object' in fields map
+        assert_eq!(summary.multi_fields.total, 1);
+        assert_eq!(
+            summary.multi_fields.names,
+            vec!["no_type_with_fields".to_string()]
+        );
+        assert_eq!(summary.fields.get("object").unwrap(), &1); // object_with_no_type
     }
 }

--- a/src/processor/elasticsearch/mapping_stats/data.rs
+++ b/src/processor/elasticsearch/mapping_stats/data.rs
@@ -27,11 +27,54 @@ pub struct Mappings {
     pub date_detection: Option<bool>,
     pub numeric_detection: Option<bool>,
     pub dynamic_date_formats: Option<Vec<String>>,
-    pub dynamic_templates: Option<Vec<serde_json::Value>>,
+    #[serde(default, deserialize_with = "count_sequence_elements")]
+    pub dynamic_templates: Option<u32>,
     pub _data_stream_timestamp: Option<DataStreamTimestamp>,
     pub _source: Option<SourceMode>,
     pub _meta: Option<serde_json::Value>,
     pub properties: Option<HashMap<String, FieldDefinition>>,
+}
+
+fn count_sequence_elements<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct SequenceCounter;
+
+    impl<'de> serde::de::Visitor<'de> for SequenceCounter {
+        type Value = Option<u32>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a sequence of objects")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut count = 0;
+            while let Some(serde::de::IgnoredAny) = seq.next_element()? {
+                count += 1;
+            }
+            Ok(Some(count))
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(self)
+        }
+    }
+
+    deserializer.deserialize_option(SequenceCounter)
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -96,11 +139,7 @@ impl IndexMapping {
             date_detection: self.mappings.date_detection,
             numeric_detection: self.mappings.numeric_detection,
             dynamic_date_formats: self.mappings.dynamic_date_formats.clone(),
-            dynamic_templates: self
-                .mappings
-                .dynamic_templates
-                .as_ref()
-                .map(|t| t.len() as u32),
+            dynamic_templates: self.mappings.dynamic_templates,
             _data_stream_timestamp: self.mappings._data_stream_timestamp.clone(),
             _source: self.mappings._source.clone(),
             _meta: self.mappings._meta.clone(),

--- a/src/processor/elasticsearch/mapping_stats/data.rs
+++ b/src/processor/elasticsearch/mapping_stats/data.rs
@@ -67,6 +67,13 @@ pub struct MappingSummary {
     pub _meta: Option<serde_json::Value>,
     #[serde(flatten)]
     pub fields: HashMap<String, u64>,
+    #[serde(rename = "multi-fields")]
+    pub multi_fields: MultiFieldSummary,
+}
+
+#[derive(Clone, Default, Deserialize, Serialize)]
+pub struct MultiFieldSummary {
+    pub total: u64,
 }
 
 impl MappingStats {
@@ -102,7 +109,7 @@ impl IndexMapping {
 
         if let Some(properties) = &self.mappings.properties {
             for field in properties.values() {
-                field.summarize(&mut summary.fields);
+                field.summarize(&mut summary.fields, &mut summary.multi_fields);
             }
         }
 
@@ -111,7 +118,11 @@ impl IndexMapping {
 }
 
 impl FieldDefinition {
-    pub fn summarize(&self, fields: &mut HashMap<String, u64>) {
+    pub fn summarize(
+        &self,
+        fields: &mut HashMap<String, u64>,
+        multi_fields: &mut MultiFieldSummary,
+    ) {
         // Increment total count, avoiding repeated String allocation
         if let Some(count) = fields.get_mut("total") {
             *count += 1;
@@ -126,6 +137,11 @@ impl FieldDefinition {
             } else {
                 fields.insert(field_type.clone(), 1);
             }
+
+            // Check if it's a multi-field mapping (has type AND fields)
+            if self.fields.is_some() {
+                multi_fields.total += 1;
+            }
         } else if self.properties.is_some() {
             // It's likely an 'object' or 'nested' type without explicit 'type' field
             if let Some(count) = fields.get_mut("object") {
@@ -137,13 +153,13 @@ impl FieldDefinition {
 
         if let Some(properties) = &self.properties {
             for field in properties.values() {
-                field.summarize(fields);
+                field.summarize(fields, multi_fields);
             }
         }
 
         if let Some(fields_map) = &self.fields {
             for field in fields_map.values() {
-                field.summarize(fields);
+                field.summarize(fields, multi_fields);
             }
         }
     }
@@ -213,6 +229,7 @@ mod tests {
         assert_eq!(summary.fields.get("keyword").unwrap(), &1);
         assert_eq!(summary.fields.get("long").unwrap(), &1);
         assert_eq!(summary.fields.get("object").unwrap(), &1);
+        assert_eq!(summary.multi_fields.total, 0);
     }
 
     #[test]
@@ -239,5 +256,6 @@ mod tests {
         assert_eq!(summary.fields.get("total").unwrap(), &2); // field1, field1.keyword
         assert_eq!(summary.fields.get("text").unwrap(), &1);
         assert_eq!(summary.fields.get("keyword").unwrap(), &1);
+        assert_eq!(summary.multi_fields.total, 1); // field1 is a multi-field
     }
 }

--- a/src/processor/elasticsearch/mapping_stats/lookup.rs
+++ b/src/processor/elasticsearch/mapping_stats/lookup.rs
@@ -8,8 +8,8 @@ use eyre::Result;
 impl From<MappingStats> for Lookup<MappingSummary> {
     fn from(mapping_stats: MappingStats) -> Self {
         let mut lookup = Lookup::new();
-        for (index_name, summary) in mapping_stats.summaries() {
-            lookup.add(summary).with_name(&index_name);
+        for (index_name, index_mapping) in mapping_stats.indices {
+            lookup.add(index_mapping.summarize()).with_name(&index_name);
         }
         lookup
     }

--- a/src/processor/elasticsearch/mapping_stats/lookup.rs
+++ b/src/processor/elasticsearch/mapping_stats/lookup.rs
@@ -1,0 +1,28 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+use super::{super::Lookup, MappingStats, MappingSummary};
+use eyre::Result;
+
+impl From<MappingStats> for Lookup<MappingSummary> {
+    fn from(mapping_stats: MappingStats) -> Self {
+        let mut lookup = Lookup::new();
+        for (index_name, summary) in mapping_stats.summaries() {
+            lookup.add(summary).with_name(&index_name);
+        }
+        lookup
+    }
+}
+
+impl From<Result<MappingStats>> for Lookup<MappingSummary> {
+    fn from(mapping_stats: Result<MappingStats>) -> Self {
+        match mapping_stats {
+            Ok(stats) => Lookup::<MappingSummary>::from(stats),
+            Err(e) => {
+                log::warn!("Failed to parse MappingStats: {}", e);
+                Lookup::new()
+            }
+        }
+    }
+}

--- a/src/processor/elasticsearch/mapping_stats/mod.rs
+++ b/src/processor/elasticsearch/mapping_stats/mod.rs
@@ -1,0 +1,8 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+pub mod data;
+pub mod lookup;
+
+pub use data::*;

--- a/src/processor/elasticsearch/mod.rs
+++ b/src/processor/elasticsearch/mod.rs
@@ -20,6 +20,8 @@ mod ilm_policies;
 mod indices_settings;
 /// The `_stats` API
 mod indices_stats;
+/// The `_mapping` API
+mod mapping_stats;
 /// The `_license` API
 mod licenses;
 /// Elasticsearch diagnostics metadata
@@ -71,6 +73,7 @@ use {
     ilm_policies::IlmPolicies,
     indices_settings::{IndexSettings, IndicesSettings},
     indices_stats::IndicesStats,
+    mapping_stats::{MappingStats, MappingSummary},
     licenses::Licenses,
     nodes::{NodeDocument, Nodes},
     nodes_stats::NodesStats,
@@ -144,6 +147,7 @@ impl DiagnosticProcessor for ElasticsearchDiagnostic {
             node: Lookup::from(receiver.get::<Nodes>().await),
             ilm_explain: Lookup::from(receiver.get::<IlmExplain>().await),
             shared_cache: Lookup::from(receiver.get::<SearchableSnapshotsCacheStats>().await),
+            mapping_stats: Lookup::from(receiver.get::<MappingStats>().await),
         };
         let license = receiver
             .get::<Licenses>()
@@ -158,6 +162,7 @@ impl DiagnosticProcessor for ElasticsearchDiagnostic {
         report.add_lookup("node", &lookups.node);
         report.add_lookup("ilm_explain", &lookups.ilm_explain);
         report.add_lookup("shared_cache", &lookups.shared_cache);
+        report.add_lookup("mapping_stats", &lookups.mapping_stats);
 
         Ok((
             Box::new(Self {
@@ -249,6 +254,7 @@ pub struct Lookups {
     pub data_stream: Lookup<DataStreamDocument>,
     pub ilm_explain: Lookup<IlmStats>,
     pub index_settings: Lookup<IndexSettings>,
+    pub mapping_stats: Lookup<MappingSummary>,
     pub node: Lookup<NodeDocument>,
     pub shared_cache: Lookup<SharedCacheStats>,
 }


### PR DESCRIPTION
## Summary
This PR introduces a new `MappingStats` processor that extracts and summarizes field type distributions, dynamic settings, and metadata from index mapping files. These summaries are used to enrich index statistics documents, providing structural insights without the overhead of full mapping files.

## Changes
- **New `MappingStats` Processor**: Parses `mapping.json` using optimized Rust structs for memory efficiency with large mappings.
- **Mapping Summarization**: Extracts field type counts (grouped under `field.fields`), `dynamic` setting, `dynamic_date_formats`, `dynamic_templates` count, and `_source` mode.
- **Index Stats Enrichment**: Enriches `IndicesStats` documents with the summarized mapping data via the `Lookups` system.
- **Data Stream Support**: Extends the `metrics-index-esdiag` index template to support the new mapping fields.
- **OpenSpec Artifacts**: Includes structured proposal, specifications, design, and task tracking for the change.

## Verification
- Added comprehensive unit tests for mapping summarization and recursive field counting.
- Verified integration within the `IndicesStats` processing flow.
- Ran `cargo test` and `cargo clippy` to ensure code quality and correctness.