### PR TITLE
feat: allow skipping assets when security is disabled

### DIFF
--- a/assets/elasticsearch/assets.yml
+++ b/assets/elasticsearch/assets.yml
@@ -14,3 +14,4 @@
 - name: "roles"
   endpoint: "_security/role"
   method: "PUT"
+  requires_security: true

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -146,7 +146,7 @@ impl Client {
                         .get("security")
                         .and_then(|s| s.get("enabled"))
                         .and_then(|e| e.as_bool())
-                        .unwrap_or(false);
+                        .unwrap_or(true);
                     Ok(enabled)
                 } else {
                     match status.as_u16() {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -121,7 +121,10 @@ impl Client {
         }
     }
 
-    /// Check if security is enabled on the cluster
+    /// Check if security is enabled on the cluster.
+    ///
+    /// For Elasticsearch, this checks the `security.enabled` flag in `/_xpack/usage`.
+    /// For Kibana, this currently always returns `true`.
     pub async fn has_security_enabled(&self) -> Result<bool> {
         match self {
             Client::Elasticsearch(client) => {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -120,6 +120,44 @@ impl Client {
             }
         }
     }
+
+    /// Check if security is enabled on the cluster
+    pub async fn has_security_enabled(&self) -> Result<bool> {
+        match self {
+            Client::Elasticsearch(client) => {
+                let response = client
+                    .send(
+                        es::http::Method::Get,
+                        "/_xpack/usage",
+                        es::http::headers::HeaderMap::new(),
+                        Option::<&serde_json::Value>::None,
+                        Option::<es::http::request::JsonBody<serde_json::Value>>::None,
+                        None,
+                    )
+                    .await?;
+
+                if response.status_code().is_success() {
+                    let json: serde_json::Value = response.json().await?;
+                    let enabled = json
+                        .get("security")
+                        .and_then(|s| s.get("enabled"))
+                        .and_then(|e| e.as_bool())
+                        .unwrap_or(false);
+                    Ok(enabled)
+                } else {
+                    log::warn!(
+                        "Failed to check security status (HTTP {}). Assuming security is disabled.",
+                        response.status_code()
+                    );
+                    Ok(false)
+                }
+            }
+            Client::Kibana(_) => {
+                // For Kibana we assume true for now as requested
+                Ok(true)
+            }
+        }
+    }
 }
 
 impl From<Client> for Product {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -136,7 +136,8 @@ impl Client {
                     )
                     .await?;
 
-                if response.status_code().is_success() {
+                let status = response.status_code();
+                if status.is_success() {
                     let json: serde_json::Value = response.json().await?;
                     let enabled = json
                         .get("security")
@@ -145,11 +146,20 @@ impl Client {
                         .unwrap_or(false);
                     Ok(enabled)
                 } else {
-                    log::warn!(
-                        "Failed to check security status (HTTP {}). Assuming security is disabled.",
-                        response.status_code()
-                    );
-                    Ok(false)
+                    match status.as_u16() {
+                        401 | 403 => {
+                            log::debug!("Security detection returned {status}. Security is enabled but access to /_xpack/usage is restricted.");
+                            Ok(true)
+                        }
+                        404 => {
+                            log::debug!("Security detection returned 404. Assuming security is disabled or not supported.");
+                            Ok(false)
+                        }
+                        _ => {
+                            log::warn!("Failed to check security status (HTTP {status}).");
+                            Err(eyre!("Failed to check security status: HTTP {status}"))
+                        }
+                    }
                 }
             }
             Client::Kibana(_) => {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -86,7 +86,14 @@ pub async fn assets(client: &Client) -> Result<()> {
     let assets = parse_assets_yml(client.into())?;
 
     // Check security status
-    let security_enabled = client.has_security_enabled().await.unwrap_or(false);
+    let security_enabled = match client.has_security_enabled().await {
+        Ok(enabled) => enabled,
+        Err(e) => {
+            log::error!("Failed to determine security status: {e:?}");
+            return Err(eyre!("Failed to determine security status: {e:?}"));
+        }
+    };
+
     if !security_enabled {
         log::info!("Security is disabled on the cluster. Security-dependent assets will be skipped.");
     }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -4,7 +4,7 @@
 
 use crate::{client::Client, data::Product};
 //use bytes::Bytes;
-use eyre::{Result, eyre};
+use eyre::{Result, eyre, WrapErr};
 use include_dir::{Dir, File, include_dir};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -25,10 +25,16 @@ pub struct Asset {
     pub headers: HashMap<String, String>,
     pub suffix: Option<String>,
     pub query: Option<String>,
+    #[serde(default)]
+    pub requires_security: bool,
 }
 
 fn default_headers() -> HashMap<String, String> {
     HashMap::from([("Content-Type".to_string(), "application/json".to_string())])
+}
+
+fn should_skip_asset(asset: &Asset, security_enabled: bool) -> bool {
+    asset.requires_security && !security_enabled
 }
 
 async fn send_asset(client: &Client, asset: &Asset, file: &File<'_>, named: bool) -> Result<()> {
@@ -78,9 +84,21 @@ async fn send_asset(client: &Client, asset: &Asset, file: &File<'_>, named: bool
 pub async fn assets(client: &Client) -> Result<()> {
     // load asset list from ./assets/{product}/assets.yml
     let assets = parse_assets_yml(client.into())?;
+
+    // Check security status
+    let security_enabled = client.has_security_enabled().await.unwrap_or(false);
+    if !security_enabled {
+        log::info!("Security is disabled on the cluster. Security-dependent assets will be skipped.");
+    }
+
     let mut error_count = 0;
 
     for asset in assets {
+        if should_skip_asset(&asset, security_enabled) {
+            log::debug!("Skipping security-dependent asset: {}", &asset.name);
+            continue;
+        }
+
         log::info!("Processing asset: {}", &asset.name);
         log::debug!("Asset: {}", serde_json::to_string(&asset).unwrap());
         let path = PathBuf::from(format!("{}/{}", client, asset.name));
@@ -123,4 +141,58 @@ fn parse_assets_yml(product: Product) -> Result<Vec<Asset>> {
         .ok_or(eyre!("Error reading {filename}"))?;
     let assets = serde_yaml::from_slice(file.contents())?;
     Ok(assets)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_asset_deserialization_with_requires_security() {
+        let yaml = r#"
+- name: "roles"
+  endpoint: "_security/role"
+  method: "PUT"
+  requires_security: true
+- name: "ingest_pipelines"
+  endpoint: "_ingest/pipeline"
+  method: "PUT"
+"#;
+        let assets: Vec<Asset> = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(assets.len(), 2);
+        assert_eq!(assets[0].name, "roles");
+        assert!(assets[0].requires_security);
+        assert_eq!(assets[1].name, "ingest_pipelines");
+        assert!(!assets[1].requires_security);
+    }
+
+    #[test]
+    fn test_should_skip_asset() {
+        let security_asset = Asset {
+            endpoint: "/".to_string(),
+            method: "GET".to_string(),
+            name: "test".to_string(),
+            headers: HashMap::new(),
+            suffix: None,
+            query: None,
+            requires_security: true,
+        };
+        let normal_asset = Asset {
+            endpoint: "/".to_string(),
+            method: "GET".to_string(),
+            name: "test".to_string(),
+            headers: HashMap::new(),
+            suffix: None,
+            query: None,
+            requires_security: false,
+        };
+
+        // Security enabled: skip nothing
+        assert!(!should_skip_asset(&security_asset, true));
+        assert!(!should_skip_asset(&normal_asset, true));
+
+        // Security disabled: skip security asset
+        assert!(should_skip_asset(&security_asset, false));
+        assert!(!should_skip_asset(&normal_asset, false));
+    }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -86,13 +86,10 @@ pub async fn assets(client: &Client) -> Result<()> {
     let assets = parse_assets_yml(client.into())?;
 
     // Check security status
-    let security_enabled = match client.has_security_enabled().await {
-        Ok(enabled) => enabled,
-        Err(e) => {
-            log::error!("Failed to determine security status: {e:?}");
-            return Err(eyre!("Failed to determine security status: {e:?}"));
-        }
-    };
+    let security_enabled = client
+        .has_security_enabled()
+        .await
+        .wrap_err("Failed to determine security status")?;
 
     if !security_enabled {
         log::info!("Security is disabled on the cluster. Security-dependent assets will be skipped.");


### PR DESCRIPTION
## Summary
- Added `requires_security` field to the `Asset` struct in `assets.yml`.
- Implemented security detection during the setup phase to check if the Elasticsearch cluster has security enabled.
- Assets marked with `requires_security: true` are now skipped if security is disabled, reducing log noise.
- Marked the `roles` asset in Elasticsearch's `assets.yml` as security-dependent.

Closes #224