### PR TITLE
chore: maintenance - version bump, dependency upgrades, and optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,13 +96,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7661ff56517787343f376f75db037426facd7c8d3049cef8911f1e75016f3a37"
 dependencies = [
  "askama_parser",
- "basic-toml",
  "memchr",
  "proc-macro2",
  "quote",
  "rustc-hash",
- "serde",
- "serde_derive",
  "syn",
 ]
 
@@ -122,8 +119,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d62d674238a526418b30c0def480d5beadb9d8964e7f38d635b03bf639c704c"
 dependencies = [
  "rustc-hash",
- "serde",
- "serde_derive",
  "unicode-ident",
  "winnow",
 ]
@@ -263,15 +258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "basic-toml"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,10 +298,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -478,12 +462,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "deflate64"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 
 [[package]]
 name = "deranged"
@@ -667,7 +645,6 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
- "zlib-rs",
 ]
 
 [[package]]
@@ -2187,7 +2164,6 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2920,37 +2896,15 @@ version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc12baa6db2b15a140161ce53d72209dacea594230798c24774139b54ecaa980"
 dependencies = [
- "chrono",
  "crc32fast",
- "deflate64",
  "flate2",
  "indexmap 2.13.0",
  "memchr",
- "time",
  "typed-path",
- "zopfli",
 ]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7948af682ccbc3342b6e9420e8c51c1fe5d7bf7756002b4a3c6cabfe96a7e3c"
 
 [[package]]
 name = "zmij"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
-
-[[package]]
-name = "zopfli"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
-dependencies = [
- "bumpalo",
- "crc32fast",
- "log",
- "simd-adler32",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ setup = ["flate2", "tar"]
 server = []
 
 [dependencies]
-askama = "0.15.4"
+askama = { version = "0.15.4", default-features = false, features = ["derive", "std"] }
 async-stream = "0.3.6"
 axum = { version = "0.8.8", features = ["multipart", "macros"] }
 axum-server = "0.8.0"
 base64 = "0.22.1"
 bytes = "1.11.1"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
 clap = { version = "4.5", features = ["derive"] }
 datastar = { version = "0.3.1", features = ["axum"] }
 elasticsearch = { git = "https://github.com/VimCommando/elasticsearch-rs", rev = "2eff23f3d908c177b8ecc03c4a8af0f8080d7a80" }
@@ -29,11 +29,11 @@ json-patch = "4.1"
 log = "0.4"
 rayon = "1.11"
 regex = "1.12"
-reqwest = { version = "0.12.15", features = ["json", "blocking", "multipart"] }
+reqwest = { version = "0.12.28", features = ["json", "blocking", "multipart"] }
 semver = { version = "1.0.27", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.149"
-serde_with = "3.16.1"
+serde_with = { version = "3.16.1", default-features = false, features = ["macros"] }
 serde_yaml = "0.9"
 tar = { version = "0.4.44", optional = true, default-features = false }
 tokio = { version = "1.49", features = [
@@ -48,16 +48,22 @@ url = { version = "2.5.8", features = ["serde"] }
 urlencoding = "2.1.3"
 uuid = { version = "1.20", features = ["v4", "fast-rng"] }
 zip = { version = "7.4.0", default-features = false, features = [
-    "chrono",
-    "deflate",
-    "deflate64",
-    "time",
+    "deflate-flate2",
 ] }
 
 [dev-dependencies]
 portpicker = "0.1.1"
-reqwest = { version = "0.12.15", features = ["json", "blocking", "multipart"] }
+reqwest = { version = "0.12.28", features = ["json", "blocking", "multipart"] }
 tokio-test = "0.4.5"
+tokio = { version = "1.49", features = [
+    "fs",
+    "rt-multi-thread",
+    "macros",
+    "time",
+    "signal",
+    "sync",
+    "io-util",
+] }
 
 [build-dependencies]
 flate2 = { version = "1.1", default-features = false, features = ["rust_backend"] }

--- a/esdiag.spdx.json
+++ b/esdiag.spdx.json
@@ -1428,11 +1428,11 @@
       "versionInfo": "0.2.0"
     },
     {
-      "SPDXID": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT",
+      "SPDXID": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT",
       "downloadLocation": "NONE",
       "licenseConcluded": "NOASSERTION",
       "name": "esdiag",
-      "versionInfo": "0.13.0-SNAPSHOT"
+      "versionInfo": "0.14.0-SNAPSHOT"
     },
     {
       "SPDXID": "SPDXRef-Package-futures-channel-0.3.31",
@@ -5000,7 +5000,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-axum-server-0.7.2",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
@@ -5025,12 +5025,12 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-chrono-0.4.42",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-futures-0.3.31",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
@@ -5040,7 +5040,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-zip-6.0.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
@@ -5080,7 +5080,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-env--logger-0.11.8",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
@@ -5320,7 +5320,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-rayon-1.11.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-log-0.4.28",
@@ -5405,7 +5405,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-serde--path--to--error-0.1.20",
@@ -5460,7 +5460,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-serde--with-3.15.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
@@ -5505,7 +5505,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-urlencoding-2.1.3",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-windows-targets-0.53.5",
@@ -5625,7 +5625,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-semver-1.0.27",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-windows--i686--gnu-0.52.6",
@@ -5860,7 +5860,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-regex-1.12.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-tower-http-0.6.6",
@@ -5985,7 +5985,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-shared-0.2.104",
@@ -6180,7 +6180,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-log-0.4.28",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-openssl-macros-0.1.1",
@@ -6245,7 +6245,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-include--dir-0.7.4",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-rustls-pki-types-1.12.0",
@@ -6260,7 +6260,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-json-patch-4.1.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-adler2-2.0.1",
@@ -6335,7 +6335,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-uuid-1.18.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
@@ -6385,7 +6385,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-askama-0.14.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.60.2",
@@ -6420,7 +6420,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-clap-4.5.48",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-windows--x86--64--gnullvm-0.52.6",
@@ -6530,7 +6530,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
@@ -6543,7 +6543,7 @@
       "spdxElementId": "SPDXRef-Package-rand-0.9.2"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT",
+      "relatedSpdxElement": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT",
       "relationshipType": "GENERATED_FROM",
       "spdxElementId": "SPDXRef-File-esdiag"
     },
@@ -6735,7 +6735,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-async-stream-0.3.6",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
@@ -7050,7 +7050,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-axum-0.8.6",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
@@ -7125,7 +7125,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-url-2.5.7",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.104",
@@ -7145,7 +7145,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.145",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.52.0",
@@ -7360,7 +7360,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-reqwest-0.12.23",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-fnv-1.0.7",
@@ -7370,7 +7370,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
@@ -7755,7 +7755,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-datastar-0.3.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-openssl-probe-0.1.6",
@@ -8040,7 +8040,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-eyre-0.6.12",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
@@ -8345,7 +8345,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-serde--yaml-0.9.34-plus-deprecated",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
@@ -8585,7 +8585,7 @@
     {
       "relatedSpdxElement": "SPDXRef-Package-base64-0.22.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.13.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-serde--derive-1.0.228",


### PR DESCRIPTION
## Summary
This PR performs routine maintenance to keep the crate up to date and optimized:

- **Version Bump**: Incremented version to `0.14.0-SNAPSHOT`.
- **Dependency Upgrades**: Upgraded core dependencies including `axum` (0.8), `askama` (0.15), `tokio` (1.49), and `zip` (7.4).
- **Reqwest**: Upgraded to `0.12.28` (latest 0.12) to maintain compatibility with `elasticsearch-rs`.
- **Optimizations**:
  - Removed `axum-server` in favor of native `axum::serve`.
  - Refined features for `chrono`, `serde_with`, `askama`, and `zip` to reduce transitive dependencies and build times.
  - Reduced total dependency graph from ~310 to ~294 packages.
- **Fixes**: Refactored `KibanaClient` and response handling to accommodate breaking changes in upgraded crates.