### PR TITLE
feat: Implement Elasticsearch snapshot and repository collection

### DIFF
--- a/assets/elasticsearch/index_templates/metadata-snapshots.json
+++ b/assets/elasticsearch/index_templates/metadata-snapshots.json
@@ -1,0 +1,69 @@
+{
+  "_meta": {
+    "description": "ESDiag Elasticsearch Snapshots"
+  },
+  "index_patterns": ["metadata-snapshots-esdiag*"],
+  "composed_of": ["esdiag@mappings", "esdiag@metadata", "esdiag@settings"],
+  "allow_auto_create": true,
+  "data_stream": {
+    "hidden": false,
+    "allow_custom_routing": false
+  },
+  "priority": 300,
+  "template": {
+    "mappings": {
+      "properties": {
+        "data_stream": {
+          "type": "object",
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword",
+              "value": "snapshots"
+            },
+            "type": {
+              "type": "constant_keyword",
+              "value": "metadata"
+            }
+          }
+        },
+        "snapshot": {
+          "properties": {
+            "snapshot": {
+              "type": "keyword"
+            },
+            "uuid": {
+              "type": "keyword"
+            },
+            "state": {
+              "type": "keyword"
+            },
+            "start_time": {
+              "type": "date"
+            },
+            "start_time_in_millis": {
+              "type": "long",
+              "index": false
+            },
+            "end_time": {
+              "type": "date"
+            },
+            "end_time_in_millis": {
+              "type": "long",
+              "index": false
+            },
+            "duration_in_millis": {
+              "type": "long"
+            },
+            "indices": {
+              "type": "keyword"
+            },
+            "repository": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": 1
+}

--- a/assets/elasticsearch/index_templates/settings-snapshot_repositories.json
+++ b/assets/elasticsearch/index_templates/settings-snapshot_repositories.json
@@ -1,0 +1,47 @@
+{
+  "_meta": {
+    "description": "ESDiag Elasticsearch Snapshot Repositories"
+  },
+  "index_patterns": ["settings-snapshot_repositories-esdiag*"],
+  "composed_of": ["esdiag@mappings", "esdiag@metadata", "esdiag@settings"],
+  "allow_auto_create": true,
+  "data_stream": {
+    "hidden": false,
+    "allow_custom_routing": false
+  },
+  "priority": 300,
+  "template": {
+    "mappings": {
+      "properties": {
+        "data_stream": {
+          "type": "object",
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword",
+              "value": "snapshot_repositories"
+            },
+            "type": {
+              "type": "constant_keyword",
+              "value": "settings"
+            }
+          }
+        },
+        "repository": {
+          "properties": {
+            "name": {
+              "type": "keyword"
+            },
+            "type": {
+              "type": "keyword"
+            },
+            "settings": {
+              "type": "object",
+              "enabled": false
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": 1
+}

--- a/openspec/changes/snapshot-api/.openspec.yaml
+++ b/openspec/changes/snapshot-api/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-08

--- a/openspec/changes/snapshot-api/design.md
+++ b/openspec/changes/snapshot-api/design.md
@@ -1,0 +1,40 @@
+## Context
+ESDiag currently lacks snapshot and repository information in its Elasticsearch diagnostics. This change introduces the necessary data structures and processing logic to collect and export this information using the project's existing trait-driven architecture.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Implement `DataSource` for Elasticsearch Snapshot Repository (`_snapshot`) and Snapshots (`_snapshot/_all/_all`) APIs.
+- Create structured Rust models for the responses from these APIs using `serde`.
+- Integrate the new data sources into the `ElasticsearchDiagnostic` processor to ensure they are collected during diagnostic runs.
+
+**Non-Goals:**
+- Management of snapshots (creation, deletion, restore).
+- Deep analysis of snapshot content; the focus is on the metadata and state of the snapshots and repositories.
+
+## Decisions
+
+### Decision: Separate Modules for Repositories and Snapshots
+We will create a unified `snapshots` module that handles both repositories and snapshot details, rather than two separate top-level modules.
+
+**Rationale:** These two APIs are logically grouped under the snapshotting functionality. Within the `snapshots` module, we will define separate `DataSource` implementations for each endpoint.
+
+### Decision: Module Structure
+The new code will be located in `src/processor/elasticsearch/snapshots/`, containing:
+- `mod.rs`: Module exports.
+- `data.rs`: Serde-compatible structs for API responses.
+- `processor.rs`: Implementation of the data collection and export logic.
+
+**Rationale:** This maintains consistency with existing Elasticsearch processors like `nodes_stats` and `indices_settings`.
+
+### Decision: Index Templates for Snapshots
+We will add index templates for the new data streams to ensure they are correctly mapped in Elasticsearch.
+
+**Rationale:** Proper mappings (e.g., keyword vs text, date formats) are essential for efficient querying and visualization of snapshot data.
+
+## Risks / Trade-offs
+
+- **[Risk] Large Response Size** → Clusters with a very high number of snapshots (thousands) may return a large JSON payload from `_snapshot/_all/_all`.
+  - **Mitigation**: The system is designed to handle large diagnostic documents, but we should ensure the deserialization is efficient.
+- **[Trade-off] All repositories vs specific repositories** → We chose `_all/_all` to get everything in one call.
+  - **Mitigation**: This is standard for diagnostic collection to ensure no data is missed.

--- a/openspec/changes/snapshot-api/proposal.md
+++ b/openspec/changes/snapshot-api/proposal.md
@@ -1,0 +1,19 @@
+## Why
+Currently, ESDiag does not collect information about Elasticsearch snapshot repositories and snapshots. This information is crucial for diagnosing backup/restore issues and understanding the state of data durability in a cluster.
+
+## What Changes
+- Add support for collecting Snapshot Repository information via the `_snapshot` API.
+- Add support for collecting Snapshot details via the `_snapshot/_all/_all` API.
+- Integrate these new data sources into the `ElasticsearchDiagnostic` processor to ensure they are included in diagnostic reports.
+
+## Capabilities
+
+### New Capabilities
+- `snapshot-api`: Collection and processing of Elasticsearch snapshot repositories and snapshots.
+
+### Modified Capabilities
+
+## Impact
+- New modules in `src/processor/elasticsearch/` for snapshot data structures and processing logic.
+- Updates to `ElasticsearchDiagnostic` in `src/processor/elasticsearch/mod.rs` to register and execute the new snapshot processor.
+- Addition of snapshot and repository data to the exported diagnostic documents.

--- a/openspec/changes/snapshot-api/specs/snapshot-api/spec.md
+++ b/openspec/changes/snapshot-api/specs/snapshot-api/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Snapshot Repository Collection
+The system SHALL collect information about all configured snapshot repositories in the Elasticsearch cluster to provide visibility into backup configurations.
+
+#### Scenario: Successful Repository Collection
+- **WHEN** the Elasticsearch diagnostic collector executes
+- **THEN** it MUST perform a GET request to the `_snapshot` endpoint and capture the response.
+
+### Requirement: Snapshot Details Collection
+The system SHALL collect comprehensive details for all snapshots across all repositories to allow for auditing of backup history.
+
+#### Scenario: Successful Snapshot Collection
+- **WHEN** the Elasticsearch diagnostic collector executes
+- **THEN** it MUST perform a GET request to the `_snapshot/_all/_all` endpoint and capture the response.
+
+### Requirement: Snapshot Processor Integration
+The system SHALL integrate the snapshot and repository data into the `ElasticsearchDiagnostic` processing pipeline.
+
+#### Scenario: Data Available in Diagnostic Output
+- **WHEN** the diagnostic processing for a cluster completes
+- **THEN** the resulting diagnostic output MUST include the structured data retrieved from the snapshot and repository APIs.
+
+### Requirement: Snapshot API Index Templates
+The system SHALL provide Elasticsearch index templates for the snapshot repository and snapshot data streams to ensure proper indexing and mapping.
+
+#### Scenario: Index Templates Exist
+- **WHEN** the project assets are inspected
+- **THEN** index templates for `settings-snapshot_repositories-esdiag` and `metadata-snapshots-esdiag` MUST exist in the `assets/` directory.

--- a/openspec/changes/snapshot-api/tasks.md
+++ b/openspec/changes/snapshot-api/tasks.md
@@ -1,0 +1,26 @@
+## 1. Setup and Module Creation
+
+- [x] 1.1 Create `src/processor/elasticsearch/snapshots/` directory and required files (`mod.rs`, `data.rs`, `processor.rs`)
+- [x] 1.2 Register the `snapshots` module in `src/processor/elasticsearch/mod.rs`
+
+## 2. Data Model Implementation
+
+- [x] 2.1 Define `SnapshotRepositories` and `Snapshots` data structures in `data.rs` with `Serialize` and `Deserialize` support
+- [x] 2.2 Implement the `DataSource` trait for `SnapshotRepositories` mapping to the `_snapshot` API endpoint
+- [x] 2.3 Implement the `DataSource` trait for `Snapshots` mapping to the `_snapshot/_all/_all` API endpoint
+
+## 3. Processor Integration
+
+- [x] 3.1 Integrate the new data sources into the `ElasticsearchDiagnostic` struct and its `try_new` initialization
+- [x] 3.2 Update the `process` method in `ElasticsearchDiagnostic` to include the execution of snapshot and repository data collection
+
+## 4. Verification
+
+- [x] 4.1 Run `cargo clippy` to ensure adherence to project coding standards
+- [x] 4.2 Run `cargo test` to verify the new data structures and integration
+- [x] 4.3 Manually verify that the diagnostic output includes the expected snapshot and repository information
+
+## 5. Assets
+
+- [x] 5.1 Create `assets/elasticsearch/index_templates/settings-snapshot_repositories.json`
+- [x] 5.2 Create `assets/elasticsearch/index_templates/metadata-snapshots.json`

--- a/openspec/specs/snapshot-api/spec.md
+++ b/openspec/specs/snapshot-api/spec.md
@@ -1,0 +1,34 @@
+# Snapshot API
+
+## Purpose
+Collect and process information about Elasticsearch snapshot repositories and snapshots to assist in diagnosing backup and recovery issues.
+
+## Requirements
+
+### Requirement: Snapshot Repository Collection
+The system SHALL collect information about all configured snapshot repositories in the Elasticsearch cluster to provide visibility into backup configurations.
+
+#### Scenario: Successful Repository Collection
+- **WHEN** the Elasticsearch diagnostic collector executes
+- **THEN** it MUST perform a GET request to the `_snapshot` endpoint and capture the response.
+
+### Requirement: Snapshot Details Collection
+The system SHALL collect comprehensive details for all snapshots across all repositories to allow for auditing of backup history.
+
+#### Scenario: Successful Snapshot Collection
+- **WHEN** the Elasticsearch diagnostic collector executes
+- **THEN** it MUST perform a GET request to the `_snapshot/_all/_all` endpoint and capture the response.
+
+### Requirement: Snapshot Processor Integration
+The system SHALL integrate the snapshot and repository data into the `ElasticsearchDiagnostic` processing pipeline.
+
+#### Scenario: Data Available in Diagnostic Output
+- **WHEN** the diagnostic processing for a cluster completes
+- **THEN** the resulting diagnostic output MUST include the structured data retrieved from the snapshot and repository APIs.
+
+### Requirement: Snapshot API Index Templates
+The system SHALL provide Elasticsearch index templates for the snapshot repository and snapshot data streams to ensure proper indexing and mapping.
+
+#### Scenario: Index Templates Exist
+- **WHEN** the project assets are inspected
+- **THEN** index templates for `settings-snapshot_repositories-esdiag` and `metadata-snapshots-esdiag` MUST exist in the `assets/` directory.

--- a/src/data/known_host.rs
+++ b/src/data/known_host.rs
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use crate::data::{Auth, Product};
-use eyre::{Result, eyre};
+use eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
 use serde_yaml;
 use std::{

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -41,7 +41,6 @@ pub fn save_file<T: Serialize>(filename: &str, content: &T) -> Result<()> {
 
 /// The standard deserializer from serde_json does not deserializing u64 from
 /// strings. Unfortunately the _settings API frequently wraps numbers in quotes.
-
 pub fn u64_from_string<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
 where
     D: Deserializer<'de>,
@@ -60,7 +59,6 @@ where
 
 /// The standard deserializer from serde_json does not deserializing i64 from
 /// strings. Unfortunately the _settings API frequently wraps numbers in quotes.
-
 pub fn i64_from_string<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
 where
     D: Deserializer<'de>,

--- a/src/data/uri.rs
+++ b/src/data/uri.rs
@@ -5,7 +5,7 @@
 use crate::data::Product;
 
 use super::{ElasticCloud, KnownHost, KnownHostBuilder};
-use eyre::{OptionExt, Report, Result, eyre};
+use eyre::{eyre, OptionExt, Report, Result};
 use serde::{Deserialize, Deserializer};
 use std::{
     path::{Path, PathBuf},

--- a/src/processor/elasticsearch/mod.rs
+++ b/src/processor/elasticsearch/mod.rs
@@ -36,6 +36,8 @@ mod pending_tasks;
 mod searchable_snapshots_cache_stats;
 /// The `_searchable_snapshots/stats` API
 mod searchable_snapshots_stats;
+/// The `_snapshot` API
+mod snapshots;
 /// The `_slm/policy` API
 mod slm_policies;
 /// The `_tasks` API
@@ -64,6 +66,7 @@ use crate::{
 };
 use eyre::{Result, eyre};
 use serde::{Serialize, de::DeserializeOwned};
+use serde_json::Value;
 use std::sync::Arc;
 use {
     alias::{Alias, AliasList},
@@ -81,6 +84,7 @@ use {
     searchable_snapshots_cache_stats::{SearchableSnapshotsCacheStats, SharedCacheStats},
     searchable_snapshots_stats::SearchableSnapshotsStats,
     slm_policies::SlmPolicies,
+    snapshots::{SnapshotRepositories, Snapshots},
     tasks::Tasks,
 };
 
@@ -153,6 +157,7 @@ impl DiagnosticProcessor for ElasticsearchDiagnostic {
             node: Lookup::from(receiver.get::<Nodes>().await),
             ilm_explain: Lookup::from(receiver.get::<IlmExplain>().await),
             shared_cache: Lookup::from(receiver.get::<SearchableSnapshotsCacheStats>().await),
+            snapshot_repository: Lookup::from(receiver.get::<SnapshotRepositories>().await),
             mapping_stats: Lookup::from(receiver.get::<MappingStats>().await),
         };
         let license = receiver
@@ -168,6 +173,7 @@ impl DiagnosticProcessor for ElasticsearchDiagnostic {
         report.add_lookup("node", &lookups.node);
         report.add_lookup("ilm_explain", &lookups.ilm_explain);
         report.add_lookup("shared_cache", &lookups.shared_cache);
+        report.add_lookup("snapshot_repository", &lookups.snapshot_repository);
         report.add_lookup("mapping_stats", &lookups.mapping_stats);
 
         Ok((
@@ -225,6 +231,10 @@ impl DiagnosticProcessor for ElasticsearchDiagnostic {
                 .await?;
             diag.process_datasource::<SlmPolicies>(summary_tx.clone())
                 .await?;
+            diag.process_datasource::<SnapshotRepositories>(summary_tx.clone())
+                .await?;
+            diag.process_datasource::<Snapshots>(summary_tx.clone())
+                .await?;
             diag.process_datasource::<Tasks>(summary_tx.clone()).await?;
             Ok::<(), eyre::Error>(())
         });
@@ -263,4 +273,5 @@ pub struct Lookups {
     pub mapping_stats: Lookup<MappingSummary>,
     pub node: Lookup<NodeDocument>,
     pub shared_cache: Lookup<SharedCacheStats>,
+    pub snapshot_repository: Lookup<Value>,
 }

--- a/src/processor/elasticsearch/nodes_stats/processor/transport_actions.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/transport_actions.rs
@@ -9,7 +9,6 @@ use serde_json::{Value, json};
 use tokio::sync::mpsc::Sender;
 
 /// Extract transport.actions
-
 pub async fn extract(
     sender: &Sender<Value>,
     mut actions: Value,

--- a/src/processor/elasticsearch/snapshots/data.rs
+++ b/src/processor/elasticsearch/snapshots/data.rs
@@ -1,0 +1,43 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+use super::super::super::diagnostic::data_source::PathType;
+use super::super::DataSource;
+use eyre::Result;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub type SnapshotRepositories = HashMap<String, Value>;
+
+#[derive(Serialize, Deserialize)]
+pub struct Snapshots {
+    pub snapshots: Vec<Value>,
+}
+
+impl DataSource for SnapshotRepositories {
+    fn source(path: PathType) -> Result<&'static str> {
+        match path {
+            PathType::File => Ok("commercial/snapshot_repositories.json"),
+            PathType::Url => Ok("_snapshot"),
+        }
+    }
+
+    fn name() -> String {
+        "snapshot_repositories".to_string()
+    }
+}
+
+impl DataSource for Snapshots {
+    fn source(path: PathType) -> Result<&'static str> {
+        match path {
+            PathType::File => Ok("commercial/snapshots.json"),
+            PathType::Url => Ok("_snapshot/_all/_all"),
+        }
+    }
+
+    fn name() -> String {
+        "snapshots".to_string()
+    }
+}

--- a/src/processor/elasticsearch/snapshots/lookup.rs
+++ b/src/processor/elasticsearch/snapshots/lookup.rs
@@ -1,0 +1,30 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+use super::{super::Lookup, SnapshotRepositories};
+use eyre::Result;
+use serde_json::Value;
+
+impl From<SnapshotRepositories> for Lookup<Value> {
+    fn from(mut repositories: SnapshotRepositories) -> Self {
+        let mut lookup: Lookup<Value> = Lookup::new();
+        repositories.drain().for_each(|(name, config)| {
+            lookup.add(config).with_name(&name);
+        });
+        log::debug!("lookup snapshot repository entries: {}", lookup.len());
+        lookup
+    }
+}
+
+impl From<Result<SnapshotRepositories>> for Lookup<Value> {
+    fn from(repositories: Result<SnapshotRepositories>) -> Self {
+        match repositories {
+            Ok(repositories) => Lookup::<Value>::from_parsed(repositories),
+            Err(e) => {
+                log::warn!("Failed to parse SnapshotRepositories: {}", e);
+                Lookup::new()
+            }
+        }
+    }
+}

--- a/src/processor/elasticsearch/snapshots/mod.rs
+++ b/src/processor/elasticsearch/snapshots/mod.rs
@@ -1,0 +1,9 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+mod data;
+mod lookup;
+mod processor;
+
+pub use data::*;

--- a/src/processor/elasticsearch/snapshots/processor.rs
+++ b/src/processor/elasticsearch/snapshots/processor.rs
@@ -1,0 +1,97 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+use super::super::{DocumentExporter, ElasticsearchMetadata, Lookups, Metadata, ProcessorSummary};
+use super::{SnapshotRepositories, Snapshots};
+use crate::exporter::Exporter;
+use rayon::prelude::*;
+use serde::Serialize;
+use serde_json::Value;
+
+impl DocumentExporter<Lookups, ElasticsearchMetadata> for SnapshotRepositories {
+    async fn documents_export(
+        self,
+        exporter: &Exporter,
+        _lookups: &Lookups,
+        metadata: &ElasticsearchMetadata,
+    ) -> ProcessorSummary {
+        log::debug!("processing snapshot repositories");
+        let data_stream = "settings-snapshot_repositories-esdiag".to_string();
+        let metadata = metadata.for_data_stream(&data_stream).as_meta_doc();
+
+        let mut repos: Vec<(String, Value)> = self.into_par_iter().collect();
+
+        let repos: Vec<Value> = repos
+            .par_drain(..)
+            .filter_map(|(name, config)| {
+                serde_json::to_value(SnapshotRepositoryDoc {
+                    repository: SnapshotRepositoryDetails { name, config },
+                    metadata: metadata.clone(),
+                })
+                .ok()
+            })
+            .collect();
+
+        log::debug!("snapshot repositories docs: {}", repos.len());
+        let mut summary = ProcessorSummary::new(data_stream.clone());
+        match exporter.send(data_stream, repos).await {
+            Ok(batch) => summary.add_batch(batch),
+            Err(err) => log::error!("Failed to send snapshot repositories: {}", err),
+        }
+        summary
+    }
+}
+
+impl DocumentExporter<Lookups, ElasticsearchMetadata> for Snapshots {
+    async fn documents_export(
+        self,
+        exporter: &Exporter,
+        _lookups: &Lookups,
+        metadata: &ElasticsearchMetadata,
+    ) -> ProcessorSummary {
+        log::debug!("processing snapshots");
+        let data_stream = "metadata-snapshots-esdiag".to_string();
+        let metadata = metadata.for_data_stream(&data_stream).as_meta_doc();
+
+        let snapshots: Vec<Value> = self.snapshots
+            .into_par_iter()
+            .filter_map(|snapshot| {
+                serde_json::to_value(SnapshotDoc {
+                    snapshot,
+                    metadata: metadata.clone(),
+                })
+                .ok()
+            })
+            .collect();
+
+        log::debug!("snapshots docs: {}", snapshots.len());
+        let mut summary = ProcessorSummary::new(data_stream.clone());
+        match exporter.send(data_stream, snapshots).await {
+            Ok(batch) => summary.add_batch(batch),
+            Err(err) => log::error!("Failed to send snapshots: {}", err),
+        }
+        summary
+    }
+}
+
+#[derive(Serialize)]
+struct SnapshotRepositoryDoc {
+    repository: SnapshotRepositoryDetails,
+    #[serde(flatten)]
+    metadata: Value,
+}
+
+#[derive(Serialize)]
+struct SnapshotRepositoryDetails {
+    name: String,
+    #[serde(flatten)]
+    config: Value,
+}
+
+#[derive(Serialize)]
+struct SnapshotDoc {
+    snapshot: Value,
+    #[serde(flatten)]
+    metadata: Value,
+}

--- a/src/processor/elasticsearch/tasks/processor.rs
+++ b/src/processor/elasticsearch/tasks/processor.rs
@@ -166,7 +166,7 @@ impl TaskData {
                         bulk: None,
                     }),
                     shard: Some(TaskShard {
-                        number: number,
+                        number,
                         primary: Some(is_primary),
                         bulk: Some(BulkDocs { docs }),
                     }),

--- a/src/server/file_upload.rs
+++ b/src/server/file_upload.rs
@@ -118,7 +118,7 @@ pub async fn process(
             None =>{
                 yield patch_signals(r#"{"processing":false}"#);
                 yield patch_template(template::JobFailed {
-                    job_id: job_id,
+                    job_id,
                     error: "Failed to upload file",
                     source: "User upload",
                 });
@@ -133,7 +133,7 @@ pub async fn process(
                 log::error!("{}", error);
                 yield patch_signals(r#"{"processing":false}"#);
                 yield patch_template(template::JobFailed {
-                    job_id: job_id,
+                    job_id,
                     error: "Failed to create file receiver",
                     source: &filename,
                 });
@@ -166,7 +166,7 @@ pub async fn process(
         match processor.start().await {
             Ok(processor) => {
                 yield patch_template(template::JobProcessing {
-                    job_id: job_id,
+                    job_id,
                     source: &filename,
                 });
                 yield patch_signals(r#"{"loading":false,"processing":true}"#);
@@ -176,7 +176,7 @@ pub async fn process(
                         let report = &completed.state.report;
                         state.record_success(report.diagnostic.docs.total, report.diagnostic.docs.errors).await;
                         yield patch_template(template::JobCompleted {
-                            job_id: job_id,
+                            job_id,
                             diagnostic_id: &report.diagnostic.metadata.id,
                             docs_created: &report.diagnostic.docs.created,
                             duration: &format!("{:.3}", report.diagnostic.processing_duration as f64 / 1000.0),
@@ -188,7 +188,7 @@ pub async fn process(
                     Err(failed) => {
                         state.record_failure().await;
                         yield patch_template(template::JobFailed {
-                            job_id: job_id,
+                            job_id,
                             error: &failed.state.error,
                             source: &filename,
                         });
@@ -198,7 +198,7 @@ pub async fn process(
             Err(failed) => {
                 state.record_failure().await;
                 yield patch_template(template::JobFailed {
-                    job_id: job_id,
+                    job_id,
                     error: &failed.state.error,
                     source: &filename,
                 });


### PR DESCRIPTION
## Summary
- Added support for collecting Elasticsearch snapshot repositories via the `_snapshot` API.
- Added support for collecting snapshot details via the `_snapshot/_all/_all` API.
- Integrated new data sources into the `ElasticsearchDiagnostic` processor.
- Added index templates for the new `settings-snapshot_repositories-esdiag` and `metadata-snapshots-esdiag` data streams.
- Included OpenSpec artifacts (proposal, design, specs) for the new capability.
- Fixed several existing clippy warnings in modified files to ensure a clean build.

This change allows ESDiag to capture critical backup/restore state for diagnostic analysis.