### PR TITLE
feat: auto-generate NOTICE.txt and SBOM in build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2892,9 +2892,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "7.4.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc12baa6db2b15a140161ce53d72209dacea594230798c24774139b54ecaa980"
+checksum = "6e499faf5c6b97a0d086f4a8733de6d47aee2252b8127962439d8d4311a73f72"
 dependencies = [
  "crc32fast",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "esdiag"
 version = "0.14.0-SNAPSHOT"
 edition = "2024"
 rust-version = "1.89"
+license = "Elastic-2.0"
 
 [features]
 default = ["full"]
@@ -47,7 +48,7 @@ tokio = { version = "1.49", features = [
 url = { version = "2.5.8", features = ["serde"] }
 urlencoding = "2.1.3"
 uuid = { version = "1.20", features = ["v4", "fast-rng"] }
-zip = { version = "7.4.0", default-features = false, features = [
+zip = { version = "8.1.0", default-features = false, features = [
     "deflate-flate2",
 ] }
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,9 +1,5762 @@
 Elastic Stack Diagnostics (ESDiag)
 Copyright 2012-2025 Elasticsearch B.V.
 
----
-This product bundles code based on datastar@1.0.0 which is available under a "MIT" license.
+# Third Party License Notifications
+This document lists the licenses of the projects used in esdiag.
 
+## Overview of licenses
+- [Apache License 2.0](#Apache-2.0) (190)
+- [MIT License](#MIT) (52)
+- [Unicode License v3](#Unicode-3.0) (19)
+- [BSD 3-Clause "New" or "Revised" License](#BSD-3-Clause) (2)
+- [BSD Zero Clause License](#0BSD) (1)
+- [Elastic License 2.0](#Elastic-2.0) (1)
+- [The Unlicense](#Unlicense) (1)
+
+## All license text
+### 0BSD
+BSD Zero Clause License
+
+#### Used by
+- [adler2]( https://github.com/oyvindln/adler2 ) 2.0.1
+
+#### License
+```
+Copyright (C) Jonas Schievink <jonasschievink@gmail.com>
+
+Permission to use, copy, modify, and/or distribute this software for
+any purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [encoding_rs]( https://github.com/hsivonen/encoding_rs ) 0.8.35
+- [iri-string]( https://github.com/lo48576/iri-string ) 0.7.10
+- [utf8_iter]( https://github.com/hsivonen/utf8_iter ) 1.0.4
+- [zeroize]( https://github.com/RustCrypto/utils ) 1.8.2
+
+#### License
+```
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [windows-core]( https://github.com/microsoft/windows-rs ) 0.62.2
+- [windows-implement]( https://github.com/microsoft/windows-rs ) 0.60.2
+- [windows-interface]( https://github.com/microsoft/windows-rs ) 0.59.3
+- [windows-link]( https://github.com/microsoft/windows-rs ) 0.2.1
+- [windows-registry]( https://github.com/microsoft/windows-rs ) 0.6.1
+- [windows-result]( https://github.com/microsoft/windows-rs ) 0.4.1
+- [windows-strings]( https://github.com/microsoft/windows-rs ) 0.5.1
+- [windows-sys]( https://github.com/microsoft/windows-rs ) 0.60.2
+- [windows-sys]( https://github.com/microsoft/windows-rs ) 0.61.2
+- [windows-targets]( https://github.com/microsoft/windows-rs ) 0.53.5
+- [windows_aarch64_gnullvm]( https://github.com/microsoft/windows-rs ) 0.53.1
+- [windows_aarch64_msvc]( https://github.com/microsoft/windows-rs ) 0.53.1
+- [windows_i686_gnu]( https://github.com/microsoft/windows-rs ) 0.53.1
+- [windows_i686_gnullvm]( https://github.com/microsoft/windows-rs ) 0.53.1
+- [windows_i686_msvc]( https://github.com/microsoft/windows-rs ) 0.53.1
+- [windows_x86_64_gnu]( https://github.com/microsoft/windows-rs ) 0.53.1
+- [windows_x86_64_gnullvm]( https://github.com/microsoft/windows-rs ) 0.53.1
+- [windows_x86_64_msvc]( https://github.com/microsoft/windows-rs ) 0.53.1
+
+#### License
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (c) Microsoft Corporation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [zerocopy]( https://github.com/google/zerocopy ) 0.8.39
+
+#### License
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 The Fuchsia Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [ipnet]( https://github.com/krisprice/ipnet ) 2.11.0
+
+#### License
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 Juniper Networks, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [json-patch]( https://github.com/idubrov/json-patch ) 4.1.0
+
+#### License
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [anstream]( https://github.com/rust-cli/anstyle.git ) 0.6.21
+- [anstyle-parse]( https://github.com/rust-cli/anstyle.git ) 0.2.7
+- [anstyle-query]( https://github.com/rust-cli/anstyle.git ) 1.1.4
+- [anstyle-wincon]( https://github.com/rust-cli/anstyle.git ) 3.0.10
+- [anstyle]( https://github.com/rust-cli/anstyle.git ) 1.0.13
+- [clap]( https://github.com/clap-rs/clap ) 4.5.48
+- [clap_builder]( https://github.com/clap-rs/clap ) 4.5.48
+- [clap_derive]( https://github.com/clap-rs/clap ) 4.5.47
+- [clap_lex]( https://github.com/clap-rs/clap ) 0.7.5
+- [colorchoice]( https://github.com/rust-cli/anstyle.git ) 1.0.4
+- [crc32fast]( https://github.com/srijs/rust-crc32fast ) 1.5.0
+- [env_filter]( https://github.com/rust-cli/env_logger ) 0.1.3
+- [env_logger]( https://github.com/rust-cli/env_logger ) 0.11.8
+- [foreign-types-shared]( https://github.com/sfackler/foreign-types ) 0.1.1
+- [foreign-types]( https://github.com/sfackler/foreign-types ) 0.3.2
+- [is_terminal_polyfill]( https://github.com/polyfill-rs/is_terminal_polyfill ) 1.70.1
+- [native-tls]( https://github.com/sfackler/rust-native-tls ) 0.2.14
+- [once_cell_polyfill]( https://github.com/polyfill-rs/once_cell_polyfill ) 1.70.1
+- [openssl-macros]( https://crates.io/crates/openssl-macros ) 0.1.1
+- [openssl]( https://github.com/rust-openssl/rust-openssl ) 0.10.75
+
+#### License
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [jsonptr]( https://github.com/chanced/jsonptr ) 0.7.1
+
+#### License
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+Copyright 2024 Chance Dinkins
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [futures-channel]( https://github.com/rust-lang/futures-rs ) 0.3.31
+- [futures-core]( https://github.com/rust-lang/futures-rs ) 0.3.31
+- [futures-executor]( https://github.com/rust-lang/futures-rs ) 0.3.31
+- [futures-io]( https://github.com/rust-lang/futures-rs ) 0.3.31
+- [futures-macro]( https://github.com/rust-lang/futures-rs ) 0.3.31
+- [futures-sink]( https://github.com/rust-lang/futures-rs ) 0.3.31
+- [futures-task]( https://github.com/rust-lang/futures-rs ) 0.3.31
+- [futures-util]( https://github.com/rust-lang/futures-rs ) 0.3.31
+- [futures]( https://github.com/rust-lang/futures-rs ) 0.3.31
+
+#### License
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright (c) 2016 Alex Crichton
+Copyright (c) 2017 The Tokio Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [reqwest]( https://github.com/seanmonstar/reqwest ) 0.12.28
+
+#### License
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2016 Sean McArthur
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [http]( https://github.com/hyperium/http ) 1.4.0
+
+#### License
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2017 http-rs authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [askama]( https://github.com/askama-rs/askama ) 0.15.4
+- [askama_derive]( https://github.com/askama-rs/askama ) 0.15.4
+- [askama_macros]( https://github.com/askama-rs/askama ) 0.15.4
+- [askama_parser]( https://github.com/askama-rs/askama ) 0.15.4
+
+#### License
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2017-2020 Dirkjan Ochtman
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [pin-utils]( https://github.com/rust-lang-nursery/pin-utils ) 0.1.0
+
+#### License
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2018 The pin-utils authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [ppv-lite86]( https://github.com/cryptocorrosion/cryptocorrosion ) 0.2.21
+
+#### License
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2019 The CryptoCorrosion Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [iana-time-zone-haiku]( https://github.com/strawlab/iana-time-zone ) 0.1.2
+- [iana-time-zone]( https://github.com/strawlab/iana-time-zone ) 0.1.65
+
+#### License
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2020 Andrew Straw
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [rustls-pki-types]( https://github.com/rustls/pki-types ) 1.14.0
+
+#### License
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2023 Dirkjan Ochtman
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [atomic-waker]( https://github.com/smol-rs/atomic-waker ) 1.1.2
+- [autocfg]( https://github.com/cuviper/autocfg ) 1.5.0
+- [base64]( https://github.com/marshallpierce/rust-base64 ) 0.22.1
+- [bitflags]( https://github.com/bitflags/bitflags ) 2.10.0
+- [bumpalo]( https://github.com/fitzgen/bumpalo ) 3.19.1
+- [cc]( https://github.com/rust-lang/cc-rs ) 1.2.55
+- [cfg-if]( https://github.com/rust-lang/cfg-if ) 1.0.4
+- [core-foundation-sys]( https://github.com/servo/core-foundation-rs ) 0.8.7
+- [core-foundation]( https://github.com/servo/core-foundation-rs ) 0.9.4
+- [crossbeam-deque]( https://github.com/crossbeam-rs/crossbeam ) 0.8.6
+- [crossbeam-epoch]( https://github.com/crossbeam-rs/crossbeam ) 0.9.18
+- [crossbeam-utils]( https://github.com/crossbeam-rs/crossbeam ) 0.8.21
+- [displaydoc]( https://github.com/yaahc/displaydoc ) 0.2.5
+- [either]( https://github.com/rayon-rs/either ) 1.15.0
+- [equivalent]( https://github.com/indexmap-rs/equivalent ) 1.0.2
+- [errno]( https://github.com/lambda-fairy/rust-errno ) 0.3.14
+- [eyre]( https://github.com/eyre-rs/eyre ) 0.6.12
+- [fastrand]( https://github.com/smol-rs/fastrand ) 2.3.0
+- [filetime]( https://github.com/alexcrichton/filetime ) 0.2.27
+- [find-msvc-tools]( https://github.com/rust-lang/cc-rs ) 0.1.9
+- [flate2]( https://github.com/rust-lang/flate2-rs ) 1.1.9
+- [fnv]( https://github.com/servo/rust-fnv ) 1.0.7
+- [form_urlencoded]( https://github.com/servo/rust-url ) 1.2.2
+- [hashbrown]( https://github.com/rust-lang/hashbrown ) 0.16.1
+- [heck]( https://github.com/withoutboats/heck ) 0.5.0
+- [httparse]( https://github.com/seanmonstar/httparse ) 1.10.1
+- [hyper-tls]( https://github.com/hyperium/hyper-tls ) 0.6.0
+- [idna]( https://github.com/servo/rust-url/ ) 1.1.0
+- [idna_adapter]( https://github.com/hsivonen/idna_adapter ) 1.2.1
+- [indexmap]( https://github.com/indexmap-rs/indexmap ) 2.13.0
+- [js-sys]( https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ) 0.3.85
+- [lazy_static]( https://github.com/rust-lang-nursery/lazy-static.rs ) 1.5.0
+- [linux-raw-sys]( https://github.com/sunfishcode/linux-raw-sys ) 0.11.0
+- [lock_api]( https://github.com/Amanieu/parking_lot ) 0.4.14
+- [log]( https://github.com/rust-lang/log ) 0.4.29
+- [mime]( https://github.com/hyperium/mime ) 0.3.17
+- [num-traits]( https://github.com/rust-num/num-traits ) 0.2.19
+- [once_cell]( https://github.com/matklad/once_cell ) 1.21.3
+- [openssl-probe]( https://github.com/alexcrichton/openssl-probe ) 0.1.6
+- [parking_lot]( https://github.com/Amanieu/parking_lot ) 0.12.5
+- [parking_lot_core]( https://github.com/Amanieu/parking_lot ) 0.9.12
+- [percent-encoding]( https://github.com/servo/rust-url/ ) 2.3.2
+- [pkg-config]( https://github.com/rust-lang/pkg-config-rs ) 0.3.32
+- [rayon-core]( https://github.com/rayon-rs/rayon ) 1.13.0
+- [rayon]( https://github.com/rayon-rs/rayon ) 1.11.0
+- [regex-automata]( https://github.com/rust-lang/regex ) 0.4.14
+- [regex-syntax]( https://github.com/rust-lang/regex ) 0.8.9
+- [regex]( https://github.com/rust-lang/regex ) 1.12.3
+- [rustc_version]( https://github.com/djc/rustc-version-rs ) 0.4.1
+- [rustix]( https://github.com/bytecodealliance/rustix ) 1.1.3
+- [scopeguard]( https://github.com/bluss/scopeguard ) 1.2.0
+- [security-framework-sys]( https://github.com/kornelski/rust-security-framework ) 2.15.0
+- [security-framework]( https://github.com/kornelski/rust-security-framework ) 2.11.1
+- [serde_with]( https://github.com/jonasbb/serde_with/ ) 3.16.1
+- [serde_with_macros]( https://github.com/jonasbb/serde_with/ ) 3.16.1
+- [signal-hook-registry]( https://github.com/vorner/signal-hook ) 1.4.8
+- [smallvec]( https://github.com/servo/rust-smallvec ) 1.15.1
+- [socket2]( https://github.com/rust-lang/socket2 ) 0.6.2
+- [stable_deref_trait]( https://github.com/storyyeller/stable_deref_trait ) 1.2.1
+- [system-configuration-sys]( https://github.com/mullvad/system-configuration-rs ) 0.6.0
+- [system-configuration]( https://github.com/mullvad/system-configuration-rs ) 0.7.0
+- [tar]( https://github.com/alexcrichton/tar-rs ) 0.4.44
+- [tempfile]( https://github.com/Stebalien/tempfile ) 3.24.0
+- [unicase]( https://github.com/seanmonstar/unicase ) 2.9.0
+- [url]( https://github.com/servo/rust-url ) 2.5.8
+- [uuid]( https://github.com/uuid-rs/uuid ) 1.20.0
+- [version_check]( https://github.com/SergioBenitez/version_check ) 0.9.5
+- [wasi]( https://github.com/bytecodealliance/wasi ) 0.11.1+wasi-snapshot-preview1
+- [wasm-bindgen-futures]( https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ) 0.4.58
+- [wasm-bindgen-macro-support]( https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ) 0.2.108
+- [wasm-bindgen-macro]( https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ) 0.2.108
+- [wasm-bindgen-shared]( https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ) 0.2.108
+- [wasm-bindgen]( https://github.com/wasm-bindgen/wasm-bindgen ) 0.2.108
+- [web-sys]( https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ) 0.3.85
+- [wit-bindgen]( https://github.com/bytecodealliance/wit-bindgen ) 0.51.0
+
+#### License
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [rand_core]( https://github.com/rust-random/rand ) 0.6.4
+- [rand_core]( https://github.com/rust-random/rand ) 0.9.5
+
+#### License
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     https://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [getrandom]( https://github.com/rust-random/getrandom ) 0.2.17
+- [getrandom]( https://github.com/rust-random/getrandom ) 0.3.4
+- [rand_chacha]( https://github.com/rust-random/rand ) 0.3.1
+
+#### License
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     https://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [fs-err]( https://github.com/andrewhickman/fs-err ) 3.3.0
+
+#### License
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [vcpkg]( https://github.com/mcgoo/vcpkg-rs ) 0.2.15
+
+#### License
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [httpdate]( https://github.com/pyfisch/httpdate ) 1.0.3
+
+#### License
+```
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [elasticsearch]( https://github.com/elastic/elasticsearch-rs ) 9.1.0-alpha.1
+- [android_system_properties]( https://github.com/nical/android_system_properties ) 0.1.5
+- [async-compression]( https://github.com/Nullus157/async-compression ) 0.4.39
+- [compression-codecs]( https://github.com/Nullus157/async-compression ) 0.4.36
+- [compression-core]( https://github.com/Nullus157/async-compression ) 0.4.31
+- [dyn-clone]( https://github.com/dtolnay/dyn-clone ) 1.0.20
+- [ident_case]( https://github.com/TedDriggs/ident_case ) 1.0.1
+- [indenter]( https://github.com/yaahc/indenter ) 0.3.4
+- [itoa]( https://github.com/dtolnay/itoa ) 1.0.17
+- [libc]( https://github.com/rust-lang/libc ) 0.2.180
+- [miniz_oxide]( https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ) 0.8.9
+- [pin-project-lite]( https://github.com/taiki-e/pin-project-lite ) 0.2.16
+- [portable-atomic-util]( https://github.com/taiki-e/portable-atomic ) 0.2.4
+- [portable-atomic]( https://github.com/taiki-e/portable-atomic ) 1.11.1
+- [proc-macro2]( https://github.com/dtolnay/proc-macro2 ) 1.0.106
+- [quote]( https://github.com/dtolnay/quote ) 1.0.44
+- [r-efi]( https://github.com/r-efi/r-efi ) 5.3.0
+- [rand]( https://github.com/rust-random/rand ) 0.8.5
+- [rand]( https://github.com/rust-random/rand ) 0.9.2
+- [rand_chacha]( https://github.com/rust-random/rand ) 0.9.0
+- [rustc-hash]( https://github.com/rust-lang/rustc-hash ) 2.1.1
+- [rustversion]( https://github.com/dtolnay/rustversion ) 1.0.22
+- [ryu]( https://github.com/dtolnay/ryu ) 1.0.22
+- [semver]( https://github.com/dtolnay/semver ) 1.0.27
+- [serde]( https://github.com/serde-rs/serde ) 1.0.228
+- [serde_core]( https://github.com/serde-rs/serde ) 1.0.228
+- [serde_derive]( https://github.com/serde-rs/serde ) 1.0.228
+- [serde_json]( https://github.com/serde-rs/json ) 1.0.149
+- [serde_path_to_error]( https://github.com/dtolnay/path-to-error ) 0.1.20
+- [serde_urlencoded]( https://github.com/nox/serde_urlencoded ) 0.7.1
+- [serde_yaml]( https://github.com/dtolnay/serde-yaml ) 0.9.34+deprecated
+- [shlex]( https://github.com/comex/rust-shlex ) 1.3.0
+- [syn]( https://github.com/dtolnay/syn ) 2.0.114
+- [sync_wrapper]( https://github.com/Actyx/sync_wrapper ) 1.0.2
+- [thiserror-impl]( https://github.com/dtolnay/thiserror ) 1.0.69
+- [thiserror]( https://github.com/dtolnay/thiserror ) 1.0.69
+- [typed-path]( https://github.com/chipsenkbeil/typed-path ) 0.12.2
+- [unicode-ident]( https://github.com/dtolnay/unicode-ident ) 1.0.22
+- [utf8parse]( https://github.com/alacritty/vte ) 0.2.2
+- [wasip2]( https://github.com/bytecodealliance/wasi-rs ) 1.0.2+wasi-0.2.9
+
+#### License
+```
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [chrono]( https://github.com/chronotope/chrono ) 0.4.43
+
+#### License
+```
+Rust-chrono is dual-licensed under The MIT License [1] and
+Apache 2.0 License [2]. Copyright (c) 2014--2026, Kang Seonghoon and
+contributors.
+
+Nota Bene: This is same as the Rust Project's own license.
+
+
+[1]: <http://opensource.org/licenses/MIT>, which is reproduced below:
+
+~~~~
+The MIT License (MIT)
+
+Copyright (c) 2014, Kang Seonghoon.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+~~~~
+
+
+[2]: <http://www.apache.org/licenses/LICENSE-2.0>, which is reproduced below:
+
+~~~~
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+~~~~
+
+
+```
+### BSD-3-Clause
+BSD 3-Clause "New" or "Revised" License
+
+#### Used by
+- [matchit]( https://github.com/ibraheemdev/matchit ) 0.8.4
+
+#### License
+```
+BSD 3-Clause License
+
+Copyright (c) 2013, Julien Schmidt
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+```
+### BSD-3-Clause
+BSD 3-Clause "New" or "Revised" License
+
+#### Used by
+- [encoding_rs]( https://github.com/hsivonen/encoding_rs ) 0.8.35
+
+#### License
+```
+Copyright © WHATWG (Apple, Google, Mozilla, Microsoft).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+```
+### Elastic-2.0
+Elastic License 2.0
+
+#### Used by
+- [esdiag]( https://crates.io/crates/esdiag ) 0.14.0-SNAPSHOT
+
+#### License
+```
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.
+```
+### MIT
+MIT License
+
+#### Used by
+- [openssl-sys]( https://github.com/rust-openssl/rust-openssl ) 0.9.111
+
+#### License
+```
+Copyright (c) 2014 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [mio]( https://github.com/tokio-rs/mio ) 1.1.1
+
+#### License
+```
+Copyright (c) 2014 Carl Lerche and other MIO contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [hyper]( https://github.com/hyperium/hyper ) 1.8.1
+
+#### License
+```
+Copyright (c) 2014-2025 Sean McArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [schannel]( https://github.com/steffengy/schannel-rs ) 0.1.28
+
+#### License
+```
+Copyright (c) 2015 steffengy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [redox_syscall]( https://gitlab.redox-os.org/redox-os/syscall ) 0.5.18
+
+#### License
+```
+Copyright (c) 2017 Redox OS Developers
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [h2]( https://github.com/hyperium/h2 ) 0.4.13
+
+#### License
+```
+Copyright (c) 2017 h2 authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [bytes]( https://github.com/tokio-rs/bytes ) 1.11.1
+
+#### License
+```
+Copyright (c) 2018 Carl Lerche
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [want]( https://github.com/seanmonstar/want ) 0.3.1
+
+#### License
+```
+Copyright (c) 2018-2019 Sean McArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [try-lock]( https://github.com/seanmonstar/try-lock ) 0.2.5
+
+#### License
+```
+Copyright (c) 2018-2023 Sean McArthur
+Copyright (c) 2016 Alex Crichton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [slab]( https://github.com/tokio-rs/slab ) 0.4.12
+
+#### License
+```
+Copyright (c) 2019 Carl Lerche
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [tokio-native-tls]( https://github.com/tokio-rs/tls ) 0.3.1
+- [tracing-core]( https://github.com/tokio-rs/tracing ) 0.1.36
+- [tracing]( https://github.com/tokio-rs/tracing ) 0.1.44
+
+#### License
+```
+Copyright (c) 2019 Tokio Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [tower-layer]( https://github.com/tower-rs/tower ) 0.3.3
+- [tower-service]( https://github.com/tower-rs/tower ) 0.3.3
+- [tower]( https://github.com/tower-rs/tower ) 0.5.3
+
+#### License
+```
+Copyright (c) 2019 Tower Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [axum]( https://github.com/tokio-rs/axum ) 0.8.8
+
+#### License
+```
+Copyright (c) 2019 axum Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [tower-http]( https://github.com/tower-rs/tower-http ) 0.6.8
+
+#### License
+```
+Copyright (c) 2019-2021 Tower Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [http-body]( https://github.com/hyperium/http-body ) 1.0.1
+
+#### License
+```
+Copyright (c) 2019-2024 Sean McArthur & Hyper Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [http-body-util]( https://github.com/hyperium/http-body ) 0.1.3
+
+#### License
+```
+Copyright (c) 2019-2025 Sean McArthur & Hyper Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [hyper-util]( https://github.com/hyperium/hyper-util ) 0.1.20
+
+#### License
+```
+Copyright (c) 2023-2025 Sean McArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [synstructure]( https://github.com/mystor/synstructure ) 0.13.2
+
+#### License
+```
+Copyright 2016 Nika Layzell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [axum-macros]( https://github.com/tokio-rs/axum ) 0.5.0
+
+#### License
+```
+Copyright 2021 Axum Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [axum-server]( https://github.com/programatik29/axum-server ) 0.8.0
+
+#### License
+```
+Copyright 2021 Axum Server Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [datastar]( https://github.com/starfederation/datastar-rust ) 0.3.1
+
+#### License
+```
 Copyright © Star Federation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -11,3 +5764,703 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [darling]( https://github.com/TedDriggs/darling ) 0.21.3
+- [darling_core]( https://github.com/TedDriggs/darling ) 0.21.3
+- [darling_macro]( https://github.com/TedDriggs/darling ) 0.21.3
+
+#### License
+```
+MIT License
+
+Copyright (c) 2017 Ted Driggs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [tokio-macros]( https://github.com/tokio-rs/tokio ) 2.6.0
+
+#### License
+```
+MIT License
+
+Copyright (c) 2019 Yoshua Wuyts
+Copyright (c) Tokio Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [axum-core]( https://github.com/tokio-rs/axum ) 0.5.6
+
+#### License
+```
+MIT License
+
+Copyright (c) 2019–2025 axum Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+### MIT
+MIT License
+
+#### Used by
+- [multer]( https://github.com/rwf2/multer ) 3.1.0
+
+#### License
+```
+MIT License
+
+Copyright (c) 2020 Rousan Ali
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [matchit]( https://github.com/ibraheemdev/matchit ) 0.8.4
+
+#### License
+```
+MIT License
+
+Copyright (c) 2022 Ibraheem Ahmed
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [libredox]( https://gitlab.redox-os.org/redox-os/libredox.git ) 0.1.12
+
+#### License
+```
+MIT License
+
+Copyright (c) 2023 4lDO2
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [async-stream-impl]( https://github.com/tokio-rs/async-stream ) 0.3.6
+- [async-stream]( https://github.com/tokio-rs/async-stream ) 0.3.6
+- [void]( https://github.com/reem/rust-void.git ) 1.0.2
+
+#### License
+```
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [tokio-stream]( https://github.com/tokio-rs/tokio ) 0.1.18
+- [tokio-test]( https://github.com/tokio-rs/tokio ) 0.4.5
+- [tokio-util]( https://github.com/tokio-rs/tokio ) 0.7.18
+- [tokio]( https://github.com/tokio-rs/tokio ) 1.49.0
+
+#### License
+```
+MIT License
+
+Copyright (c) Tokio Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [simd-adler32]( https://github.com/mcountryman/simd-adler32 ) 0.3.8
+
+#### License
+```
+MIT License
+
+Copyright (c) [2021] [Marvin Countryman]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [unsafe-libyaml]( https://github.com/dtolnay/unsafe-libyaml ) 0.2.11
+- [zmij]( https://github.com/dtolnay/zmij ) 1.0.19
+
+#### License
+```
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [winnow]( https://github.com/winnow-rs/winnow ) 0.7.14
+
+#### License
+```
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [spin]( https://github.com/mvdnes/spin-rs.git ) 0.9.8
+
+#### License
+```
+The MIT License (MIT)
+
+Copyright (c) 2014 Mathijs van de Nes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+### MIT
+MIT License
+
+#### Used by
+- [zip]( https://github.com/zip-rs/zip2.git ) 8.1.0
+
+#### License
+```
+The MIT License (MIT)
+
+Copyright (c) 2014 Mathijs van de Nes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Some files in the "tests/data" subdirectory of this repository are under other
+licences; see files named LICENSE.*.txt for details.
+```
+### MIT
+MIT License
+
+#### Used by
+- [aho-corasick]( https://github.com/BurntSushi/aho-corasick ) 1.1.4
+- [jiff]( https://github.com/BurntSushi/jiff ) 0.2.15
+- [memchr]( https://github.com/BurntSushi/memchr ) 2.8.0
+
+#### License
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Andrew Gallant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [strsim]( https://github.com/rapidfuzz/strsim-rs ) 0.11.1
+
+#### License
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Danny Guo
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com>
+Copyright (c) 2018 Akash Kurdekar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [mime_guess]( https://github.com/abonander/mime_guess ) 2.0.5
+
+#### License
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Austin Bonander
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+```
+### MIT
+MIT License
+
+#### Used by
+- [urlencoding]( https://github.com/kornelski/rust_urlencoding ) 2.1.3
+
+#### License
+```
+© 2016 Bertram Truong
+© 2021 Kornel Lesiński
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+```
+### Unicode-3.0
+Unicode License v3
+
+#### Used by
+- [unicode-ident]( https://github.com/dtolnay/unicode-ident ) 1.0.22
+
+#### License
+```
+UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2023 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.
+
+```
+### Unicode-3.0
+Unicode License v3
+
+#### Used by
+- [icu_collections]( https://github.com/unicode-org/icu4x ) 2.1.1
+- [icu_locale_core]( https://github.com/unicode-org/icu4x ) 2.1.1
+- [icu_normalizer]( https://github.com/unicode-org/icu4x ) 2.1.1
+- [icu_normalizer_data]( https://github.com/unicode-org/icu4x ) 2.1.1
+- [icu_properties]( https://github.com/unicode-org/icu4x ) 2.1.2
+- [icu_properties_data]( https://github.com/unicode-org/icu4x ) 2.1.2
+- [icu_provider]( https://github.com/unicode-org/icu4x ) 2.1.1
+- [litemap]( https://github.com/unicode-org/icu4x ) 0.8.1
+- [potential_utf]( https://github.com/unicode-org/icu4x ) 0.1.4
+- [tinystr]( https://github.com/unicode-org/icu4x ) 0.8.2
+- [writeable]( https://github.com/unicode-org/icu4x ) 0.6.2
+- [yoke-derive]( https://github.com/unicode-org/icu4x ) 0.8.1
+- [yoke]( https://github.com/unicode-org/icu4x ) 0.8.1
+- [zerofrom-derive]( https://github.com/unicode-org/icu4x ) 0.1.6
+- [zerofrom]( https://github.com/unicode-org/icu4x ) 0.1.6
+- [zerotrie]( https://github.com/unicode-org/icu4x ) 0.2.3
+- [zerovec-derive]( https://github.com/unicode-org/icu4x ) 0.11.2
+- [zerovec]( https://github.com/unicode-org/icu4x ) 0.11.5
+
+#### License
+```
+UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 2020-2024 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
+
+—
+
+Portions of ICU4X may have been adapted from ICU4C and/or ICU4J.
+ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation and others.
+
+```
+### Unlicense
+The Unlicense
+
+#### Used by
+- [portpicker]( https://github.com/Dentosal/portpicker-rs ) 0.1.1
+
+#### License
+```
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>
+```
+

--- a/about.hbs
+++ b/about.hbs
@@ -1,0 +1,26 @@
+Elastic Stack Diagnostics (ESDiag)
+Copyright 2012-2025 Elasticsearch B.V.
+
+# Third Party License Notifications
+This document lists the licenses of the projects used in esdiag.
+
+## Overview of licenses
+{{#each overview}}
+- [{{{name}}}](#{{{id}}}) ({{count}})
+{{/each}}
+
+## All license text
+{{#each licenses}}
+### {{{id}}}
+{{{name}}}
+
+#### Used by
+{{#each used_by}}
+- [{{{crate.name}}}]({{#if crate.repository}} {{crate.repository}} {{else}} https://crates.io/crates/{{crate.name}} {{/if}}) {{{crate.version}}}
+{{/each}}
+
+#### License
+```
+{{{text}}}
+```
+{{/each}}

--- a/about.toml
+++ b/about.toml
@@ -1,0 +1,13 @@
+accepted = [
+    "0BSD",
+    "Apache-2.0",
+    "BSL-1.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Elastic-2.0",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,7 @@ use flate2::Compression;
 use std::env;
 use std::fs::File;
 use std::path::Path;
+use std::process::Command;
 use tar::Builder;
 
 fn main() {
@@ -11,6 +12,62 @@ fn main() {
 
     println!("cargo:rerun-if-changed=assets");
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+    println!("cargo:rerun-if-changed=about.hbs");
+
+    let notice_path = Path::new("NOTICE.txt");
+    let sbom_path = Path::new("esdiag.spdx.json");
+    let cargo_toml_path = Path::new("Cargo.toml");
+    let about_hbs_path = Path::new("about.hbs");
+
+    let should_generate = if !notice_path.exists() || !sbom_path.exists() {
+        true
+    } else {
+        let notice_mtime = notice_path.metadata().and_then(|m| m.modified()).ok();
+        let sbom_mtime = sbom_path.metadata().and_then(|m| m.modified()).ok();
+        let cargo_mtime = cargo_toml_path.metadata().and_then(|m| m.modified()).ok();
+        let about_mtime = about_hbs_path.metadata().and_then(|m| m.modified()).ok();
+
+        match (notice_mtime, sbom_mtime, cargo_mtime, about_mtime) {
+            (Some(nm), Some(sm), Some(cm), Some(am)) => cm > nm || am > nm || cm > sm,
+            _ => true,
+        }
+    };
+
+    if should_generate {
+        let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+
+        // Generate NOTICE.txt
+        let output_about = Command::new(&cargo)
+            .args(["about", "generate", "about.hbs"])
+            .output()
+            .expect("failed to execute cargo about. Is cargo-about installed?");
+
+        if output_about.status.success() {
+            std::fs::write(notice_path, output_about.stdout).expect("failed to write NOTICE.txt");
+        } else {
+            panic!(
+                "cargo about failed: {}",
+                String::from_utf8_lossy(&output_about.stderr)
+            );
+        }
+
+        // Generate esdiag.spdx.json
+        let output_sbom = Command::new(&cargo)
+            .args(["sbom"])
+            .output()
+            .expect("failed to execute cargo sbom. Is cargo-sbom installed?");
+
+        if output_sbom.status.success() {
+            std::fs::write(sbom_path, output_sbom.stdout)
+                .expect("failed to write esdiag.spdx.json");
+        } else {
+            panic!(
+                "cargo sbom failed: {}",
+                String::from_utf8_lossy(&output_sbom.stderr)
+            );
+        }
+    }
 
     let assets_dir = Path::new("assets");
     if !assets_dir.exists() || !assets_dir.is_dir() {

--- a/esdiag.spdx.json
+++ b/esdiag.spdx.json
@@ -1,20 +1,20 @@
 {
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
-    "created": "2026-02-02T23:22:43Z",
+    "created": "2026-02-18T03:59:31Z",
     "creators": [
       "Tool: cargo-sbom-v0.10.0"
     ]
   },
   "dataLicense": "CC0-1.0",
-  "documentNamespace": "https://spdx.org/spdxdocs/esdiag-9460746d-d43a-46fb-9a01-dad37fe37365",
+  "documentNamespace": "https://spdx.org/spdxdocs/esdiag-f015f09f-d65c-4723-aabb-285c97b38d3b",
   "files": [
     {
       "SPDXID": "SPDXRef-File-esdiag",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "86e9484d9ba23de7087363d9810b05361eb00470"
+          "checksumValue": "f4e44369d911fc61aaab01fd0663957cba58ddae"
         }
       ],
       "fileName": "./Cargo.lock",
@@ -28,7 +28,7 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "86e9484d9ba23de7087363d9810b05361eb00470"
+          "checksumValue": "f4e44369d911fc61aaab01fd0663957cba58ddae"
         }
       ],
       "fileName": "./Cargo.lock",
@@ -41,1857 +41,87 @@
   "name": "esdiag",
   "packages": [
     {
-      "SPDXID": "SPDXRef-Package-miniz--oxide-0.8.9",
-      "description": "DEFLATE compression and decompression library rewritten in Rust based on miniz",
+      "SPDXID": "SPDXRef-Package-yoke-0.8.1",
+      "description": "Abstraction allowing borrowed data to be carried along with the backing data it borrows from",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/miniz_oxide@0.8.9",
+          "referenceLocator": "pkg:cargo/yoke@0.8.1",
           "referenceType": "purl"
         }
       ],
-      "homepage": "https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide",
-      "licenseConcluded": "MIT OR Zlib OR Apache-2.0",
-      "licenseDeclared": "MIT OR Zlib OR Apache-2.0",
-      "name": "miniz_oxide",
-      "versionInfo": "0.8.9"
+      "licenseConcluded": "Unicode-3.0",
+      "licenseDeclared": "Unicode-3.0",
+      "name": "yoke",
+      "versionInfo": "0.8.1"
     },
     {
-      "SPDXID": "SPDXRef-Package-zeroize-1.8.2",
-      "description": "Securely clear secrets from memory with a simple trait built on\nstable Rust primitives which guarantee memory is zeroed using an\noperation will not be 'optimized away' by the compiler.\nUses a portable pure Rust implementation that works everywhere,\neven WASM!\n",
+      "SPDXID": "SPDXRef-Package-tokio-macros-2.6.0",
+      "description": "Tokio's proc macros.\n",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/zeroize@1.8.2",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/RustCrypto/utils/tree/master/zeroize",
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "zeroize",
-      "versionInfo": "1.8.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows-sys-0.61.2",
-      "description": "Rust for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows-sys@0.61.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows-sys",
-      "versionInfo": "0.61.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-iana-time-zone-0.1.64",
-      "description": "get the IANA time zone for the current system",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/iana-time-zone@0.1.64",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "iana-time-zone",
-      "versionInfo": "0.1.64"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-tracing-0.1.41",
-      "description": "Application-level tracing for Rust.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/tracing@0.1.41",
+          "referenceLocator": "pkg:cargo/tokio-macros@2.6.0",
           "referenceType": "purl"
         }
       ],
       "homepage": "https://tokio.rs",
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
-      "name": "tracing",
-      "versionInfo": "0.1.41"
+      "name": "tokio-macros",
+      "versionInfo": "2.6.0"
     },
     {
-      "SPDXID": "SPDXRef-Package-equivalent-1.0.2",
-      "description": "Traits for key comparison in maps.",
+      "SPDXID": "SPDXRef-Package-icu--locale--core-2.1.1",
+      "description": "API for managing Unicode Language and Locale Identifiers",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/equivalent@1.0.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "equivalent",
-      "versionInfo": "1.0.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows--x86--64--gnu-0.52.6",
-      "description": "Import lib for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_x86_64_gnu@0.52.6",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_x86_64_gnu",
-      "versionInfo": "0.52.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-libz-rs-sys-0.5.2",
-      "description": "A memory-safe zlib implementation written in rust",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/libz-rs-sys@0.5.2",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/trifectatechfoundation/zlib-rs",
-      "licenseConcluded": "Zlib",
-      "licenseDeclared": "Zlib",
-      "name": "libz-rs-sys",
-      "versionInfo": "0.5.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-time-macros-0.2.24",
-      "description": "    Procedural macros for the time crate.\n    This crate is an implementation detail and should not be relied upon directly.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/time-macros@0.2.24",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "time-macros",
-      "versionInfo": "0.2.24"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-rand--chacha-0.9.0",
-      "description": "ChaCha random number generator\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/rand_chacha@0.9.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://rust-random.github.io/book",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "rand_chacha",
-      "versionInfo": "0.9.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-arbitrary-1.4.2",
-      "description": "The trait for generating structured data from unstructured data",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/arbitrary@1.4.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "arbitrary",
-      "versionInfo": "1.4.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-scopeguard-1.2.0",
-      "description": "A RAII scope guard that will run a given closure when it goes out of scope,\neven if the code between panics (assuming unwinding panic).\n\nDefines the macros `defer!`, `defer_on_unwind!`, `defer_on_success!` as\nshorthands for guards with one of the implemented strategies.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/scopeguard@1.2.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "scopeguard",
-      "versionInfo": "1.2.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-tokio-util-0.7.16",
-      "description": "Additional utilities for working with Tokio.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/tokio-util@0.7.16",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://tokio.rs",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "tokio-util",
-      "versionInfo": "0.7.16"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-anstyle-wincon-3.0.10",
-      "description": "Styling legacy Windows terminals",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/anstyle-wincon@3.0.10",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "anstyle-wincon",
-      "versionInfo": "3.0.10"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-ipnet-2.11.0",
-      "description": "Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/ipnet@2.11.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "ipnet",
-      "versionInfo": "2.11.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-icu--properties-2.0.1",
-      "description": "Definitions for Unicode properties",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/icu_properties@2.0.1",
+          "referenceLocator": "pkg:cargo/icu_locale_core@2.1.1",
           "referenceType": "purl"
         }
       ],
       "homepage": "https://icu4x.unicode.org",
       "licenseConcluded": "Unicode-3.0",
       "licenseDeclared": "Unicode-3.0",
-      "name": "icu_properties",
-      "versionInfo": "2.0.1"
+      "name": "icu_locale_core",
+      "versionInfo": "2.1.1"
     },
     {
-      "SPDXID": "SPDXRef-Package-askama--parser-0.14.0",
-      "description": "Parser for Askama templates",
+      "SPDXID": "SPDXRef-Package-windows--i686--gnu-0.53.1",
+      "description": "Import lib for Windows",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/askama_parser@0.14.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/askama-rs/askama",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "askama_parser",
-      "versionInfo": "0.14.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-log-0.4.28",
-      "description": "A lightweight logging facade for Rust\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/log@0.4.28",
+          "referenceLocator": "pkg:cargo/windows_i686_gnu@0.53.1",
           "referenceType": "purl"
         }
       ],
       "licenseConcluded": "MIT OR Apache-2.0",
       "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "log",
-      "versionInfo": "0.4.28"
+      "name": "windows_i686_gnu",
+      "versionInfo": "0.53.1"
     },
     {
-      "SPDXID": "SPDXRef-Package-idna-1.1.0",
-      "description": "IDNA (Internationalizing Domain Names in Applications) and Punycode.",
+      "SPDXID": "SPDXRef-Package-zerotrie-0.2.3",
+      "description": "A data structure that efficiently maps strings to integers",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/idna@1.1.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "idna",
-      "versionInfo": "1.1.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-icu--collections-2.0.0",
-      "description": "Collection of API for use in ICU libraries.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/icu_collections@2.0.0",
+          "referenceLocator": "pkg:cargo/zerotrie@0.2.3",
           "referenceType": "purl"
         }
       ],
       "homepage": "https://icu4x.unicode.org",
       "licenseConcluded": "Unicode-3.0",
       "licenseDeclared": "Unicode-3.0",
-      "name": "icu_collections",
-      "versionInfo": "2.0.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-regex-1.12.1",
-      "description": "An implementation of regular expressions for Rust. This implementation uses\nfinite automata and guarantees linear time matching on all inputs.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/regex@1.12.1",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/rust-lang/regex",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "regex",
-      "versionInfo": "1.12.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-untrusted-0.9.0",
-      "description": "Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/untrusted@0.9.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "ISC",
-      "licenseDeclared": "ISC",
-      "name": "untrusted",
-      "versionInfo": "0.9.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-quote-1.0.41",
-      "description": "Quasi-quoting macro quote!(...)",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/quote@1.0.41",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "quote",
-      "versionInfo": "1.0.41"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-darling--core-0.21.3",
-      "description": "Helper crate for proc-macro library for reading attributes into structs when\nimplementing custom derives. Use https://crates.io/crates/darling in your code.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/darling_core@0.21.3",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "darling_core",
-      "versionInfo": "0.21.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-thiserror-impl-1.0.69",
-      "description": "Implementation detail of the `thiserror` crate",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/thiserror-impl@1.0.69",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "thiserror-impl",
-      "versionInfo": "1.0.69"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-ryu-1.0.20",
-      "description": "Fast floating point to string conversion",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/ryu@1.0.20",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR BSL-1.0",
-      "licenseDeclared": "Apache-2.0 OR BSL-1.0",
-      "name": "ryu",
-      "versionInfo": "1.0.20"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-encoding--rs-0.8.35",
-      "description": "A Gecko-oriented implementation of the Encoding Standard",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/encoding_rs@0.8.35",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://docs.rs/encoding_rs/",
-      "licenseConcluded": "(Apache-2.0 OR MIT) AND BSD-3-Clause",
-      "licenseDeclared": "(Apache-2.0 OR MIT) AND BSD-3-Clause",
-      "name": "encoding_rs",
-      "versionInfo": "0.8.35"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-http-body-1.0.1",
-      "description": "Trait representing an asynchronous, streaming, HTTP request or response body.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/http-body@1.0.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "http-body",
-      "versionInfo": "1.0.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows-link-0.2.1",
-      "description": "Linking for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows-link@0.2.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows-link",
-      "versionInfo": "0.2.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-darling--macro-0.21.3",
-      "description": "Internal support for a proc-macro library for reading attributes into structs when\nimplementing custom derives. Use https://crates.io/crates/darling in your code.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/darling_macro@0.21.3",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "darling_macro",
-      "versionInfo": "0.21.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows--i686--gnullvm-0.52.6",
-      "description": "Import lib for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_i686_gnullvm@0.52.6",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_i686_gnullvm",
-      "versionInfo": "0.52.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows-sys-0.60.2",
-      "description": "Rust for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows-sys@0.60.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows-sys",
-      "versionInfo": "0.60.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-axum-server-0.7.2",
-      "description": "High level server designed to be used with axum framework.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/axum-server@0.7.2",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/programatik29/axum-server",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "axum-server",
-      "versionInfo": "0.7.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-serde--path--to--error-0.1.20",
-      "description": "Path to the element that failed to deserialize",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/serde_path_to_error@0.1.20",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "serde_path_to_error",
-      "versionInfo": "0.1.20"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows--x86--64--msvc-0.53.1",
-      "description": "Import lib for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_x86_64_msvc@0.53.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_x86_64_msvc",
-      "versionInfo": "0.53.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-is--terminal--polyfill-1.70.1",
-      "description": "Polyfill for `is_terminal` stdlib feature for use with older MSRVs",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/is_terminal_polyfill@1.70.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "is_terminal_polyfill",
-      "versionInfo": "1.70.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-openssl-0.10.73",
-      "description": "OpenSSL bindings",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/openssl@0.10.73",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0",
-      "licenseDeclared": "Apache-2.0",
-      "name": "openssl",
-      "versionInfo": "0.10.73"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-unicase-2.8.1",
-      "description": "A case-insensitive wrapper around strings.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/unicase@2.8.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "unicase",
-      "versionInfo": "2.8.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows--x86--64--gnullvm-0.53.1",
-      "description": "Import lib for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_x86_64_gnullvm@0.53.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_x86_64_gnullvm",
-      "versionInfo": "0.53.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows--x86--64--msvc-0.52.6",
-      "description": "Import lib for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_x86_64_msvc@0.52.6",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_x86_64_msvc",
-      "versionInfo": "0.52.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows-interface-0.59.3",
-      "description": "The interface macro for the Windows crates",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows-interface@0.59.3",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows-interface",
-      "versionInfo": "0.59.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-zlib-rs-0.5.2",
-      "description": "A memory-safe zlib implementation written in rust",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/zlib-rs@0.5.2",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/trifectatechfoundation/zlib-rs",
-      "licenseConcluded": "Zlib",
-      "licenseDeclared": "Zlib",
-      "name": "zlib-rs",
-      "versionInfo": "0.5.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-wasm-bindgen-futures-0.4.54",
-      "description": "Bridging the gap between Rust Futures and JavaScript Promises",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/wasm-bindgen-futures@0.4.54",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "wasm-bindgen-futures",
-      "versionInfo": "0.4.54"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-ref-cast-impl-1.0.25",
-      "description": "Derive implementation for ref_cast::RefCast.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/ref-cast-impl@1.0.25",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "ref-cast-impl",
-      "versionInfo": "1.0.25"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-wasi-0.14.7-plus-wasi-0.2.4",
-      "description": "WASI API bindings for Rust",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/wasi@0.14.7%2Bwasi-0.2.4",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
-      "name": "wasi",
-      "versionInfo": "0.14.7+wasi-0.2.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-anstyle-1.0.13",
-      "description": "ANSI text styling",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/anstyle@1.0.13",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "anstyle",
-      "versionInfo": "1.0.13"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-ref-cast-1.0.25",
-      "description": "Safely cast &T to &U where the struct U contains a single field of type T.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/ref-cast@1.0.25",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "ref-cast",
-      "versionInfo": "1.0.25"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-hyper-rustls-0.27.7",
-      "description": "Rustls+hyper integration for pure rust HTTPS",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/hyper-rustls@0.27.7",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/rustls/hyper-rustls",
-      "licenseConcluded": "Apache-2.0 OR ISC OR MIT",
-      "licenseDeclared": "Apache-2.0 OR ISC OR MIT",
-      "name": "hyper-rustls",
-      "versionInfo": "0.27.7"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-stable--deref--trait-1.2.1",
-      "description": "An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/stable_deref_trait@1.2.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "stable_deref_trait",
-      "versionInfo": "1.2.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-proc-macro2-1.0.101",
-      "description": "A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/proc-macro2@1.0.101",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "proc-macro2",
-      "versionInfo": "1.0.101"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-axum-core-0.5.5",
-      "description": "Core types and traits for axum",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/axum-core@0.5.5",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/tokio-rs/axum",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "axum-core",
-      "versionInfo": "0.5.5"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows--x86--64--gnullvm-0.52.6",
-      "description": "Import lib for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_x86_64_gnullvm@0.52.6",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_x86_64_gnullvm",
-      "versionInfo": "0.52.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-tower-service-0.3.3",
-      "description": "Trait representing an asynchronous, request / response based, client or server.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/tower-service@0.3.3",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/tower-rs/tower",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "tower-service",
-      "versionInfo": "0.3.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-futures-sink-0.3.31",
-      "description": "The asynchronous `Sink` trait for the futures-rs library.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/futures-sink@0.3.31",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://rust-lang.github.io/futures-rs",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "futures-sink",
-      "versionInfo": "0.3.31"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-once--cell-1.21.3",
-      "description": "Single assignment cells and lazy values.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/once_cell@1.21.3",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "once_cell",
-      "versionInfo": "1.21.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-atomic-waker-1.1.2",
-      "description": "A synchronization primitive for task wakeup",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/atomic-waker@1.1.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "atomic-waker",
-      "versionInfo": "1.1.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-winnow-0.7.13",
-      "description": "A byte-oriented, zero-copy, parser combinators library",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/winnow@0.7.13",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "winnow",
-      "versionInfo": "0.7.13"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-basic-toml-0.1.10",
-      "description": "Minimal TOML library with few dependencies",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/basic-toml@0.1.10",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "basic-toml",
-      "versionInfo": "0.1.10"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-heck-0.5.0",
-      "description": "heck is a case conversion library.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/heck@0.5.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "heck",
-      "versionInfo": "0.5.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-subtle-2.6.1",
-      "description": "Pure-Rust traits and utilities for constant-time cryptographic implementations.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/subtle@2.6.1",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://dalek.rs/",
-      "licenseConcluded": "BSD-3-Clause",
-      "licenseDeclared": "BSD-3-Clause",
-      "name": "subtle",
-      "versionInfo": "2.6.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-errno-0.3.14",
-      "description": "Cross-platform interface to the `errno` variable.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/errno@0.3.14",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "errno",
-      "versionInfo": "0.3.14"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-socket2-0.6.0",
-      "description": "Utilities for handling networking sockets with a maximal amount of configuration\npossible intended.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/socket2@0.6.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/rust-lang/socket2",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "socket2",
-      "versionInfo": "0.6.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-sync--wrapper-1.0.2",
-      "description": "A tool for enlisting the compiler's help in proving the absence of concurrency",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/sync_wrapper@1.0.2",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://docs.rs/sync_wrapper",
-      "licenseConcluded": "Apache-2.0",
-      "licenseDeclared": "Apache-2.0",
-      "name": "sync_wrapper",
-      "versionInfo": "1.0.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-bumpalo-3.19.0",
-      "description": "A fast bump allocation arena for Rust.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/bumpalo@3.19.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "bumpalo",
-      "versionInfo": "3.19.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-zerofrom-0.1.6",
-      "description": "ZeroFrom trait for constructing",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/zerofrom@0.1.6",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Unicode-3.0",
-      "licenseDeclared": "Unicode-3.0",
-      "name": "zerofrom",
-      "versionInfo": "0.1.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-num-conv-0.1.0",
-      "description": "`num_conv` is a crate to convert between integer types without using `as` casts. This provides\nbetter certainty when refactoring, makes the exact behavior of code more explicit, and allows using\nturbofish syntax.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/num-conv@0.1.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "num-conv",
-      "versionInfo": "0.1.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows-strings-0.4.2",
-      "description": "Windows string types",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows-strings@0.4.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows-strings",
-      "versionInfo": "0.4.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-datastar-0.3.1",
-      "description": "Datastar SDK for Rust",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/datastar@0.3.1",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://data-star.dev",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "datastar",
-      "versionInfo": "0.3.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-synstructure-0.13.2",
-      "description": "Helper methods and macros for custom derives",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/synstructure@0.13.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "synstructure",
-      "versionInfo": "0.13.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-slab-0.4.11",
-      "description": "Pre-allocated storage for a uniform data type",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/slab@0.4.11",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "slab",
-      "versionInfo": "0.4.11"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-http-body-util-0.1.3",
-      "description": "Combinators and adapters for HTTP request or response bodies.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/http-body-util@0.1.3",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "http-body-util",
-      "versionInfo": "0.1.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-serde--derive-1.0.228",
-      "description": "Macros 1.1 implementation of #[derive(Serialize, Deserialize)]",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/serde_derive@1.0.228",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://serde.rs",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "serde_derive",
-      "versionInfo": "1.0.228"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-libc-0.2.177",
-      "description": "Raw FFI bindings to platform libraries like libc.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/libc@0.2.177",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "libc",
-      "versionInfo": "0.2.177"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows-result-0.3.4",
-      "description": "Windows error handling",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows-result@0.3.4",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows-result",
-      "versionInfo": "0.3.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-hyper-1.7.0",
-      "description": "A protective and efficient HTTP library for all.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/hyper@1.7.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://hyper.rs",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "hyper",
-      "versionInfo": "1.7.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-schannel-0.1.28",
-      "description": "Schannel bindings for rust, allowing SSL/TLS (e.g. https) without openssl",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/schannel@0.1.28",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "schannel",
-      "versionInfo": "0.1.28"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-clap-4.5.48",
-      "description": "A simple to use, efficient, and full-featured Command Line Argument Parser",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/clap@4.5.48",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "clap",
-      "versionInfo": "4.5.48"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-zerovec-0.11.4",
-      "description": "Zero-copy vector backed by a byte array",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/zerovec@0.11.4",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Unicode-3.0",
-      "licenseDeclared": "Unicode-3.0",
-      "name": "zerovec",
-      "versionInfo": "0.11.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-once--cell--polyfill-1.70.1",
-      "description": "Polyfill for `OnceCell` stdlib feature for use with older MSRVs",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/once_cell_polyfill@1.70.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "once_cell_polyfill",
-      "versionInfo": "1.70.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-rustls-pki-types-1.12.0",
-      "description": "Shared types for the rustls PKI ecosystem",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/rustls-pki-types@1.12.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/rustls/pki-types",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "rustls-pki-types",
-      "versionInfo": "1.12.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-jsonptr-0.7.1",
-      "description": "Data structures and logic for resolving, assigning, and deleting by JSON Pointers (RFC 6901)",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/jsonptr@0.7.1",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/chanced/jsonptr",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "jsonptr",
-      "versionInfo": "0.7.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-crc32fast-1.5.0",
-      "description": "Fast, SIMD-accelerated CRC32 (IEEE) checksum computation",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/crc32fast@1.5.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "crc32fast",
-      "versionInfo": "1.5.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-foreign-types-0.3.2",
-      "description": "A framework for Rust wrappers over C APIs",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/foreign-types@0.3.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "foreign-types",
-      "versionInfo": "0.3.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-zopfli-0.8.2",
-      "description": "A Rust implementation of the Zopfli compression algorithm.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/zopfli@0.8.2",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/zopfli-rs/zopfli",
-      "licenseConcluded": "Apache-2.0",
-      "licenseDeclared": "Apache-2.0",
-      "name": "zopfli",
-      "versionInfo": "0.8.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-powerfmt-0.2.0",
-      "description": "    `powerfmt` is a library that provides utilities for formatting values. This crate makes it\n    significantly easier to support filling to a minimum width with alignment, avoid heap\n    allocation, and avoid repetitive calculations.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/powerfmt@0.2.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "powerfmt",
-      "versionInfo": "0.2.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT",
-      "downloadLocation": "NONE",
-      "licenseConcluded": "NOASSERTION",
-      "name": "esdiag",
-      "versionInfo": "0.14.0-SNAPSHOT"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-futures-channel-0.3.31",
-      "description": "Channels for asynchronous communication using futures-rs.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/futures-channel@0.3.31",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://rust-lang.github.io/futures-rs",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "futures-channel",
-      "versionInfo": "0.3.31"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-multer-3.1.0",
-      "description": "An async parser for `multipart/form-data` content-type in Rust.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/multer@3.1.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/rwf2/multer",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "multer",
-      "versionInfo": "3.1.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-lock--api-0.4.14",
-      "description": "Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/lock_api@0.4.14",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "lock_api",
-      "versionInfo": "0.4.14"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-anstream-0.6.21",
-      "description": "IO stream adapters for writing colored text that will gracefully degrade according to your terminal's capabilities.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/anstream@0.6.21",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "anstream",
-      "versionInfo": "0.6.21"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-env--logger-0.11.8",
-      "description": "A logging implementation for `log` which is configured via an environment\nvariable.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/env_logger@0.11.8",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "env_logger",
-      "versionInfo": "0.11.8"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-bitflags-2.9.4",
-      "description": "A macro to generate structures which behave like bitflags.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/bitflags@2.9.4",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/bitflags/bitflags",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "bitflags",
-      "versionInfo": "2.9.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-itoa-1.0.15",
-      "description": "Fast integer primitive to string conversion",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/itoa@1.0.15",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "itoa",
-      "versionInfo": "1.0.15"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-unicode-ident-1.0.19",
-      "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/unicode-ident@1.0.19",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "(MIT OR Apache-2.0) AND Unicode-3.0",
-      "licenseDeclared": "(MIT OR Apache-2.0) AND Unicode-3.0",
-      "name": "unicode-ident",
-      "versionInfo": "1.0.19"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-cfg-if-1.0.3",
-      "description": "A macro to ergonomically define an item depending on a large number of #[cfg]\nparameters. Structured like an if-else chain, the first matching branch is the\nitem that gets emitted.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/cfg-if@1.0.3",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "cfg-if",
-      "versionInfo": "1.0.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-askama-0.14.0",
-      "description": "Type-safe, compiled Jinja-like templates for Rust",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/askama@0.14.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://askama.readthedocs.io/",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "askama",
-      "versionInfo": "0.14.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-system-configuration-0.6.1",
-      "description": "Bindings to SystemConfiguration framework for macOS",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/system-configuration@0.6.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "system-configuration",
-      "versionInfo": "0.6.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-core-foundation-sys-0.8.7",
-      "description": "Bindings to Core Foundation for macOS",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/core-foundation-sys@0.8.7",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/servo/core-foundation-rs",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "core-foundation-sys",
-      "versionInfo": "0.8.7"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows--i686--msvc-0.53.1",
-      "description": "Import lib for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_i686_msvc@0.53.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_i686_msvc",
-      "versionInfo": "0.53.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-schemars-1.0.4",
-      "description": "Generate JSON Schemas from Rust code",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/schemars@1.0.4",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://graham.cool/schemars/",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "schemars",
-      "versionInfo": "1.0.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-redox--syscall-0.5.18",
-      "description": "A Rust library to access raw Redox system calls",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/redox_syscall@0.5.18",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "redox_syscall",
-      "versionInfo": "0.5.18"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-getrandom-0.3.3",
-      "description": "A small cross-platform library for retrieving random data from system source",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/getrandom@0.3.3",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "getrandom",
-      "versionInfo": "0.3.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-indenter-0.3.4",
-      "description": "A formatter wrapper that indents the text, designed for error display impls\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/indenter@0.3.4",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/yaahc/indenter",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "indenter",
-      "versionInfo": "0.3.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-addr2line-0.25.1",
-      "description": "A cross-platform symbolication library written in Rust, using `gimli`",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/addr2line@0.25.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "addr2line",
-      "versionInfo": "0.25.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-dyn-clone-1.0.20",
-      "description": "Clone trait that is dyn-compatible",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/dyn-clone@1.0.20",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "dyn-clone",
-      "versionInfo": "1.0.20"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows--aarch64--gnullvm-0.53.1",
-      "description": "Import lib for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_aarch64_gnullvm@0.53.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_aarch64_gnullvm",
-      "versionInfo": "0.53.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-crossbeam-utils-0.8.21",
-      "description": "Utilities for concurrent programming",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/crossbeam-utils@0.8.21",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "crossbeam-utils",
-      "versionInfo": "0.8.21"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-serde--yaml-0.9.34-plus-deprecated",
-      "description": "YAML data format for Serde",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/serde_yaml@0.9.34%2Bdeprecated",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "serde_yaml",
-      "versionInfo": "0.9.34+deprecated"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-android--system--properties-0.1.5",
-      "description": "Minimal Android system properties wrapper",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/android_system_properties@0.1.5",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/nical/android_system_properties",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "android_system_properties",
-      "versionInfo": "0.1.5"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-indexmap-1.9.3",
-      "description": "A hash table with consistent order and fast iteration.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/indexmap@1.9.3",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "indexmap",
-      "versionInfo": "1.9.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-rand--core-0.9.3",
-      "description": "Core random number generator traits and tools for implementation.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/rand_core@0.9.3",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://rust-random.github.io/book",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "rand_core",
-      "versionInfo": "0.9.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-time-0.3.44",
-      "description": "Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/time@0.3.44",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://time-rs.github.io",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "time",
-      "versionInfo": "0.3.44"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-colorchoice-1.0.4",
-      "description": "Global override of color control",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/colorchoice@1.0.4",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "colorchoice",
-      "versionInfo": "1.0.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-native-tls-0.2.14",
-      "description": "A wrapper over a platform's native TLS implementation",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/native-tls@0.2.14",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "native-tls",
-      "versionInfo": "0.2.14"
+      "name": "zerotrie",
+      "versionInfo": "0.2.3"
     },
     {
       "SPDXID": "SPDXRef-Package-windows-targets-0.53.5",
@@ -1908,480 +138,6 @@
       "licenseDeclared": "MIT OR Apache-2.0",
       "name": "windows-targets",
       "versionInfo": "0.53.5"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-tinystr-0.8.1",
-      "description": "A small ASCII-only bounded length string representation.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/tinystr@0.8.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Unicode-3.0",
-      "licenseDeclared": "Unicode-3.0",
-      "name": "tinystr",
-      "versionInfo": "0.8.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-futures-executor-0.3.31",
-      "description": "Executors for asynchronous tasks based on the futures-rs library.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/futures-executor@0.3.31",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://rust-lang.github.io/futures-rs",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "futures-executor",
-      "versionInfo": "0.3.31"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-deflate64-0.1.10",
-      "description": "Deflate64 implementation based on .NET's implementation",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/deflate64@0.1.10",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/anatawa12/deflate64-rs#readme",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "deflate64",
-      "versionInfo": "0.1.10"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-indexmap-2.11.4",
-      "description": "A hash table with consistent order and fast iteration.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/indexmap@2.11.4",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "indexmap",
-      "versionInfo": "2.11.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-simd-adler32-0.3.7",
-      "description": "A SIMD-accelerated Adler-32 hash algorithm implementation.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/simd-adler32@0.3.7",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "simd-adler32",
-      "versionInfo": "0.3.7"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows-targets-0.52.6",
-      "description": "Import libs for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows-targets@0.52.6",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows-targets",
-      "versionInfo": "0.52.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-mime--guess-2.0.5",
-      "description": "A simple crate for detection of a file's MIME type by its extension.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/mime_guess@2.0.5",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "mime_guess",
-      "versionInfo": "2.0.5"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-icu--normalizer-2.0.0",
-      "description": "API for normalizing text into Unicode Normalization Forms",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/icu_normalizer@2.0.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://icu4x.unicode.org",
-      "licenseConcluded": "Unicode-3.0",
-      "licenseDeclared": "Unicode-3.0",
-      "name": "icu_normalizer",
-      "versionInfo": "2.0.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-h2-0.4.12",
-      "description": "An HTTP/2 client and server",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/h2@0.4.12",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "h2",
-      "versionInfo": "0.4.12"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows--aarch64--msvc-0.53.1",
-      "description": "Import lib for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_aarch64_msvc@0.53.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_aarch64_msvc",
-      "versionInfo": "0.53.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-compression-core-0.4.29",
-      "description": "Abstractions for compression algorithms.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/compression-core@0.4.29",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "compression-core",
-      "versionInfo": "0.4.29"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-linux-raw-sys-0.11.0",
-      "description": "Generated bindings for Linux's userspace API",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/linux-raw-sys@0.11.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
-      "name": "linux-raw-sys",
-      "versionInfo": "0.11.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-serde--with-3.15.0",
-      "description": "Custom de/serialization functions for Rust's serde",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/serde_with@3.15.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "serde_with",
-      "versionInfo": "3.15.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-thiserror-1.0.69",
-      "description": "derive(Error)",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/thiserror@1.0.69",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "thiserror",
-      "versionInfo": "1.0.69"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-ident--case-1.0.1",
-      "description": "Utility for applying case rules to Rust identifiers.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/ident_case@1.0.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "ident_case",
-      "versionInfo": "1.0.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-lazy--static-1.5.0",
-      "description": "A macro for declaring lazily evaluated statics in Rust.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/lazy_static@1.5.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "lazy_static",
-      "versionInfo": "1.5.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-include--dir--macros-0.7.4",
-      "description": "The procedural macro used by include_dir",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/include_dir_macros@0.7.4",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "include_dir_macros",
-      "versionInfo": "0.7.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-tracing-core-0.1.34",
-      "description": "Core primitives for application-level tracing.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/tracing-core@0.1.34",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://tokio.rs",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "tracing-core",
-      "versionInfo": "0.1.34"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-form--urlencoded-1.2.2",
-      "description": "Parser and serializer for the application/x-www-form-urlencoded syntax, as used by HTML forms.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/form_urlencoded@1.2.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "form_urlencoded",
-      "versionInfo": "1.2.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-tokio-rustls-0.26.4",
-      "description": "Asynchronous TLS/SSL streams for Tokio using Rustls.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/tokio-rustls@0.26.4",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/rustls/tokio-rustls",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "tokio-rustls",
-      "versionInfo": "0.26.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-tower-http-0.6.6",
-      "description": "Tower middleware and utilities for HTTP clients and servers",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/tower-http@0.6.6",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/tower-rs/tower-http",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "tower-http",
-      "versionInfo": "0.6.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-hex-0.4.3",
-      "description": "Encoding and decoding data into/from hexadecimal representation.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/hex@0.4.3",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "hex",
-      "versionInfo": "0.4.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-async-compression-0.4.32",
-      "description": "Adaptors between compression crates and Rust's modern asynchronous IO types.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/async-compression@0.4.32",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "async-compression",
-      "versionInfo": "0.4.32"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-time-core-0.1.6",
-      "description": "This crate is an implementation detail and should not be relied upon directly.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/time-core@0.1.6",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "time-core",
-      "versionInfo": "0.1.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-backtrace-0.3.76",
-      "description": "A library to acquire a stack trace (backtrace) at runtime in a Rust program.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/backtrace@0.3.76",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/rust-lang/backtrace-rs",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "backtrace",
-      "versionInfo": "0.3.76"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-axum-macros-0.5.0",
-      "description": "Macros for axum",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/axum-macros@0.5.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/tokio-rs/axum",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "axum-macros",
-      "versionInfo": "0.5.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-syn-2.0.106",
-      "description": "Parser for Rust source code",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/syn@2.0.106",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "syn",
-      "versionInfo": "2.0.106"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-schemars-0.9.0",
-      "description": "Generate JSON Schemas from Rust code",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/schemars@0.9.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://graham.cool/schemars/",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "schemars",
-      "versionInfo": "0.9.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-displaydoc-0.2.5",
-      "description": "A derive macro for implementing the display Trait via a doc comment and string interpolation\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/displaydoc@0.2.5",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/yaahc/displaydoc",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "displaydoc",
-      "versionInfo": "0.2.5"
     },
     {
       "SPDXID": "SPDXRef-Package-core-foundation-0.9.4",
@@ -2401,636 +157,70 @@
       "versionInfo": "0.9.4"
     },
     {
-      "SPDXID": "SPDXRef-Package-windows--aarch64--msvc-0.52.6",
-      "description": "Import lib for Windows",
+      "SPDXID": "SPDXRef-Package-tower-http-0.6.8",
+      "description": "Tower middleware and utilities for HTTP clients and servers",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_aarch64_msvc@0.52.6",
+          "referenceLocator": "pkg:cargo/tower-http@0.6.8",
           "referenceType": "purl"
         }
       ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_aarch64_msvc",
-      "versionInfo": "0.52.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-gimli-0.32.3",
-      "description": "A library for reading and writing the DWARF debugging format.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/gimli@0.32.3",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "gimli",
-      "versionInfo": "0.32.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-potential--utf-0.1.3",
-      "description": "Unvalidated string and character types",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/potential_utf@0.1.3",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://icu4x.unicode.org",
-      "licenseConcluded": "Unicode-3.0",
-      "licenseDeclared": "Unicode-3.0",
-      "name": "potential_utf",
-      "versionInfo": "0.1.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-signal-hook-registry-1.4.6",
-      "description": "Backend crate for signal-hook",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/signal-hook-registry@1.4.6",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "signal-hook-registry",
-      "versionInfo": "1.4.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-matchit-0.8.4",
-      "description": "A high performance, zero-copy URL router.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/matchit@0.8.4",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT AND BSD-3-Clause",
-      "licenseDeclared": "MIT AND BSD-3-Clause",
-      "name": "matchit",
-      "versionInfo": "0.8.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows--aarch64--gnullvm-0.52.6",
-      "description": "Import lib for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_aarch64_gnullvm@0.52.6",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_aarch64_gnullvm",
-      "versionInfo": "0.52.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-openssl-macros-0.1.1",
-      "description": "Internal macros used by the openssl crate.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/openssl-macros@0.1.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "openssl-macros",
-      "versionInfo": "0.1.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-serde--with--macros-3.15.0",
-      "description": "proc-macro library for serde_with",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/serde_with_macros@3.15.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "serde_with_macros",
-      "versionInfo": "3.15.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-darling-0.21.3",
-      "description": "A proc-macro library for reading attributes into structs when\nimplementing custom derives.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/darling@0.21.3",
-          "referenceType": "purl"
-        }
-      ],
+      "homepage": "https://github.com/tower-rs/tower-http",
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
-      "name": "darling",
-      "versionInfo": "0.21.3"
+      "name": "tower-http",
+      "versionInfo": "0.6.8"
     },
     {
-      "SPDXID": "SPDXRef-Package-derive--arbitrary-1.4.2",
-      "description": "Derives arbitrary traits",
+      "SPDXID": "SPDXRef-Package-hashbrown-0.16.1",
+      "description": "A Rust port of Google's SwissTable hash map",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/derive_arbitrary@1.4.2",
+          "referenceLocator": "pkg:cargo/hashbrown@0.16.1",
           "referenceType": "purl"
         }
       ],
       "licenseConcluded": "MIT OR Apache-2.0",
       "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "derive_arbitrary",
-      "versionInfo": "1.4.2"
+      "name": "hashbrown",
+      "versionInfo": "0.16.1"
     },
     {
-      "SPDXID": "SPDXRef-Package-spin-0.9.8",
-      "description": "Spin-based synchronization primitives",
+      "SPDXID": "SPDXRef-Package-multer-3.1.0",
+      "description": "An async parser for `multipart/form-data` content-type in Rust.",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/spin@0.9.8",
+          "referenceLocator": "pkg:cargo/multer@3.1.0",
           "referenceType": "purl"
         }
       ],
+      "homepage": "https://github.com/rwf2/multer",
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
-      "name": "spin",
-      "versionInfo": "0.9.8"
+      "name": "multer",
+      "versionInfo": "3.1.0"
     },
     {
-      "SPDXID": "SPDXRef-Package-rustc-demangle-0.1.26",
-      "description": "Rust compiler symbol demangling.\n",
+      "SPDXID": "SPDXRef-Package-serde--with-3.16.1",
+      "description": "Custom de/serialization functions for Rust's serde",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/rustc-demangle@0.1.26",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/rust-lang/rustc-demangle",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "rustc-demangle",
-      "versionInfo": "0.1.26"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-async-stream-impl-0.3.6",
-      "description": "proc macros for async-stream crate",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/async-stream-impl@0.3.6",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "async-stream-impl",
-      "versionInfo": "0.3.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-zerotrie-0.2.2",
-      "description": "A data structure that efficiently maps strings to integers",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/zerotrie@0.2.2",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://icu4x.unicode.org",
-      "licenseConcluded": "Unicode-3.0",
-      "licenseDeclared": "Unicode-3.0",
-      "name": "zerotrie",
-      "versionInfo": "0.2.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-idna--adapter-1.2.1",
-      "description": "Back end adapter for idna",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/idna_adapter@1.2.1",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://docs.rs/crate/idna_adapter/latest",
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "idna_adapter",
-      "versionInfo": "1.2.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-wasm-bindgen-macro-0.2.104",
-      "description": "Definition of the `#[wasm_bindgen]` attribute, an internal dependency\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/wasm-bindgen-macro@0.2.104",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "wasm-bindgen-macro",
-      "versionInfo": "0.2.104"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-try-lock-0.2.5",
-      "description": "A lightweight atomic lock.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/try-lock@0.2.5",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/seanmonstar/try-lock",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "try-lock",
-      "versionInfo": "0.2.5"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1",
-      "description": "Official Elasticsearch Rust client",
-      "downloadLocation": "git+https://github.com/VimCommando/elasticsearch-rs?rev=2eff23f3d908c177b8ecc03c4a8af0f8080d7a80#2eff23f3d908c177b8ecc03c4a8af0f8080d7a80",
-      "licenseConcluded": "Apache-2.0",
-      "licenseDeclared": "Apache-2.0",
-      "name": "elasticsearch",
-      "versionInfo": "9.1.0-alpha.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-wasi-0.11.1-plus-wasi-snapshot-preview1",
-      "description": "Experimental WASI API bindings for Rust",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/wasi@0.11.1%2Bwasi-snapshot-preview1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
-      "name": "wasi",
-      "versionInfo": "0.11.1+wasi-snapshot-preview1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-r-efi-5.3.0",
-      "description": "UEFI Reference Specification Protocol Constants and Definitions",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/r-efi@5.3.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/r-efi/r-efi/wiki",
-      "licenseConcluded": "MIT OR Apache-2.0 OR LGPL-2.1-or-later",
-      "licenseDeclared": "MIT OR Apache-2.0 OR LGPL-2.1-or-later",
-      "name": "r-efi",
-      "versionInfo": "5.3.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-yoke-0.8.0",
-      "description": "Abstraction allowing borrowed data to be carried along with the backing data it borrows from",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/yoke@0.8.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Unicode-3.0",
-      "licenseDeclared": "Unicode-3.0",
-      "name": "yoke",
-      "versionInfo": "0.8.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-httparse-1.10.1",
-      "description": "A tiny, safe, speedy, zero-copy HTTP/1.x parser.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/httparse@1.10.1",
+          "referenceLocator": "pkg:cargo/serde_with@3.16.1",
           "referenceType": "purl"
         }
       ],
       "licenseConcluded": "MIT OR Apache-2.0",
       "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "httparse",
-      "versionInfo": "1.10.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-async-stream-0.3.6",
-      "description": "Asynchronous streams using async & await notation",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/async-stream@0.3.6",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "async-stream",
-      "versionInfo": "0.3.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows-sys-0.52.0",
-      "description": "Rust for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows-sys@0.52.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows-sys",
-      "versionInfo": "0.52.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-wasip2-1.0.1-plus-wasi-0.2.4",
-      "description": "WASIp2 API bindings for Rust",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/wasip2@1.0.1%2Bwasi-0.2.4",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
-      "name": "wasip2",
-      "versionInfo": "1.0.1+wasi-0.2.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-uuid-1.18.1",
-      "description": "A library to generate and parse UUIDs.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/uuid@1.18.1",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/uuid-rs/uuid",
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "uuid",
-      "versionInfo": "1.18.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-mio-1.0.4",
-      "description": "Lightweight non-blocking I/O.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/mio@1.0.4",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/tokio-rs/mio",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "mio",
-      "versionInfo": "1.0.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-foreign-types-shared-0.1.1",
-      "description": "An internal crate used by foreign-types",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/foreign-types-shared@0.1.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "foreign-types-shared",
-      "versionInfo": "0.1.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-portable-atomic-1.11.1",
-      "description": "Portable atomic types including support for 128-bit atomics, atomic float, etc.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/portable-atomic@1.11.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "portable-atomic",
-      "versionInfo": "1.11.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-crossbeam-deque-0.8.6",
-      "description": "Concurrent work-stealing deque",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/crossbeam-deque@0.8.6",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-deque",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "crossbeam-deque",
-      "versionInfo": "0.8.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-json-patch-4.1.0",
-      "description": "RFC 6902, JavaScript Object Notation (JSON) Patch",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/json-patch@4.1.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "json-patch",
-      "versionInfo": "4.1.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-include--dir-0.7.4",
-      "description": "Embed the contents of a directory in your binary",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/include_dir@0.7.4",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "include_dir",
-      "versionInfo": "0.7.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-openssl-probe-0.1.6",
-      "description": "Tool for helping to find SSL certificate locations on the system for OpenSSL\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/openssl-probe@0.1.6",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/alexcrichton/openssl-probe",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "openssl-probe",
-      "versionInfo": "0.1.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-security-framework-sys-2.15.0",
-      "description": "Apple `Security.framework` low-level FFI bindings",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/security-framework-sys@2.15.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://lib.rs/crates/security-framework-sys",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "security-framework-sys",
-      "versionInfo": "2.15.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-url-2.5.7",
-      "description": "URL library for Rust, based on the WHATWG URL Standard",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/url@2.5.7",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "url",
-      "versionInfo": "2.5.7"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-portable-atomic-util-0.2.4",
-      "description": "Synchronization primitives built with portable-atomic.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/portable-atomic-util@0.2.4",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "portable-atomic-util",
-      "versionInfo": "0.2.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-regex-syntax-0.8.7",
-      "description": "A regular expression parser.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/regex-syntax@0.8.7",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/rust-lang/regex/tree/master/regex-syntax",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "regex-syntax",
-      "versionInfo": "0.8.7"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-icu--properties--data-2.0.1",
-      "description": "Data for the icu_properties crate",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/icu_properties_data@2.0.1",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://icu4x.unicode.org",
-      "licenseConcluded": "Unicode-3.0",
-      "licenseDeclared": "Unicode-3.0",
-      "name": "icu_properties_data",
-      "versionInfo": "2.0.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-aho-corasick-1.1.3",
-      "description": "Fast multiple substring searching.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/aho-corasick@1.1.3",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/BurntSushi/aho-corasick",
-      "licenseConcluded": "Unlicense OR MIT",
-      "licenseDeclared": "Unlicense OR MIT",
-      "name": "aho-corasick",
-      "versionInfo": "1.1.3"
+      "name": "serde_with",
+      "versionInfo": "3.16.1"
     },
     {
       "SPDXID": "SPDXRef-Package-ppv-lite86-0.2.21",
@@ -3049,37 +239,347 @@
       "versionInfo": "0.2.21"
     },
     {
-      "SPDXID": "SPDXRef-Package-security-framework-2.11.1",
-      "description": "Security.framework bindings for macOS and iOS",
+      "SPDXID": "SPDXRef-Package-js-sys-0.3.85",
+      "description": "Bindings for all JS global objects and functions in all JS environments like\nNode.js and browsers, built on `#[wasm_bindgen]` using the `wasm-bindgen` crate.\n",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/security-framework@2.11.1",
+          "referenceLocator": "pkg:cargo/js-sys@0.3.85",
           "referenceType": "purl"
         }
       ],
-      "homepage": "https://lib.rs/crates/security_framework",
+      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
       "licenseConcluded": "MIT OR Apache-2.0",
       "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "security-framework",
-      "versionInfo": "2.11.1"
+      "name": "js-sys",
+      "versionInfo": "0.3.85"
     },
     {
-      "SPDXID": "SPDXRef-Package-openssl-sys-0.9.109",
-      "description": "FFI bindings to OpenSSL",
+      "SPDXID": "SPDXRef-Package-matchit-0.8.4",
+      "description": "A high performance, zero-copy URL router.",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/openssl-sys@0.9.109",
+          "referenceLocator": "pkg:cargo/matchit@0.8.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT AND BSD-3-Clause",
+      "licenseDeclared": "MIT AND BSD-3-Clause",
+      "name": "matchit",
+      "versionInfo": "0.8.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rand--chacha-0.9.0",
+      "description": "ChaCha random number generator\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rand_chacha@0.9.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-random.github.io/book",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "rand_chacha",
+      "versionInfo": "0.9.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rustls-0.23.36",
+      "description": "Rustls is a modern TLS library written in Rust.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rustls@0.23.36",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rustls/rustls",
+      "licenseConcluded": "Apache-2.0 OR ISC OR MIT",
+      "licenseDeclared": "Apache-2.0 OR ISC OR MIT",
+      "name": "rustls",
+      "versionInfo": "0.23.36"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zerofrom-0.1.6",
+      "description": "ZeroFrom trait for constructing",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zerofrom@0.1.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Unicode-3.0",
+      "licenseDeclared": "Unicode-3.0",
+      "name": "zerofrom",
+      "versionInfo": "0.1.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-sys-0.61.2",
+      "description": "Rust for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-sys@0.61.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-sys",
+      "versionInfo": "0.61.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-compression-core-0.4.31",
+      "description": "Abstractions for compression algorithms.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/compression-core@0.4.31",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "compression-core",
+      "versionInfo": "0.4.31"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-channel-0.3.31",
+      "description": "Channels for asynchronous communication using futures-rs.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-channel@0.3.31",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures-channel",
+      "versionInfo": "0.3.31"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-proc-macro2-1.0.106",
+      "description": "A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/proc-macro2@1.0.106",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "proc-macro2",
+      "versionInfo": "1.0.106"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-idna-1.1.0",
+      "description": "IDNA (Internationalizing Domain Names in Applications) and Punycode.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/idna@1.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "idna",
+      "versionInfo": "1.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-mime--guess-2.0.5",
+      "description": "A simple crate for detection of a file's MIME type by its extension.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/mime_guess@2.0.5",
           "referenceType": "purl"
         }
       ],
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
-      "name": "openssl-sys",
-      "versionInfo": "0.9.109"
+      "name": "mime_guess",
+      "versionInfo": "2.0.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-semver-1.0.27",
+      "description": "Parser and evaluator for Cargo's flavor of Semantic Versioning",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/semver@1.0.27",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "semver",
+      "versionInfo": "1.0.27"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-axum-macros-0.5.0",
+      "description": "Macros for axum",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/axum-macros@0.5.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/tokio-rs/axum",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "axum-macros",
+      "versionInfo": "0.5.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-once--cell-1.21.3",
+      "description": "Single assignment cells and lazy values.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/once_cell@1.21.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "once_cell",
+      "versionInfo": "1.21.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ipnet-2.11.0",
+      "description": "Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ipnet@2.11.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "ipnet",
+      "versionInfo": "2.11.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasm-bindgen-macro-0.2.108",
+      "description": "Definition of the `#[wasm_bindgen]` attribute, an internal dependency\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasm-bindgen-macro@0.2.108",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "wasm-bindgen-macro",
+      "versionInfo": "0.2.108"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-reqwest-0.12.28",
+      "description": "higher level HTTP client library",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/reqwest@0.12.28",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "reqwest",
+      "versionInfo": "0.12.28"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasm-bindgen-0.2.108",
+      "description": "Easy support for interacting between JS and Rust.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasm-bindgen@0.2.108",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "wasm-bindgen",
+      "versionInfo": "0.2.108"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-darling-0.21.3",
+      "description": "A proc-macro library for reading attributes into structs when\nimplementing custom derives.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/darling@0.21.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "darling",
+      "versionInfo": "0.21.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-deranged-0.5.5",
+      "description": "Ranged integers",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/deranged@0.5.5",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "deranged",
+      "versionInfo": "0.5.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-scopeguard-1.2.0",
+      "description": "A RAII scope guard that will run a given closure when it goes out of scope,\neven if the code between panics (assuming unwinding panic).\n\nDefines the macros `defer!`, `defer_on_unwind!`, `defer_on_success!` as\nshorthands for guards with one of the implemented strategies.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/scopeguard@1.2.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "scopeguard",
+      "versionInfo": "1.2.0"
     },
     {
       "SPDXID": "SPDXRef-Package-pin-project-lite-0.2.16",
@@ -3098,283 +598,85 @@
       "versionInfo": "0.2.16"
     },
     {
-      "SPDXID": "SPDXRef-Package-rand-0.9.2",
-      "description": "Random number generators and other randomness functionality.\n",
+      "SPDXID": "SPDXRef-Package-colorchoice-1.0.4",
+      "description": "Global override of color control",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/rand@0.9.2",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://rust-random.github.io/book",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "rand",
-      "versionInfo": "0.9.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-smallvec-1.15.1",
-      "description": "'Small vector' optimization: store up to a small number of items on the stack",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/smallvec@1.15.1",
+          "referenceLocator": "pkg:cargo/colorchoice@1.0.4",
           "referenceType": "purl"
         }
       ],
       "licenseConcluded": "MIT OR Apache-2.0",
       "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "smallvec",
-      "versionInfo": "1.15.1"
+      "name": "colorchoice",
+      "versionInfo": "1.0.4"
     },
     {
-      "SPDXID": "SPDXRef-Package-askama--derive-0.14.0",
-      "description": "Procedural macro package for Askama",
+      "SPDXID": "SPDXRef-Package-ref-cast-impl-1.0.25",
+      "description": "Derive implementation for ref_cast::RefCast.",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/askama_derive@0.14.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/askama-rs/askama",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "askama_derive",
-      "versionInfo": "0.14.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.104",
-      "description": "The part of the implementation of the `#[wasm_bindgen]` attribute that is not in the shared backend crate\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/wasm-bindgen-macro-support@0.2.104",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "wasm-bindgen-macro-support",
-      "versionInfo": "0.2.104"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-http-1.3.1",
-      "description": "A set of types for representing HTTP requests and responses.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/http@1.3.1",
+          "referenceLocator": "pkg:cargo/ref-cast-impl@1.0.25",
           "referenceType": "purl"
         }
       ],
       "licenseConcluded": "MIT OR Apache-2.0",
       "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "http",
-      "versionInfo": "1.3.1"
+      "name": "ref-cast-impl",
+      "versionInfo": "1.0.25"
     },
     {
-      "SPDXID": "SPDXRef-Package-clap--derive-4.5.47",
-      "description": "Parse command line argument by defining a struct, derive crate.",
+      "SPDXID": "SPDXRef-Package-lock--api-0.4.14",
+      "description": "Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/clap_derive@4.5.47",
+          "referenceLocator": "pkg:cargo/lock_api@0.4.14",
           "referenceType": "purl"
         }
       ],
       "licenseConcluded": "MIT OR Apache-2.0",
       "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "clap_derive",
-      "versionInfo": "4.5.47"
+      "name": "lock_api",
+      "versionInfo": "0.4.14"
     },
     {
-      "SPDXID": "SPDXRef-Package-hashbrown-0.12.3",
-      "description": "A Rust port of Google's SwissTable hash map",
+      "SPDXID": "SPDXRef-Package-hyper-rustls-0.27.7",
+      "description": "Rustls+hyper integration for pure rust HTTPS",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/hashbrown@0.12.3",
+          "referenceLocator": "pkg:cargo/hyper-rustls@0.27.7",
           "referenceType": "purl"
         }
       ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "hashbrown",
-      "versionInfo": "0.12.3"
+      "homepage": "https://github.com/rustls/hyper-rustls",
+      "licenseConcluded": "Apache-2.0 OR ISC OR MIT",
+      "licenseDeclared": "Apache-2.0 OR ISC OR MIT",
+      "name": "hyper-rustls",
+      "versionInfo": "0.27.7"
     },
     {
-      "SPDXID": "SPDXRef-Package-system-configuration-sys-0.6.0",
-      "description": "Low level bindings to SystemConfiguration framework for macOS",
+      "SPDXID": "SPDXRef-Package-async-stream-impl-0.3.6",
+      "description": "proc macros for async-stream crate",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/system-configuration-sys@0.6.0",
+          "referenceLocator": "pkg:cargo/async-stream-impl@0.3.6",
           "referenceType": "purl"
         }
       ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "system-configuration-sys",
-      "versionInfo": "0.6.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-hyper-util-0.1.17",
-      "description": "hyper utilities",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/hyper-util@0.1.17",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://hyper.rs",
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
-      "name": "hyper-util",
-      "versionInfo": "0.1.17"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-fs-err-3.1.3",
-      "description": "A drop-in replacement for std::fs with more helpful error messages.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/fs-err@3.1.3",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "fs-err",
-      "versionInfo": "3.1.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-compression-codecs-0.4.31",
-      "description": "Adaptors for various compression algorithms.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/compression-codecs@0.4.31",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "compression-codecs",
-      "versionInfo": "0.4.31"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-futures-task-0.3.31",
-      "description": "Tools for working with tasks.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/futures-task@0.3.31",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://rust-lang.github.io/futures-rs",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "futures-task",
-      "versionInfo": "0.3.31"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-parking--lot--core-0.9.12",
-      "description": "An advanced API for creating custom synchronization primitives.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/parking_lot_core@0.9.12",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "parking_lot_core",
-      "versionInfo": "0.9.12"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-web-sys-0.3.81",
-      "description": "Bindings for all Web APIs, a procedurally generated crate from WebIDL\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/web-sys@0.3.81",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/web-sys/index.html",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "web-sys",
-      "versionInfo": "0.3.81"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-rayon-core-1.13.0",
-      "description": "Core APIs for Rayon",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/rayon-core@1.13.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "rayon-core",
-      "versionInfo": "1.13.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-zerocopy-derive-0.8.27",
-      "description": "Custom derive for traits from the zerocopy crate",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/zerocopy-derive@0.8.27",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "BSD-2-Clause OR Apache-2.0 OR MIT",
-      "licenseDeclared": "BSD-2-Clause OR Apache-2.0 OR MIT",
-      "name": "zerocopy-derive",
-      "versionInfo": "0.8.27"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-serde-1.0.228",
-      "description": "A generic serialization/deserialization framework",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/serde@1.0.228",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://serde.rs",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "serde",
-      "versionInfo": "1.0.228"
+      "name": "async-stream-impl",
+      "versionInfo": "0.3.6"
     },
     {
       "SPDXID": "SPDXRef-Package-futures-io-0.3.31",
@@ -3394,143 +696,228 @@
       "versionInfo": "0.3.31"
     },
     {
-      "SPDXID": "SPDXRef-Package-io-uring-0.7.10",
-      "description": "The low-level `io_uring` userspace interface for Rust",
+      "SPDXID": "SPDXRef-Package-tokio-util-0.7.18",
+      "description": "Additional utilities for working with Tokio.\n",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/io-uring@0.7.10",
+          "referenceLocator": "pkg:cargo/tokio-util@0.7.18",
           "referenceType": "purl"
         }
       ],
-      "homepage": "https://github.com/tokio-rs/io-uring",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "io-uring",
-      "versionInfo": "0.7.10"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-semver-1.0.27",
-      "description": "Parser and evaluator for Cargo's flavor of Semantic Versioning",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/semver@1.0.27",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "semver",
-      "versionInfo": "1.0.27"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows-registry-0.5.3",
-      "description": "Windows registry",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows-registry@0.5.3",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows-registry",
-      "versionInfo": "0.5.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-axum-0.8.6",
-      "description": "Web framework that focuses on ergonomics and modularity",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/axum@0.8.6",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/tokio-rs/axum",
+      "homepage": "https://tokio.rs",
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
-      "name": "axum",
-      "versionInfo": "0.8.6"
+      "name": "tokio-util",
+      "versionInfo": "0.7.18"
     },
     {
-      "SPDXID": "SPDXRef-Package-windows-implement-0.60.2",
-      "description": "The implement macro for the Windows crates",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows-implement@0.60.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows-implement",
-      "versionInfo": "0.60.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-deranged-0.5.4",
-      "description": "Ranged integers",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/deranged@0.5.4",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "deranged",
-      "versionInfo": "0.5.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-rustls-webpki-0.103.7",
-      "description": "Web PKI X.509 Certificate Verification.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/rustls-webpki@0.103.7",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "ISC",
-      "licenseDeclared": "ISC",
-      "name": "rustls-webpki",
-      "versionInfo": "0.103.7"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-getrandom-0.2.16",
+      "SPDXID": "SPDXRef-Package-getrandom-0.2.17",
       "description": "A small cross-platform library for retrieving random data from system source",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/getrandom@0.2.16",
+          "referenceLocator": "pkg:cargo/getrandom@0.2.17",
           "referenceType": "purl"
         }
       ],
       "licenseConcluded": "MIT OR Apache-2.0",
       "licenseDeclared": "MIT OR Apache-2.0",
       "name": "getrandom",
-      "versionInfo": "0.2.16"
+      "versionInfo": "0.2.17"
     },
     {
-      "SPDXID": "SPDXRef-Package-icu--provider-2.0.0",
+      "SPDXID": "SPDXRef-Package-futures-core-0.3.31",
+      "description": "The core traits and types in for the `futures` library.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-core@0.3.31",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures-core",
+      "versionInfo": "0.3.31"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zerovec-0.11.5",
+      "description": "Zero-copy vector backed by a byte array",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zerovec@0.11.5",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Unicode-3.0",
+      "licenseDeclared": "Unicode-3.0",
+      "name": "zerovec",
+      "versionInfo": "0.11.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasm-bindgen-shared-0.2.108",
+      "description": "Shared support between wasm-bindgen and wasm-bindgen cli, an internal\ndependency.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasm-bindgen-shared@0.2.108",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "wasm-bindgen-shared",
+      "versionInfo": "0.2.108"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-icu--properties--data-2.1.2",
+      "description": "Data for the icu_properties crate",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/icu_properties_data@2.1.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://icu4x.unicode.org",
+      "licenseConcluded": "Unicode-3.0",
+      "licenseDeclared": "Unicode-3.0",
+      "name": "icu_properties_data",
+      "versionInfo": "2.1.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-utf8--iter-1.0.4",
+      "description": "Iterator by char over potentially-invalid UTF-8 in &[u8]",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/utf8_iter@1.0.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://docs.rs/utf8_iter/",
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "utf8_iter",
+      "versionInfo": "1.0.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-indexmap-1.9.3",
+      "description": "A hash table with consistent order and fast iteration.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/indexmap@1.9.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "indexmap",
+      "versionInfo": "1.9.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rand--core-0.9.5",
+      "description": "Core random number generator traits and tools for implementation.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rand_core@0.9.5",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-random.github.io/book",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "rand_core",
+      "versionInfo": "0.9.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-typed-path-0.12.2",
+      "description": "Provides typed variants of Path and PathBuf for Unix and Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/typed-path@0.12.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/chipsenkbeil/typed-path",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "typed-path",
+      "versionInfo": "0.12.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-unicase-2.9.0",
+      "description": "A case-insensitive wrapper around strings.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/unicase@2.9.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "unicase",
+      "versionInfo": "2.9.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-writeable-0.6.2",
+      "description": "A more efficient alternative to fmt::Display",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/writeable@0.6.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Unicode-3.0",
+      "licenseDeclared": "Unicode-3.0",
+      "name": "writeable",
+      "versionInfo": "0.6.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zerovec-derive-0.11.2",
+      "description": "Custom derive for the zerovec crate",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zerovec-derive@0.11.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Unicode-3.0",
+      "licenseDeclared": "Unicode-3.0",
+      "name": "zerovec-derive",
+      "versionInfo": "0.11.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-icu--provider-2.1.1",
       "description": "Trait and struct definitions for the ICU data provider",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/icu_provider@2.0.0",
+          "referenceLocator": "pkg:cargo/icu_provider@2.1.1",
           "referenceType": "purl"
         }
       ],
@@ -3538,39 +925,239 @@
       "licenseConcluded": "Unicode-3.0",
       "licenseDeclared": "Unicode-3.0",
       "name": "icu_provider",
-      "versionInfo": "2.0.0"
+      "versionInfo": "2.1.1"
     },
     {
-      "SPDXID": "SPDXRef-Package-windows--x86--64--gnu-0.53.1",
-      "description": "Import lib for Windows",
+      "SPDXID": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.108",
+      "description": "Implementation APIs for the `#[wasm_bindgen]` attribute",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_x86_64_gnu@0.53.1",
+          "referenceLocator": "pkg:cargo/wasm-bindgen-macro-support@0.2.108",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "wasm-bindgen-macro-support",
+      "versionInfo": "0.2.108"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-icu--normalizer-2.1.1",
+      "description": "API for normalizing text into Unicode Normalization Forms",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/icu_normalizer@2.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://icu4x.unicode.org",
+      "licenseConcluded": "Unicode-3.0",
+      "licenseDeclared": "Unicode-3.0",
+      "name": "icu_normalizer",
+      "versionInfo": "2.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-winnow-0.7.14",
+      "description": "A byte-oriented, zero-copy, parser combinators library",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/winnow@0.7.14",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "winnow",
+      "versionInfo": "0.7.14"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-subtle-2.6.1",
+      "description": "Pure-Rust traits and utilities for constant-time cryptographic implementations.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/subtle@2.6.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://dalek.rs/",
+      "licenseConcluded": "BSD-3-Clause",
+      "licenseDeclared": "BSD-3-Clause",
+      "name": "subtle",
+      "versionInfo": "2.6.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-core-foundation-sys-0.8.7",
+      "description": "Bindings to Core Foundation for macOS",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/core-foundation-sys@0.8.7",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/servo/core-foundation-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "core-foundation-sys",
+      "versionInfo": "0.8.7"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-regex-1.12.3",
+      "description": "An implementation of regular expressions for Rust. This implementation uses\nfinite automata and guarantees linear time matching on all inputs.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/regex@1.12.3",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rust-lang/regex",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "regex",
+      "versionInfo": "1.12.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-indenter-0.3.4",
+      "description": "A formatter wrapper that indents the text, designed for error display impls\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/indenter@0.3.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/yaahc/indenter",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "indenter",
+      "versionInfo": "0.3.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rayon-1.11.0",
+      "description": "Simple work-stealing parallelism for Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rayon@1.11.0",
           "referenceType": "purl"
         }
       ],
       "licenseConcluded": "MIT OR Apache-2.0",
       "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_x86_64_gnu",
-      "versionInfo": "0.53.1"
+      "name": "rayon",
+      "versionInfo": "1.11.0"
     },
     {
-      "SPDXID": "SPDXRef-Package-reqwest-0.12.23",
-      "description": "higher level HTTP client library",
+      "SPDXID": "SPDXRef-Package-getrandom-0.3.4",
+      "description": "A small cross-platform library for retrieving random data from system source",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/reqwest@0.12.23",
+          "referenceLocator": "pkg:cargo/getrandom@0.3.4",
           "referenceType": "purl"
         }
       ],
       "licenseConcluded": "MIT OR Apache-2.0",
       "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "reqwest",
-      "versionInfo": "0.12.23"
+      "name": "getrandom",
+      "versionInfo": "0.3.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-itoa-1.0.17",
+      "description": "Fast integer primitive to string conversion",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/itoa@1.0.17",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "itoa",
+      "versionInfo": "1.0.17"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-urlencoding-2.1.3",
+      "description": "A Rust library for doing URL percentage encoding.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/urlencoding@2.1.3",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://lib.rs/urlencoding",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "urlencoding",
+      "versionInfo": "2.1.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-lazy--static-1.5.0",
+      "description": "A macro for declaring lazily evaluated statics in Rust.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/lazy_static@1.5.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "lazy_static",
+      "versionInfo": "1.5.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-httparse-1.10.1",
+      "description": "A tiny, safe, speedy, zero-copy HTTP/1.x parser.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/httparse@1.10.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "httparse",
+      "versionInfo": "1.10.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-util-0.3.31",
+      "description": "Common utilities and extension traits for the futures-rs library.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-util@0.3.31",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures-util",
+      "versionInfo": "0.3.31"
     },
     {
       "SPDXID": "SPDXRef-Package-either-1.15.0",
@@ -3587,6 +1174,396 @@
       "licenseDeclared": "MIT OR Apache-2.0",
       "name": "either",
       "versionInfo": "1.15.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-icu--properties-2.1.2",
+      "description": "Definitions for Unicode properties",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/icu_properties@2.1.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://icu4x.unicode.org",
+      "licenseConcluded": "Unicode-3.0",
+      "licenseDeclared": "Unicode-3.0",
+      "name": "icu_properties",
+      "versionInfo": "2.1.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-thiserror-1.0.69",
+      "description": "derive(Error)",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/thiserror@1.0.69",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "thiserror",
+      "versionInfo": "1.0.69"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-litemap-0.8.1",
+      "description": "A key-value Map implementation based on a flat, sorted Vec.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/litemap@0.8.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Unicode-3.0",
+      "licenseDeclared": "Unicode-3.0",
+      "name": "litemap",
+      "versionInfo": "0.8.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-strsim-0.11.1",
+      "description": "Implementations of string similarity metrics. Includes Hamming, Levenshtein,\nOSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/strsim@0.11.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rapidfuzz/strsim-rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "strsim",
+      "versionInfo": "0.11.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-untrusted-0.9.0",
+      "description": "Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/untrusted@0.9.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "name": "untrusted",
+      "versionInfo": "0.9.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-axum-core-0.5.6",
+      "description": "Core types and traits for axum",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/axum-core@0.5.6",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/tokio-rs/axum",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "axum-core",
+      "versionInfo": "0.5.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ring-0.17.14",
+      "description": "An experiment.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ring@0.17.14",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 AND ISC",
+      "licenseDeclared": "Apache-2.0 AND ISC",
+      "name": "ring",
+      "versionInfo": "0.17.14"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-result-0.4.1",
+      "description": "Windows error handling",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-result@0.4.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-result",
+      "versionInfo": "0.4.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-jiff-0.2.15",
+      "description": "A date-time library that encourages you to jump into the pit of success.\n\nThis library is heavily inspired by the Temporal project.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/jiff@0.2.15",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Unlicense OR MIT",
+      "licenseDeclared": "Unlicense OR MIT",
+      "name": "jiff",
+      "versionInfo": "0.2.15"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-foreign-types-shared-0.1.1",
+      "description": "An internal crate used by foreign-types",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/foreign-types-shared@0.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "foreign-types-shared",
+      "versionInfo": "0.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-portable-atomic-util-0.2.4",
+      "description": "Synchronization primitives built with portable-atomic.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/portable-atomic-util@0.2.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "portable-atomic-util",
+      "versionInfo": "0.2.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-fs-err-3.3.0",
+      "description": "A drop-in replacement for std::fs with more helpful error messages.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/fs-err@3.3.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "fs-err",
+      "versionInfo": "3.3.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rand-0.9.2",
+      "description": "Random number generators and other randomness functionality.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rand@0.9.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-random.github.io/book",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "rand",
+      "versionInfo": "0.9.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-mio-1.1.1",
+      "description": "Lightweight non-blocking I/O.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/mio@1.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/tokio-rs/mio",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "mio",
+      "versionInfo": "1.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-iana-time-zone-0.1.65",
+      "description": "get the IANA time zone for the current system",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/iana-time-zone@0.1.65",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "iana-time-zone",
+      "versionInfo": "0.1.65"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-anstream-0.6.21",
+      "description": "IO stream adapters for writing colored text that will gracefully degrade according to your terminal's capabilities.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/anstream@0.6.21",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "anstream",
+      "versionInfo": "0.6.21"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-libredox-0.1.12",
+      "description": "Redox stable ABI",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/libredox@0.1.12",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "libredox",
+      "versionInfo": "0.1.12"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-bytes-1.11.1",
+      "description": "Types and traits for working with bytes",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/bytes@1.11.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "bytes",
+      "versionInfo": "1.11.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasi-0.11.1-plus-wasi-snapshot-preview1",
+      "description": "Experimental WASI API bindings for Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasi@0.11.1%2Bwasi-snapshot-preview1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wasi",
+      "versionInfo": "0.11.1+wasi-snapshot-preview1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-interface-0.59.3",
+      "description": "The interface macro for the Windows crates",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-interface@0.59.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-interface",
+      "versionInfo": "0.59.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-datastar-0.3.1",
+      "description": "Datastar SDK for Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/datastar@0.3.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://data-star.dev",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "datastar",
+      "versionInfo": "0.3.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zip-8.1.0",
+      "description": "Library to support the reading and writing of zip files.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zip@8.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "zip",
+      "versionInfo": "8.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-eyre-0.6.12",
+      "description": "Flexible concrete Error Reporting type built on std::error::Error with customizable Reports",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/eyre@0.6.12",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "eyre",
+      "versionInfo": "0.6.12"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-http-body-1.0.1",
+      "description": "Trait representing an asynchronous, streaming, HTTP request or response body.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/http-body@1.0.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "http-body",
+      "versionInfo": "1.0.1"
     },
     {
       "SPDXID": "SPDXRef-Package-fnv-1.0.7",
@@ -3621,203 +1598,86 @@
       "versionInfo": "1.0.3"
     },
     {
-      "SPDXID": "SPDXRef-Package-anstyle-parse-0.2.7",
-      "description": "Parse ANSI Style Escapes",
+      "SPDXID": "SPDXRef-Package-clap-4.5.48",
+      "description": "A simple to use, efficient, and full-featured Command Line Argument Parser",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/anstyle-parse@0.2.7",
+          "referenceLocator": "pkg:cargo/clap@4.5.48",
           "referenceType": "purl"
         }
       ],
       "licenseConcluded": "MIT OR Apache-2.0",
       "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "anstyle-parse",
-      "versionInfo": "0.2.7"
+      "name": "clap",
+      "versionInfo": "4.5.48"
     },
     {
-      "SPDXID": "SPDXRef-Package-flate2-1.1.4",
-      "description": "DEFLATE compression and decompression exposed as Read/BufRead/Write streams.\nSupports miniz_oxide and multiple zlib implementations. Supports zlib, gzip,\nand raw deflate streams.\n",
+      "SPDXID": "SPDXRef-Package-miniz--oxide-0.8.9",
+      "description": "DEFLATE compression and decompression library rewritten in Rust based on miniz",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/flate2@1.1.4",
+          "referenceLocator": "pkg:cargo/miniz_oxide@0.8.9",
           "referenceType": "purl"
         }
       ],
-      "homepage": "https://github.com/rust-lang/flate2-rs",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "flate2",
-      "versionInfo": "1.1.4"
+      "homepage": "https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide",
+      "licenseConcluded": "MIT OR Zlib OR Apache-2.0",
+      "licenseDeclared": "MIT OR Zlib OR Apache-2.0",
+      "name": "miniz_oxide",
+      "versionInfo": "0.8.9"
     },
     {
-      "SPDXID": "SPDXRef-Package-memchr-2.7.6",
-      "description": "Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for\n1, 2 or 3 byte search and single substring search.\n",
+      "SPDXID": "SPDXRef-Package-redox--syscall-0.5.18",
+      "description": "A Rust library to access raw Redox system calls",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/memchr@2.7.6",
+          "referenceLocator": "pkg:cargo/redox_syscall@0.5.18",
           "referenceType": "purl"
         }
       ],
-      "homepage": "https://github.com/BurntSushi/memchr",
-      "licenseConcluded": "Unlicense OR MIT",
-      "licenseDeclared": "Unlicense OR MIT",
-      "name": "memchr",
-      "versionInfo": "2.7.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows-strings-0.5.1",
-      "description": "Windows string types",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows-strings@0.5.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows-strings",
-      "versionInfo": "0.5.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-ring-0.17.14",
-      "description": "An experiment.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/ring@0.17.14",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 AND ISC",
-      "licenseDeclared": "Apache-2.0 AND ISC",
-      "name": "ring",
-      "versionInfo": "0.17.14"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-wasm-bindgen-shared-0.2.104",
-      "description": "Shared support between wasm-bindgen and wasm-bindgen cli, an internal\ndependency.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/wasm-bindgen-shared@0.2.104",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "wasm-bindgen-shared",
-      "versionInfo": "0.2.104"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-utf8parse-0.2.2",
-      "description": "Table-driven UTF-8 parser",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/utf8parse@0.2.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "utf8parse",
-      "versionInfo": "0.2.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-futures-util-0.3.31",
-      "description": "Common utilities and extension traits for the futures-rs library.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/futures-util@0.3.31",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://rust-lang.github.io/futures-rs",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "futures-util",
-      "versionInfo": "0.3.31"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-chrono-0.4.42",
-      "description": "Date and time library for Rust",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/chrono@0.4.42",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/chronotope/chrono",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "chrono",
-      "versionInfo": "0.4.42"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows--i686--gnu-0.52.6",
-      "description": "Import lib for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_i686_gnu@0.52.6",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_i686_gnu",
-      "versionInfo": "0.52.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-utf8--iter-1.0.4",
-      "description": "Iterator by char over potentially-invalid UTF-8 in &[u8]",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/utf8_iter@1.0.4",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://docs.rs/utf8_iter/",
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "utf8_iter",
-      "versionInfo": "1.0.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-tokio-1.47.1",
-      "description": "An event-driven, non-blocking I/O platform for writing asynchronous I/O\nbacked applications.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/tokio@1.47.1",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://tokio.rs",
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
-      "name": "tokio",
-      "versionInfo": "1.47.1"
+      "name": "redox_syscall",
+      "versionInfo": "0.5.18"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rustc-hash-2.1.1",
+      "description": "A speedy, non-cryptographic hashing algorithm used by rustc",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rustc-hash@2.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "rustc-hash",
+      "versionInfo": "2.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-askama-0.15.4",
+      "description": "Type-safe, compiled Jinja-like templates for Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/askama@0.15.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://askama.rs/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "askama",
+      "versionInfo": "0.15.4"
     },
     {
       "SPDXID": "SPDXRef-Package-num-traits-0.2.19",
@@ -3837,36 +1697,216 @@
       "versionInfo": "0.2.19"
     },
     {
-      "SPDXID": "SPDXRef-Package-litemap-0.8.0",
-      "description": "A key-value Map implementation based on a flat, sorted Vec.",
+      "SPDXID": "SPDXRef-Package-windows-sys-0.52.0",
+      "description": "Rust for Windows",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/litemap@0.8.0",
+          "referenceLocator": "pkg:cargo/windows-sys@0.52.0",
           "referenceType": "purl"
         }
       ],
-      "licenseConcluded": "Unicode-3.0",
-      "licenseDeclared": "Unicode-3.0",
-      "name": "litemap",
-      "versionInfo": "0.8.0"
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-sys",
+      "versionInfo": "0.52.0"
     },
     {
-      "SPDXID": "SPDXRef-Package-want-0.3.1",
-      "description": "Detect when another Future wants a result.",
+      "SPDXID": "SPDXRef-Package-darling--core-0.21.3",
+      "description": "Helper crate for proc-macro library for reading attributes into structs when\nimplementing custom derives. Use https://crates.io/crates/darling in your code.\n",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/want@0.3.1",
+          "referenceLocator": "pkg:cargo/darling_core@0.21.3",
           "referenceType": "purl"
         }
       ],
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
-      "name": "want",
-      "versionInfo": "0.3.1"
+      "name": "darling_core",
+      "versionInfo": "0.21.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-askama--parser-0.15.4",
+      "description": "Parser for Askama templates",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/askama_parser@0.15.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/askama-rs/askama",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "askama_parser",
+      "versionInfo": "0.15.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-num-conv-0.2.0",
+      "description": "`num_conv` is a crate to convert between integer types without using `as` casts. This provides\nbetter certainty when refactoring, makes the exact behavior of code more explicit, and allows using\nturbofish syntax.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/num-conv@0.2.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "num-conv",
+      "versionInfo": "0.2.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-is--terminal--polyfill-1.70.1",
+      "description": "Polyfill for `is_terminal` stdlib feature for use with older MSRVs",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/is_terminal_polyfill@1.70.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "is_terminal_polyfill",
+      "versionInfo": "1.70.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-smallvec-1.15.1",
+      "description": "'Small vector' optimization: store up to a small number of items on the stack",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/smallvec@1.15.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "smallvec",
+      "versionInfo": "1.15.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-core-0.62.2",
+      "description": "Core type support for COM and Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-core@0.62.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-core",
+      "versionInfo": "0.62.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tracing-0.1.44",
+      "description": "Application-level tracing for Rust.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tracing@0.1.44",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://tokio.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "tracing",
+      "versionInfo": "0.1.44"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-serde--path--to--error-0.1.20",
+      "description": "Path to the element that failed to deserialize",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/serde_path_to_error@0.1.20",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "serde_path_to_error",
+      "versionInfo": "0.1.20"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-android--system--properties-0.1.5",
+      "description": "Minimal Android system properties wrapper",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/android_system_properties@0.1.5",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/nical/android_system_properties",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "android_system_properties",
+      "versionInfo": "0.1.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-json-patch-4.1.0",
+      "description": "RFC 6902, JavaScript Object Notation (JSON) Patch",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/json-patch@4.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "json-patch",
+      "versionInfo": "4.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-executor-0.3.31",
+      "description": "Executors for asynchronous tasks based on the futures-rs library.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-executor@0.3.31",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures-executor",
+      "versionInfo": "0.3.31"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-foreign-types-0.3.2",
+      "description": "A framework for Rust wrappers over C APIs",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/foreign-types@0.3.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "foreign-types",
+      "versionInfo": "0.3.2"
     },
     {
       "SPDXID": "SPDXRef-Package-hyper-tls-0.6.0",
@@ -3886,919 +1926,86 @@
       "versionInfo": "0.6.0"
     },
     {
-      "SPDXID": "SPDXRef-Package-futures-core-0.3.31",
-      "description": "The core traits and types in for the `futures` library.\n",
+      "SPDXID": "SPDXRef-Package-system-configuration-0.7.0",
+      "description": "Bindings to SystemConfiguration framework for macOS",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/futures-core@0.3.31",
+          "referenceLocator": "pkg:cargo/system-configuration@0.7.0",
           "referenceType": "purl"
         }
       ],
-      "homepage": "https://rust-lang.github.io/futures-rs",
       "licenseConcluded": "MIT OR Apache-2.0",
       "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "futures-core",
-      "versionInfo": "0.3.31"
+      "name": "system-configuration",
+      "versionInfo": "0.7.0"
     },
     {
-      "SPDXID": "SPDXRef-Package-zip-6.0.0",
-      "description": "Library to support the reading and writing of zip files.\n",
+      "SPDXID": "SPDXRef-Package-tracing-core-0.1.36",
+      "description": "Core primitives for application-level tracing.\n",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/zip@6.0.0",
+          "referenceLocator": "pkg:cargo/tracing-core@0.1.36",
           "referenceType": "purl"
         }
       ],
+      "homepage": "https://tokio.rs",
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
-      "name": "zip",
-      "versionInfo": "6.0.0"
+      "name": "tracing-core",
+      "versionInfo": "0.1.36"
     },
     {
-      "SPDXID": "SPDXRef-Package-base64-0.22.1",
-      "description": "encodes and decodes base64 as bytes or utf8",
+      "SPDXID": "SPDXRef-Package-socket2-0.6.2",
+      "description": "Utilities for handling networking sockets with a maximal amount of configuration\npossible intended.\n",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/base64@0.22.1",
+          "referenceLocator": "pkg:cargo/socket2@0.6.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rust-lang/socket2",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "socket2",
+      "versionInfo": "0.6.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-registry-0.6.1",
+      "description": "Windows registry",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-registry@0.6.1",
           "referenceType": "purl"
         }
       ],
       "licenseConcluded": "MIT OR Apache-2.0",
       "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "base64",
-      "versionInfo": "0.22.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-writeable-0.6.1",
-      "description": "A more efficient alternative to fmt::Display",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/writeable@0.6.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Unicode-3.0",
-      "licenseDeclared": "Unicode-3.0",
-      "name": "writeable",
+      "name": "windows-registry",
       "versionInfo": "0.6.1"
     },
     {
-      "SPDXID": "SPDXRef-Package-futures-0.3.31",
-      "description": "An implementation of futures and streams featuring zero allocations,\ncomposability, and iterator-like interfaces.\n",
+      "SPDXID": "SPDXRef-Package-form--urlencoded-1.2.2",
+      "description": "Parser and serializer for the application/x-www-form-urlencoded syntax, as used by HTML forms.",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/futures@0.3.31",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://rust-lang.github.io/futures-rs",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "futures",
-      "versionInfo": "0.3.31"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-rustc-hash-2.1.1",
-      "description": "A speedy, non-cryptographic hashing algorithm used by rustc",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/rustc-hash@2.1.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "rustc-hash",
-      "versionInfo": "2.1.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-crossbeam-epoch-0.9.18",
-      "description": "Epoch-based garbage collection",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/crossbeam-epoch@0.9.18",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-epoch",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "crossbeam-epoch",
-      "versionInfo": "0.9.18"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-anstyle-query-1.1.4",
-      "description": "Look up colored console capabilities",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/anstyle-query@1.1.4",
+          "referenceLocator": "pkg:cargo/form_urlencoded@1.2.2",
           "referenceType": "purl"
         }
       ],
       "licenseConcluded": "MIT OR Apache-2.0",
       "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "anstyle-query",
-      "versionInfo": "1.1.4"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-tower-0.5.2",
-      "description": "Tower is a library of modular and reusable components for building robust\nclients and servers.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/tower@0.5.2",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/tower-rs/tower",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "tower",
-      "versionInfo": "0.5.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-iana-time-zone-haiku-0.1.2",
-      "description": "iana-time-zone support crate for Haiku OS",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/iana-time-zone-haiku@0.1.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "iana-time-zone-haiku",
-      "versionInfo": "0.1.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-wasm-bindgen-0.2.104",
-      "description": "Easy support for interacting between JS and Rust.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/wasm-bindgen@0.2.104",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "wasm-bindgen",
-      "versionInfo": "0.2.104"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-iri-string-0.7.8",
-      "description": "IRI as string types",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/iri-string@0.7.8",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "iri-string",
-      "versionInfo": "0.7.8"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-js-sys-0.3.81",
-      "description": "Bindings for all JS global objects and functions in all JS environments like\nNode.js and browsers, built on `#[wasm_bindgen]` using the `wasm-bindgen` crate.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/js-sys@0.3.81",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "js-sys",
-      "versionInfo": "0.3.81"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows-result-0.4.1",
-      "description": "Windows error handling",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows-result@0.4.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows-result",
-      "versionInfo": "0.4.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-rayon-1.11.0",
-      "description": "Simple work-stealing parallelism for Rust",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/rayon@1.11.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "rayon",
-      "versionInfo": "1.11.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-pin-utils-0.1.0",
-      "description": "Utilities for pinning\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/pin-utils@0.1.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "pin-utils",
-      "versionInfo": "0.1.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-rustls-0.23.32",
-      "description": "Rustls is a modern TLS library written in Rust.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/rustls@0.23.32",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/rustls/rustls",
-      "licenseConcluded": "Apache-2.0 OR ISC OR MIT",
-      "licenseDeclared": "Apache-2.0 OR ISC OR MIT",
-      "name": "rustls",
-      "versionInfo": "0.23.32"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-void-1.0.2",
-      "description": "The uninhabited void type for use in statically impossible cases.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/void@1.0.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "void",
-      "versionInfo": "1.0.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-jiff-static-0.2.15",
-      "description": "Create static TimeZone values for Jiff (useful in core-only environments).",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/jiff-static@0.2.15",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/BurntSushi/jiff/tree/master/crates/jiff-static",
-      "licenseConcluded": "Unlicense OR MIT",
-      "licenseDeclared": "Unlicense OR MIT",
-      "name": "jiff-static",
-      "versionInfo": "0.2.15"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows--i686--gnu-0.53.1",
-      "description": "Import lib for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_i686_gnu@0.53.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_i686_gnu",
-      "versionInfo": "0.53.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-tower-layer-0.3.3",
-      "description": "Decorates a `Service` to allow easy composition between `Service`s.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/tower-layer@0.3.3",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/tower-rs/tower",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "tower-layer",
-      "versionInfo": "0.3.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-yoke-derive-0.8.0",
-      "description": "Custom derive for the yoke crate",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/yoke-derive@0.8.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Unicode-3.0",
-      "licenseDeclared": "Unicode-3.0",
-      "name": "yoke-derive",
-      "versionInfo": "0.8.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows--i686--gnullvm-0.53.1",
-      "description": "Import lib for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_i686_gnullvm@0.53.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_i686_gnullvm",
-      "versionInfo": "0.53.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-env--filter-0.1.3",
-      "description": "Filter log events using environment variables\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/env_filter@0.1.3",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "env_filter",
-      "versionInfo": "0.1.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-futures-macro-0.3.31",
-      "description": "The futures-rs procedural macro implementations.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/futures-macro@0.3.31",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://rust-lang.github.io/futures-rs",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "futures-macro",
-      "versionInfo": "0.3.31"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-icu--normalizer--data-2.0.0",
-      "description": "Data for the icu_normalizer crate",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/icu_normalizer_data@2.0.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://icu4x.unicode.org",
-      "licenseConcluded": "Unicode-3.0",
-      "licenseDeclared": "Unicode-3.0",
-      "name": "icu_normalizer_data",
-      "versionInfo": "2.0.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows-sys-0.59.0",
-      "description": "Rust for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows-sys@0.59.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows-sys",
-      "versionInfo": "0.59.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-wasm-bindgen-backend-0.2.104",
-      "description": "Backend code generation of the wasm-bindgen tool\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/wasm-bindgen-backend@0.2.104",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "wasm-bindgen-backend",
-      "versionInfo": "0.2.104"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-strsim-0.11.1",
-      "description": "Implementations of string similarity metrics. Includes Hamming, Levenshtein,\nOSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/strsim@0.11.1",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/rapidfuzz/strsim-rs",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "strsim",
-      "versionInfo": "0.11.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-icu--locale--core-2.0.0",
-      "description": "API for managing Unicode Language and Locale Identifiers",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/icu_locale_core@2.0.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://icu4x.unicode.org",
-      "licenseConcluded": "Unicode-3.0",
-      "licenseDeclared": "Unicode-3.0",
-      "name": "icu_locale_core",
-      "versionInfo": "2.0.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-regex-automata-0.4.12",
-      "description": "Automata construction and matching using regular expressions.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/regex-automata@0.4.12",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/rust-lang/regex/tree/master/regex-automata",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "regex-automata",
-      "versionInfo": "0.4.12"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-jiff-0.2.15",
-      "description": "A date-time library that encourages you to jump into the pit of success.\n\nThis library is heavily inspired by the Temporal project.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/jiff@0.2.15",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Unlicense OR MIT",
-      "licenseDeclared": "Unlicense OR MIT",
-      "name": "jiff",
-      "versionInfo": "0.2.15"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-wit-bindgen-0.46.0",
-      "description": "Rust bindings generator and runtime support for WIT and the component model.\nUsed when compiling Rust programs to the component model.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/wit-bindgen@0.46.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://github.com/bytecodealliance/wit-bindgen",
-      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
-      "name": "wit-bindgen",
-      "versionInfo": "0.46.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows-core-0.62.2",
-      "description": "Core type support for COM and Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows-core@0.62.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows-core",
-      "versionInfo": "0.62.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows--i686--msvc-0.52.6",
-      "description": "Import lib for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows_i686_msvc@0.52.6",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows_i686_msvc",
-      "versionInfo": "0.52.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-tempfile-3.23.0",
-      "description": "A library for managing temporary files and directories.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/tempfile@3.23.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://stebalien.com/projects/tempfile-rs/",
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "tempfile",
-      "versionInfo": "3.23.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-serde--urlencoded-0.7.1",
-      "description": "`x-www-form-urlencoded` meets Serde",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/serde_urlencoded@0.7.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "serde_urlencoded",
-      "versionInfo": "0.7.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-hashbrown-0.16.0",
-      "description": "A Rust port of Google's SwissTable hash map",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/hashbrown@0.16.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "hashbrown",
-      "versionInfo": "0.16.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-mime-0.3.17",
-      "description": "Strongly Typed Mimes",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/mime@0.3.17",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "mime",
-      "versionInfo": "0.3.17"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-tokio-native-tls-0.3.1",
-      "description": "An implementation of TLS/SSL streams for Tokio using native-tls giving an implementation of TLS\nfor nonblocking I/O streams.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/tokio-native-tls@0.3.1",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://tokio.rs",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "tokio-native-tls",
-      "versionInfo": "0.3.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-unsafe-libyaml-0.2.11",
-      "description": "libyaml transpiled to rust by c2rust",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/unsafe-libyaml@0.2.11",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "unsafe-libyaml",
-      "versionInfo": "0.2.11"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-zerocopy-0.8.27",
-      "description": "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/zerocopy@0.8.27",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "BSD-2-Clause OR Apache-2.0 OR MIT",
-      "licenseDeclared": "BSD-2-Clause OR Apache-2.0 OR MIT",
-      "name": "zerocopy",
-      "versionInfo": "0.8.27"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-bytes-1.10.1",
-      "description": "Types and traits for working with bytes",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/bytes@1.10.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "bytes",
-      "versionInfo": "1.10.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-adler2-2.0.1",
-      "description": "A simple clean-room implementation of the Adler-32 checksum",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/adler2@2.0.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "0BSD OR MIT OR Apache-2.0",
-      "licenseDeclared": "0BSD OR MIT OR Apache-2.0",
-      "name": "adler2",
-      "versionInfo": "2.0.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-rustix-1.1.2",
-      "description": "Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/rustix@1.1.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
-      "name": "rustix",
-      "versionInfo": "1.1.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-zerofrom-derive-0.1.6",
-      "description": "Custom derive for the zerofrom crate",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/zerofrom-derive@0.1.6",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Unicode-3.0",
-      "licenseDeclared": "Unicode-3.0",
-      "name": "zerofrom-derive",
-      "versionInfo": "0.1.6"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-object-0.37.3",
-      "description": "A unified interface for reading and writing object file formats.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/object@0.37.3",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "object",
-      "versionInfo": "0.37.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-zerovec-derive-0.11.1",
-      "description": "Custom derive for the zerovec crate",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/zerovec-derive@0.11.1",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Unicode-3.0",
-      "licenseDeclared": "Unicode-3.0",
-      "name": "zerovec-derive",
-      "versionInfo": "0.11.1"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-windows-link-0.1.3",
-      "description": "Linking for Windows",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/windows-link@0.1.3",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "windows-link",
-      "versionInfo": "0.1.3"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-serde--json-1.0.145",
-      "description": "A JSON serialization file format",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/serde_json@1.0.145",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "serde_json",
-      "versionInfo": "1.0.145"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-fastrand-2.3.0",
-      "description": "A simple and fast random number generator",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/fastrand@2.3.0",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "Apache-2.0 OR MIT",
-      "licenseDeclared": "Apache-2.0 OR MIT",
-      "name": "fastrand",
-      "versionInfo": "2.3.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-tokio-macros-2.5.0",
-      "description": "Tokio's proc macros.\n",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/tokio-macros@2.5.0",
-          "referenceType": "purl"
-        }
-      ],
-      "homepage": "https://tokio.rs",
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "name": "tokio-macros",
-      "versionInfo": "2.5.0"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-percent-encoding-2.3.2",
-      "description": "Percent encoding and decoding",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/percent-encoding@2.3.2",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "percent-encoding",
-      "versionInfo": "2.3.2"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-clap--builder-4.5.48",
-      "description": "A simple to use, efficient, and full-featured Command Line Argument Parser",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/clap_builder@4.5.48",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "clap_builder",
-      "versionInfo": "4.5.48"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-parking--lot-0.12.5",
-      "description": "More compact and efficient implementations of the standard synchronization primitives.",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/parking_lot@0.12.5",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "parking_lot",
-      "versionInfo": "0.12.5"
-    },
-    {
-      "SPDXID": "SPDXRef-Package-eyre-0.6.12",
-      "description": "Flexible concrete Error Reporting type built on std::error::Error with customizable Reports",
-      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/eyre@0.6.12",
-          "referenceType": "purl"
-        }
-      ],
-      "licenseConcluded": "MIT OR Apache-2.0",
-      "licenseDeclared": "MIT OR Apache-2.0",
-      "name": "eyre",
-      "versionInfo": "0.6.12"
+      "name": "form_urlencoded",
+      "versionInfo": "1.2.2"
     },
     {
       "SPDXID": "SPDXRef-Package-serde--core-1.0.228",
@@ -4818,6 +2025,1242 @@
       "versionInfo": "1.0.228"
     },
     {
+      "SPDXID": "SPDXRef-Package-base64-0.22.1",
+      "description": "encodes and decodes base64 as bytes or utf8",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/base64@0.22.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "base64",
+      "versionInfo": "0.22.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tokio-1.49.0",
+      "description": "An event-driven, non-blocking I/O platform for writing asynchronous I/O\nbacked applications.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tokio@1.49.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://tokio.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "tokio",
+      "versionInfo": "1.49.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-parking--lot--core-0.9.12",
+      "description": "An advanced API for creating custom synchronization primitives.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/parking_lot_core@0.9.12",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "parking_lot_core",
+      "versionInfo": "0.9.12"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-async-compression-0.4.39",
+      "description": "Adaptors between compression crates and Rust's modern asynchronous IO types.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/async-compression@0.4.39",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "async-compression",
+      "versionInfo": "0.4.39"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-time-macros-0.2.27",
+      "description": "    Procedural macros for the time crate.\n    This crate is an implementation detail and should not be relied upon directly.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/time-macros@0.2.27",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "time-macros",
+      "versionInfo": "0.2.27"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-chrono-0.4.43",
+      "description": "Date and time library for Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/chrono@0.4.43",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/chronotope/chrono",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "chrono",
+      "versionInfo": "0.4.43"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-crossbeam-deque-0.8.6",
+      "description": "Concurrent work-stealing deque",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/crossbeam-deque@0.8.6",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-deque",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "crossbeam-deque",
+      "versionInfo": "0.8.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-fastrand-2.3.0",
+      "description": "A simple and fast random number generator",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/fastrand@2.3.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "fastrand",
+      "versionInfo": "2.3.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tower-0.5.3",
+      "description": "Tower is a library of modular and reusable components for building robust\nclients and servers.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tower@0.5.3",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/tower-rs/tower",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "tower",
+      "versionInfo": "0.5.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-iri-string-0.7.10",
+      "description": "IRI as string types",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/iri-string@0.7.10",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "iri-string",
+      "versionInfo": "0.7.10"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-bumpalo-3.19.1",
+      "description": "A fast bump allocation arena for Rust.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/bumpalo@3.19.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "bumpalo",
+      "versionInfo": "3.19.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-libc-0.2.180",
+      "description": "Raw FFI bindings to platform libraries like libc.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/libc@0.2.180",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "libc",
+      "versionInfo": "0.2.180"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-linux-raw-sys-0.11.0",
+      "description": "Generated bindings for Linux's userspace API",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/linux-raw-sys@0.11.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "linux-raw-sys",
+      "versionInfo": "0.11.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tower-layer-0.3.3",
+      "description": "Decorates a `Service` to allow easy composition between `Service`s.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tower-layer@0.3.3",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/tower-rs/tower",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "tower-layer",
+      "versionInfo": "0.3.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ref-cast-1.0.25",
+      "description": "Safely cast &T to &U where the struct U contains a single field of type T.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ref-cast@1.0.25",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "ref-cast",
+      "versionInfo": "1.0.25"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-stable--deref--trait-1.2.1",
+      "description": "An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/stable_deref_trait@1.2.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "stable_deref_trait",
+      "versionInfo": "1.2.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tempfile-3.24.0",
+      "description": "A library for managing temporary files and directories.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tempfile@3.24.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://stebalien.com/projects/tempfile-rs/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "tempfile",
+      "versionInfo": "3.24.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-utf8parse-0.2.2",
+      "description": "Table-driven UTF-8 parser",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/utf8parse@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "utf8parse",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-axum-server-0.8.0",
+      "description": "High level server designed to be used with axum framework.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/axum-server@0.8.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/programatik29/axum-server",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "axum-server",
+      "versionInfo": "0.8.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--i686--msvc-0.53.1",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_i686_msvc@0.53.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_i686_msvc",
+      "versionInfo": "0.53.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-potential--utf-0.1.4",
+      "description": "Unvalidated string and character types",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/potential_utf@0.1.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://icu4x.unicode.org",
+      "licenseConcluded": "Unicode-3.0",
+      "licenseDeclared": "Unicode-3.0",
+      "name": "potential_utf",
+      "versionInfo": "0.1.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-once--cell--polyfill-1.70.1",
+      "description": "Polyfill for `OnceCell` stdlib feature for use with older MSRVs",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/once_cell_polyfill@1.70.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "once_cell_polyfill",
+      "versionInfo": "1.70.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-bitflags-2.10.0",
+      "description": "A macro to generate structures which behave like bitflags.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/bitflags@2.10.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/bitflags/bitflags",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "bitflags",
+      "versionInfo": "2.10.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-spin-0.9.8",
+      "description": "Spin-based synchronization primitives",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/spin@0.9.8",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "spin",
+      "versionInfo": "0.9.8"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-clap--builder-4.5.48",
+      "description": "A simple to use, efficient, and full-featured Command Line Argument Parser",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/clap_builder@4.5.48",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "clap_builder",
+      "versionInfo": "4.5.48"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-errno-0.3.14",
+      "description": "Cross-platform interface to the `errno` variable.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/errno@0.3.14",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "errno",
+      "versionInfo": "0.3.14"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-serde--with--macros-3.16.1",
+      "description": "proc-macro library for serde_with",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/serde_with_macros@3.16.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "serde_with_macros",
+      "versionInfo": "3.16.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-log-0.4.29",
+      "description": "A lightweight logging facade for Rust\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/log@0.4.29",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "log",
+      "versionInfo": "0.4.29"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-sys-0.60.2",
+      "description": "Rust for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-sys@0.60.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-sys",
+      "versionInfo": "0.60.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-askama--macros-0.15.4",
+      "description": "Procedural macro package for Askama",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/askama_macros@0.15.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/askama-rs/askama",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "askama_macros",
+      "versionInfo": "0.15.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-portable-atomic-1.11.1",
+      "description": "Portable atomic types including support for 128-bit atomics, atomic float, etc.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/portable-atomic@1.11.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "portable-atomic",
+      "versionInfo": "1.11.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-jsonptr-0.7.1",
+      "description": "Data structures and logic for resolving, assigning, and deleting by JSON Pointers (RFC 6901)",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/jsonptr@0.7.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/chanced/jsonptr",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "jsonptr",
+      "versionInfo": "0.7.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-mime-0.3.17",
+      "description": "Strongly Typed Mimes",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/mime@0.3.17",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "mime",
+      "versionInfo": "0.3.17"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1",
+      "description": "Official Elasticsearch Rust client",
+      "downloadLocation": "git+https://github.com/VimCommando/elasticsearch-rs?rev=2eff23f3d908c177b8ecc03c4a8af0f8080d7a80#2eff23f3d908c177b8ecc03c4a8af0f8080d7a80",
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "name": "elasticsearch",
+      "versionInfo": "9.1.0-alpha.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rustls-pki-types-1.14.0",
+      "description": "Shared types for the rustls PKI ecosystem",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rustls-pki-types@1.14.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rustls/pki-types",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "rustls-pki-types",
+      "versionInfo": "1.14.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasip2-1.0.2-plus-wasi-0.2.9",
+      "description": "WASIp2 API bindings for Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasip2@1.0.2%2Bwasi-0.2.9",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wasip2",
+      "versionInfo": "1.0.2+wasi-0.2.9"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-link-0.2.1",
+      "description": "Linking for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-link@0.2.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-link",
+      "versionInfo": "0.2.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-displaydoc-0.2.5",
+      "description": "A derive macro for implementing the display Trait via a doc comment and string interpolation\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/displaydoc@0.2.5",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/yaahc/displaydoc",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "displaydoc",
+      "versionInfo": "0.2.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-openssl-macros-0.1.1",
+      "description": "Internal macros used by the openssl crate.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/openssl-macros@0.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "openssl-macros",
+      "versionInfo": "0.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-hex-0.4.3",
+      "description": "Encoding and decoding data into/from hexadecimal representation.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/hex@0.4.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "hex",
+      "versionInfo": "0.4.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-equivalent-1.0.2",
+      "description": "Traits for key comparison in maps.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/equivalent@1.0.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "equivalent",
+      "versionInfo": "1.0.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-macro-0.3.31",
+      "description": "The futures-rs procedural macro implementations.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-macro@0.3.31",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures-macro",
+      "versionInfo": "0.3.31"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tokio-native-tls-0.3.1",
+      "description": "An implementation of TLS/SSL streams for Tokio using native-tls giving an implementation of TLS\nfor nonblocking I/O streams.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tokio-native-tls@0.3.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://tokio.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "tokio-native-tls",
+      "versionInfo": "0.3.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-schemars-1.2.1",
+      "description": "Generate JSON Schemas from Rust code",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/schemars@1.2.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://graham.cool/schemars/",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "schemars",
+      "versionInfo": "1.2.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-security-framework-2.11.1",
+      "description": "Security.framework bindings for macOS and iOS",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/security-framework@2.11.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://lib.rs/crates/security_framework",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "security-framework",
+      "versionInfo": "2.11.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-sink-0.3.31",
+      "description": "The asynchronous `Sink` trait for the futures-rs library.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-sink@0.3.31",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures-sink",
+      "versionInfo": "0.3.31"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-simd-adler32-0.3.8",
+      "description": "A SIMD-accelerated Adler-32 hash algorithm implementation.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/simd-adler32@0.3.8",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "simd-adler32",
+      "versionInfo": "0.3.8"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-syn-2.0.114",
+      "description": "Parser for Rust source code",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/syn@2.0.114",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "syn",
+      "versionInfo": "2.0.114"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--aarch64--msvc-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_aarch64_msvc@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_aarch64_msvc",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-quote-1.0.44",
+      "description": "Quasi-quoting macro quote!(...)",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/quote@1.0.44",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "quote",
+      "versionInfo": "1.0.44"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-hashbrown-0.12.3",
+      "description": "A Rust port of Google's SwissTable hash map",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/hashbrown@0.12.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "hashbrown",
+      "versionInfo": "0.12.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-memchr-2.8.0",
+      "description": "Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for\n1, 2 or 3 byte search and single substring search.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/memchr@2.8.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/BurntSushi/memchr",
+      "licenseConcluded": "Unlicense OR MIT",
+      "licenseDeclared": "Unlicense OR MIT",
+      "name": "memchr",
+      "versionInfo": "2.8.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-strings-0.5.1",
+      "description": "Windows string types",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-strings@0.5.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-strings",
+      "versionInfo": "0.5.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-task-0.3.31",
+      "description": "Tools for working with tasks.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-task@0.3.31",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures-task",
+      "versionInfo": "0.3.31"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-targets-0.52.6",
+      "description": "Import libs for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-targets@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-targets",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-atomic-waker-1.1.2",
+      "description": "A synchronization primitive for task wakeup",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/atomic-waker@1.1.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "atomic-waker",
+      "versionInfo": "1.1.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-native-tls-0.2.14",
+      "description": "A wrapper over a platform's native TLS implementation",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/native-tls@0.2.14",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "native-tls",
+      "versionInfo": "0.2.14"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-h2-0.4.13",
+      "description": "An HTTP/2 client and server",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/h2@0.4.13",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "h2",
+      "versionInfo": "0.4.13"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-system-configuration-sys-0.6.0",
+      "description": "Low level bindings to SystemConfiguration framework for macOS",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/system-configuration-sys@0.6.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "system-configuration-sys",
+      "versionInfo": "0.6.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-signal-hook-registry-1.4.8",
+      "description": "Backend crate for signal-hook",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/signal-hook-registry@1.4.8",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "signal-hook-registry",
+      "versionInfo": "1.4.8"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--aarch64--gnullvm-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_aarch64_gnullvm@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_aarch64_gnullvm",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-parking--lot-0.12.5",
+      "description": "More compact and efficient implementations of the standard synchronization primitives.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/parking_lot@0.12.5",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "parking_lot",
+      "versionInfo": "0.12.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-uuid-1.20.0",
+      "description": "A library to generate and parse UUIDs.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/uuid@1.20.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/uuid-rs/uuid",
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "uuid",
+      "versionInfo": "1.20.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-security-framework-sys-2.15.0",
+      "description": "Apple `Security.framework` low-level FFI bindings",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/security-framework-sys@2.15.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://lib.rs/crates/security-framework-sys",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "security-framework-sys",
+      "versionInfo": "2.15.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-jiff-static-0.2.15",
+      "description": "Create static TimeZone values for Jiff (useful in core-only environments).",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/jiff-static@0.2.15",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/BurntSushi/jiff/tree/master/crates/jiff-static",
+      "licenseConcluded": "Unlicense OR MIT",
+      "licenseDeclared": "Unlicense OR MIT",
+      "name": "jiff-static",
+      "versionInfo": "0.2.15"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tinystr-0.8.2",
+      "description": "A small ASCII-only bounded length string representation.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tinystr@0.8.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Unicode-3.0",
+      "licenseDeclared": "Unicode-3.0",
+      "name": "tinystr",
+      "versionInfo": "0.8.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-cfg-if-1.0.4",
+      "description": "A macro to ergonomically define an item depending on a large number of #[cfg]\nparameters. Structured like an if-else chain, the first matching branch is the\nitem that gets emitted.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/cfg-if@1.0.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "cfg-if",
+      "versionInfo": "1.0.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--x86--64--msvc-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_x86_64_msvc@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_x86_64_msvc",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-env--filter-0.1.3",
+      "description": "Filter log events using environment variables\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/env_filter@0.1.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "env_filter",
+      "versionInfo": "0.1.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-hyper-util-0.1.20",
+      "description": "hyper utilities",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/hyper-util@0.1.20",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://hyper.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "hyper-util",
+      "versionInfo": "0.1.20"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-schemars-0.9.0",
+      "description": "Generate JSON Schemas from Rust code",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/schemars@0.9.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://graham.cool/schemars/",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "schemars",
+      "versionInfo": "0.9.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-unicode-ident-1.0.22",
+      "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/unicode-ident@1.0.22",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "(MIT OR Apache-2.0) AND Unicode-3.0",
+      "licenseDeclared": "(MIT OR Apache-2.0) AND Unicode-3.0",
+      "name": "unicode-ident",
+      "versionInfo": "1.0.22"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-yoke-derive-0.8.1",
+      "description": "Custom derive for the yoke crate",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/yoke-derive@0.8.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Unicode-3.0",
+      "licenseDeclared": "Unicode-3.0",
+      "name": "yoke-derive",
+      "versionInfo": "0.8.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-web-sys-0.3.85",
+      "description": "Bindings for all Web APIs, a procedurally generated crate from WebIDL\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/web-sys@0.3.85",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/web-sys/index.html",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "web-sys",
+      "versionInfo": "0.3.85"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-0.3.31",
+      "description": "An implementation of futures and streams featuring zero allocations,\ncomposability, and iterator-like interfaces.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures@0.3.31",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures",
+      "versionInfo": "0.3.31"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zmij-1.0.19",
+      "description": "A double-to-string conversion algorithm based on Schubfach and yy",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zmij@1.0.19",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "zmij",
+      "versionInfo": "1.0.19"
+    },
+    {
       "SPDXID": "SPDXRef-Package-clap--lex-0.7.5",
       "description": "Minimal, flexible command line parser",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
@@ -4834,68 +3277,1398 @@
       "versionInfo": "0.7.5"
     },
     {
-      "SPDXID": "SPDXRef-Package-urlencoding-2.1.3",
-      "description": "A Rust library for doing URL percentage encoding.",
+      "SPDXID": "SPDXRef-Package-slab-0.4.12",
+      "description": "Pre-allocated storage for a uniform data type",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
-          "referenceLocator": "pkg:cargo/urlencoding@2.1.3",
+          "referenceLocator": "pkg:cargo/slab@0.4.12",
           "referenceType": "purl"
         }
       ],
-      "homepage": "https://lib.rs/urlencoding",
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
-      "name": "urlencoding",
-      "versionInfo": "2.1.3"
+      "name": "slab",
+      "versionInfo": "0.4.12"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-http-1.4.0",
+      "description": "A set of types for representing HTTP requests and responses.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/http@1.4.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "http",
+      "versionInfo": "1.4.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tower-service-0.3.3",
+      "description": "Trait representing an asynchronous, request / response based, client or server.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tower-service@0.3.3",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/tower-rs/tower",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "tower-service",
+      "versionInfo": "0.3.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT",
+      "downloadLocation": "NONE",
+      "licenseConcluded": "Elastic-2.0",
+      "licenseDeclared": "Elastic-2.0",
+      "name": "esdiag",
+      "versionInfo": "0.14.0-SNAPSHOT"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rustls-webpki-0.103.9",
+      "description": "Web PKI X.509 Certificate Verification.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rustls-webpki@0.103.9",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "name": "rustls-webpki",
+      "versionInfo": "0.103.9"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-crossbeam-utils-0.8.21",
+      "description": "Utilities for concurrent programming",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/crossbeam-utils@0.8.21",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "crossbeam-utils",
+      "versionInfo": "0.8.21"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-sync--wrapper-1.0.2",
+      "description": "A tool for enlisting the compiler's help in proving the absence of concurrency",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/sync_wrapper@1.0.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://docs.rs/sync_wrapper",
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "name": "sync_wrapper",
+      "versionInfo": "1.0.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--aarch64--msvc-0.53.1",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_aarch64_msvc@0.53.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_aarch64_msvc",
+      "versionInfo": "0.53.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-serde--yaml-0.9.34-plus-deprecated",
+      "description": "YAML data format for Serde",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/serde_yaml@0.9.34%2Bdeprecated",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "serde_yaml",
+      "versionInfo": "0.9.34+deprecated"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-openssl-0.10.75",
+      "description": "OpenSSL bindings",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/openssl@0.10.75",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "name": "openssl",
+      "versionInfo": "0.10.75"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zerocopy-0.8.39",
+      "description": "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zerocopy@0.8.39",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "BSD-2-Clause OR Apache-2.0 OR MIT",
+      "licenseDeclared": "BSD-2-Clause OR Apache-2.0 OR MIT",
+      "name": "zerocopy",
+      "versionInfo": "0.8.39"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-dyn-clone-1.0.20",
+      "description": "Clone trait that is dyn-compatible",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/dyn-clone@1.0.20",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "dyn-clone",
+      "versionInfo": "1.0.20"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-anstyle-1.0.13",
+      "description": "ANSI text styling",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/anstyle@1.0.13",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "anstyle",
+      "versionInfo": "1.0.13"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-time-0.3.47",
+      "description": "Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/time@0.3.47",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://time-rs.github.io",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "time",
+      "versionInfo": "0.3.47"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wit-bindgen-0.51.0",
+      "description": "Rust bindings generator and runtime support for WIT and the component model.\nUsed when compiling Rust programs to the component model.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wit-bindgen@0.51.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/bytecodealliance/wit-bindgen",
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wit-bindgen",
+      "versionInfo": "0.51.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-regex-automata-0.4.14",
+      "description": "Automata construction and matching using regular expressions.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/regex-automata@0.4.14",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rust-lang/regex/tree/master/regex-automata",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "regex-automata",
+      "versionInfo": "0.4.14"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--i686--msvc-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_i686_msvc@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_i686_msvc",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zeroize-1.8.2",
+      "description": "Securely clear secrets from memory with a simple trait built on\nstable Rust primitives which guarantee memory is zeroed using an\noperation will not be 'optimized away' by the compiler.\nUses a portable pure Rust implementation that works everywhere,\neven WASM!\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zeroize@1.8.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/RustCrypto/utils/tree/master/zeroize",
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "zeroize",
+      "versionInfo": "1.8.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-regex-syntax-0.8.9",
+      "description": "A regular expression parser.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/regex-syntax@0.8.9",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rust-lang/regex/tree/master/regex-syntax",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "regex-syntax",
+      "versionInfo": "0.8.9"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--x86--64--gnullvm-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_x86_64_gnullvm@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_x86_64_gnullvm",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-percent-encoding-2.3.2",
+      "description": "Percent encoding and decoding",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/percent-encoding@2.3.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "percent-encoding",
+      "versionInfo": "2.3.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-hyper-1.8.1",
+      "description": "A protective and efficient HTTP library for all.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/hyper@1.8.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://hyper.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "hyper",
+      "versionInfo": "1.8.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-time-core-0.1.8",
+      "description": "This crate is an implementation detail and should not be relied upon directly.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/time-core@0.1.8",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "time-core",
+      "versionInfo": "0.1.8"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-indexmap-2.13.0",
+      "description": "A hash table with consistent order and fast iteration.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/indexmap@2.13.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "indexmap",
+      "versionInfo": "2.13.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ryu-1.0.22",
+      "description": "Fast floating point to string conversion",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ryu@1.0.22",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR BSL-1.0",
+      "licenseDeclared": "Apache-2.0 OR BSL-1.0",
+      "name": "ryu",
+      "versionInfo": "1.0.22"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-encoding--rs-0.8.35",
+      "description": "A Gecko-oriented implementation of the Encoding Standard",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/encoding_rs@0.8.35",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://docs.rs/encoding_rs/",
+      "licenseConcluded": "(Apache-2.0 OR MIT) AND BSD-3-Clause",
+      "licenseDeclared": "(Apache-2.0 OR MIT) AND BSD-3-Clause",
+      "name": "encoding_rs",
+      "versionInfo": "0.8.35"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-serde-1.0.228",
+      "description": "A generic serialization/deserialization framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/serde@1.0.228",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://serde.rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "serde",
+      "versionInfo": "1.0.228"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-compression-codecs-0.4.36",
+      "description": "Adaptors for various compression algorithms.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/compression-codecs@0.4.36",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "compression-codecs",
+      "versionInfo": "0.4.36"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-void-1.0.2",
+      "description": "The uninhabited void type for use in statically impossible cases.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/void@1.0.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "void",
+      "versionInfo": "1.0.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-openssl-probe-0.1.6",
+      "description": "Tool for helping to find SSL certificate locations on the system for OpenSSL\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/openssl-probe@0.1.6",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/alexcrichton/openssl-probe",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "openssl-probe",
+      "versionInfo": "0.1.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-idna--adapter-1.2.1",
+      "description": "Back end adapter for idna",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/idna_adapter@1.2.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://docs.rs/crate/idna_adapter/latest",
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "idna_adapter",
+      "versionInfo": "1.2.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--x86--64--gnu-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_x86_64_gnu@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_x86_64_gnu",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--x86--64--gnullvm-0.53.1",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_x86_64_gnullvm@0.53.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_x86_64_gnullvm",
+      "versionInfo": "0.53.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-want-0.3.1",
+      "description": "Detect when another Future wants a result.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/want@0.3.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "want",
+      "versionInfo": "0.3.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-try-lock-0.2.5",
+      "description": "A lightweight atomic lock.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/try-lock@0.2.5",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/seanmonstar/try-lock",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "try-lock",
+      "versionInfo": "0.2.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-filetime-0.2.27",
+      "description": "Platform-agnostic accessors of timestamps in File metadata\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/filetime@0.2.27",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/alexcrichton/filetime",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "filetime",
+      "versionInfo": "0.2.27"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-r-efi-5.3.0",
+      "description": "UEFI Reference Specification Protocol Constants and Definitions",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/r-efi@5.3.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/r-efi/r-efi/wiki",
+      "licenseConcluded": "MIT OR Apache-2.0 OR LGPL-2.1-or-later",
+      "licenseDeclared": "MIT OR Apache-2.0 OR LGPL-2.1-or-later",
+      "name": "r-efi",
+      "versionInfo": "5.3.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-env--logger-0.11.8",
+      "description": "A logging implementation for `log` which is configured via an environment\nvariable.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/env_logger@0.11.8",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "env_logger",
+      "versionInfo": "0.11.8"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-adler2-2.0.1",
+      "description": "A simple clean-room implementation of the Adler-32 checksum",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/adler2@2.0.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "0BSD OR MIT OR Apache-2.0",
+      "licenseDeclared": "0BSD OR MIT OR Apache-2.0",
+      "name": "adler2",
+      "versionInfo": "2.0.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--i686--gnu-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_i686_gnu@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_i686_gnu",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-schannel-0.1.28",
+      "description": "Schannel bindings for rust, allowing SSL/TLS (e.g. https) without openssl",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/schannel@0.1.28",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "schannel",
+      "versionInfo": "0.1.28"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--x86--64--msvc-0.53.1",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_x86_64_msvc@0.53.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_x86_64_msvc",
+      "versionInfo": "0.53.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rustix-1.1.3",
+      "description": "Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rustix@1.1.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "rustix",
+      "versionInfo": "1.1.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-url-2.5.8",
+      "description": "URL library for Rust, based on the WHATWG URL Standard",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/url@2.5.8",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "url",
+      "versionInfo": "2.5.8"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-async-stream-0.3.6",
+      "description": "Asynchronous streams using async & await notation",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/async-stream@0.3.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "async-stream",
+      "versionInfo": "0.3.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zerofrom-derive-0.1.6",
+      "description": "Custom derive for the zerofrom crate",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zerofrom-derive@0.1.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Unicode-3.0",
+      "licenseDeclared": "Unicode-3.0",
+      "name": "zerofrom-derive",
+      "versionInfo": "0.1.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--x86--64--gnu-0.53.1",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_x86_64_gnu@0.53.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_x86_64_gnu",
+      "versionInfo": "0.53.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tar-0.4.44",
+      "description": "A Rust implementation of a TAR file reader and writer. This library does not\ncurrently handle compression, but it is abstract over all I/O readers and\nwriters. Additionally, great lengths are taken to ensure that the entire\ncontents are never required to be entirely resident in memory all at once.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tar@0.4.44",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/alexcrichton/tar-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "tar",
+      "versionInfo": "0.4.44"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--aarch64--gnullvm-0.53.1",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_aarch64_gnullvm@0.53.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_aarch64_gnullvm",
+      "versionInfo": "0.53.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tokio-rustls-0.26.4",
+      "description": "Asynchronous TLS/SSL streams for Tokio using Rustls.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tokio-rustls@0.26.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rustls/tokio-rustls",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "tokio-rustls",
+      "versionInfo": "0.26.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-crossbeam-epoch-0.9.18",
+      "description": "Epoch-based garbage collection",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/crossbeam-epoch@0.9.18",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-epoch",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "crossbeam-epoch",
+      "versionInfo": "0.9.18"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-powerfmt-0.2.0",
+      "description": "    `powerfmt` is a library that provides utilities for formatting values. This crate makes it\n    significantly easier to support filling to a minimum width with alignment, avoid heap\n    allocation, and avoid repetitive calculations.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/powerfmt@0.2.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "powerfmt",
+      "versionInfo": "0.2.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-clap--derive-4.5.47",
+      "description": "Parse command line argument by defining a struct, derive crate.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/clap_derive@4.5.47",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "clap_derive",
+      "versionInfo": "4.5.47"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-anstyle-parse-0.2.7",
+      "description": "Parse ANSI Style Escapes",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/anstyle-parse@0.2.7",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "anstyle-parse",
+      "versionInfo": "0.2.7"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-axum-0.8.8",
+      "description": "Web framework that focuses on ergonomics and modularity",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/axum@0.8.8",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/tokio-rs/axum",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "axum",
+      "versionInfo": "0.8.8"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-heck-0.5.0",
+      "description": "heck is a case conversion library.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/heck@0.5.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "heck",
+      "versionInfo": "0.5.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-serde--json-1.0.149",
+      "description": "A JSON serialization file format",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/serde_json@1.0.149",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "serde_json",
+      "versionInfo": "1.0.149"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-crc32fast-1.5.0",
+      "description": "Fast, SIMD-accelerated CRC32 (IEEE) checksum computation",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/crc32fast@1.5.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "crc32fast",
+      "versionInfo": "1.5.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-anstyle-query-1.1.4",
+      "description": "Look up colored console capabilities",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/anstyle-query@1.1.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "anstyle-query",
+      "versionInfo": "1.1.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--i686--gnullvm-0.53.1",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_i686_gnullvm@0.53.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_i686_gnullvm",
+      "versionInfo": "0.53.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rayon-core-1.13.0",
+      "description": "Core APIs for Rayon",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rayon-core@1.13.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "rayon-core",
+      "versionInfo": "1.13.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-unsafe-libyaml-0.2.11",
+      "description": "libyaml transpiled to rust by c2rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/unsafe-libyaml@0.2.11",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "unsafe-libyaml",
+      "versionInfo": "0.2.11"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--i686--gnullvm-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_i686_gnullvm@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_i686_gnullvm",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-anstyle-wincon-3.0.10",
+      "description": "Styling legacy Windows terminals",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/anstyle-wincon@3.0.10",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "anstyle-wincon",
+      "versionInfo": "3.0.10"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-http-body-util-0.1.3",
+      "description": "Combinators and adapters for HTTP request or response bodies.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/http-body-util@0.1.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "http-body-util",
+      "versionInfo": "0.1.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-flate2-1.1.9",
+      "description": "DEFLATE compression and decompression exposed as Read/BufRead/Write streams.\nSupports miniz_oxide and multiple zlib implementations. Supports zlib, gzip,\nand raw deflate streams.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/flate2@1.1.9",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rust-lang/flate2-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "flate2",
+      "versionInfo": "1.1.9"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-askama--derive-0.15.4",
+      "description": "Code generator of Askama templating engine",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/askama_derive@0.15.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/askama-rs/askama",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "askama_derive",
+      "versionInfo": "0.15.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-icu--collections-2.1.1",
+      "description": "Collection of API for use in ICU libraries.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/icu_collections@2.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://icu4x.unicode.org",
+      "licenseConcluded": "Unicode-3.0",
+      "licenseDeclared": "Unicode-3.0",
+      "name": "icu_collections",
+      "versionInfo": "2.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-openssl-sys-0.9.111",
+      "description": "FFI bindings to OpenSSL",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/openssl-sys@0.9.111",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "openssl-sys",
+      "versionInfo": "0.9.111"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasm-bindgen-futures-0.4.58",
+      "description": "Bridging the gap between Rust Futures and JavaScript Promises",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasm-bindgen-futures@0.4.58",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "wasm-bindgen-futures",
+      "versionInfo": "0.4.58"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zerocopy-derive-0.8.39",
+      "description": "Custom derive for traits from the zerocopy crate",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zerocopy-derive@0.8.39",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "BSD-2-Clause OR Apache-2.0 OR MIT",
+      "licenseDeclared": "BSD-2-Clause OR Apache-2.0 OR MIT",
+      "name": "zerocopy-derive",
+      "versionInfo": "0.8.39"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-iana-time-zone-haiku-0.1.2",
+      "description": "iana-time-zone support crate for Haiku OS",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/iana-time-zone-haiku@0.1.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "iana-time-zone-haiku",
+      "versionInfo": "0.1.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ident--case-1.0.1",
+      "description": "Utility for applying case rules to Rust identifiers.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ident_case@1.0.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "ident_case",
+      "versionInfo": "1.0.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-thiserror-impl-1.0.69",
+      "description": "Implementation detail of the `thiserror` crate",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/thiserror-impl@1.0.69",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "thiserror-impl",
+      "versionInfo": "1.0.69"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-icu--normalizer--data-2.1.1",
+      "description": "Data for the icu_normalizer crate",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/icu_normalizer_data@2.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://icu4x.unicode.org",
+      "licenseConcluded": "Unicode-3.0",
+      "licenseDeclared": "Unicode-3.0",
+      "name": "icu_normalizer_data",
+      "versionInfo": "2.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-synstructure-0.13.2",
+      "description": "Helper methods and macros for custom derives",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/synstructure@0.13.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "synstructure",
+      "versionInfo": "0.13.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-aho-corasick-1.1.4",
+      "description": "Fast multiple substring searching.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/aho-corasick@1.1.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/BurntSushi/aho-corasick",
+      "licenseConcluded": "Unlicense OR MIT",
+      "licenseDeclared": "Unlicense OR MIT",
+      "name": "aho-corasick",
+      "versionInfo": "1.1.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-implement-0.60.2",
+      "description": "The implement macro for the Windows crates",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-implement@0.60.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-implement",
+      "versionInfo": "0.60.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-serde--urlencoded-0.7.1",
+      "description": "`x-www-form-urlencoded` meets Serde",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/serde_urlencoded@0.7.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "serde_urlencoded",
+      "versionInfo": "0.7.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-pin-utils-0.1.0",
+      "description": "Utilities for pinning\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/pin-utils@0.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "pin-utils",
+      "versionInfo": "0.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-darling--macro-0.21.3",
+      "description": "Internal support for a proc-macro library for reading attributes into structs when\nimplementing custom derives. Use https://crates.io/crates/darling in your code.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/darling_macro@0.21.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "darling_macro",
+      "versionInfo": "0.21.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-redox--syscall-0.7.0",
+      "description": "A Rust library to access raw Redox system calls",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/redox_syscall@0.7.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "redox_syscall",
+      "versionInfo": "0.7.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-serde--derive-1.0.228",
+      "description": "Macros 1.1 implementation of #[derive(Serialize, Deserialize)]",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/serde_derive@1.0.228",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://serde.rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "serde_derive",
+      "versionInfo": "1.0.228"
     }
   ],
   "relationships": [
     {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
+      "relatedSpdxElement": "SPDXRef-Package-tokio-macros-2.6.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-openssl-macros-0.1.1"
+      "spdxElementId": "SPDXRef-Package-tokio-1.49.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-jiff-0.2.15",
+      "relatedSpdxElement": "SPDXRef-Package-colorchoice-1.0.4",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-env--logger-0.11.8"
+      "spdxElementId": "SPDXRef-Package-anstream-0.6.21"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
+      "relatedSpdxElement": "SPDXRef-Package-icu--properties-2.1.2",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
+      "spdxElementId": "SPDXRef-Package-icu--normalizer-2.1.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-num-traits-0.2.19",
+      "relatedSpdxElement": "SPDXRef-Package-fs-err-3.3.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-chrono-0.4.42"
+      "spdxElementId": "SPDXRef-Package-axum-server-0.8.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-zerovec-0.11.4",
+      "relatedSpdxElement": "SPDXRef-Package-filetime-0.2.27",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--locale--core-2.0.0"
+      "spdxElementId": "SPDXRef-Package-tar-0.4.44"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.1.3",
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-result-0.3.4"
+      "spdxElementId": "SPDXRef-Package-zerovec-derive-0.11.2"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
+      "relatedSpdxElement": "SPDXRef-Package-openssl-macros-0.1.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-async-compression-0.4.32"
+      "spdxElementId": "SPDXRef-Package-openssl-0.10.75"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-serde--with--macros-3.15.0",
+      "relatedSpdxElement": "SPDXRef-Package-crc32fast-1.5.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--with-3.15.0"
+      "spdxElementId": "SPDXRef-Package-flate2-1.1.9"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
+      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-deranged-0.5.4"
+      "spdxElementId": "SPDXRef-Package-axum-core-0.5.6"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-windows-implement-0.60.2",
@@ -4903,1884 +4676,99 @@
       "spdxElementId": "SPDXRef-Package-windows-core-0.62.2"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-dyn-clone-1.0.20",
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
+      "spdxElementId": "SPDXRef-Package-openssl-0.10.75"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-stable--deref--trait-1.2.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-yoke-0.8.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.81",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-web-sys-0.3.81"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-encoding--rs-0.8.35",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-time-core-0.1.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-time-macros-0.2.24"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-0.5.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.104",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.81",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-chrono-0.4.42"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-mime-0.3.17",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-mime--guess-2.0.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-jsonptr-0.7.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-json-patch-4.1.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-sink-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-atomic-waker-1.1.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-h2-0.4.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-core-0.5.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zerovec-0.11.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--normalizer-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-time-core-0.1.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-time-0.3.44"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-base64-0.22.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--with-3.15.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-ryu-1.0.20",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--yaml-0.9.34-plus-deprecated"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-compression-codecs-0.4.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-async-compression-0.4.32"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-sync--wrapper-1.0.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-axum-server-0.7.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--derive-1.0.228"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-crossbeam-epoch-0.9.18",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-crossbeam-deque-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-derive--arbitrary-1.4.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-arbitrary-1.4.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-heck-0.5.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-clap--derive-4.5.47"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-chrono-0.4.42",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zip-6.0.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wit-bindgen-0.46.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasip2-1.0.1-plus-wasi-0.2.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rustix-1.1.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-sync--wrapper-1.0.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-core-0.5.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tinystr-0.8.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--provider-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-io-uring-0.7.10"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-rustc-hash-2.1.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama--derive-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-env--logger-0.11.8",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-darling--macro-0.21.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-utf8--iter-1.0.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-idna-1.1.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zerovec-0.11.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-potential--utf-0.1.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-num-conv-0.1.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-time-macros-0.2.24"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-potential--utf-0.1.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--properties-2.0.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-idna--adapter-1.2.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-idna-1.1.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-hyper-1.7.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-tls-0.6.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-aho-corasick-1.1.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-regex-automata-0.4.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-hashbrown-0.16.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-indexmap-2.11.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-0.5.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.104",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-chrono-0.4.42"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zerovec-derive-0.11.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerovec-0.11.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-sys-0.61.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-log-0.4.28",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-env--filter-0.1.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-util-0.7.16",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-derive--arbitrary-1.4.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.9.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-result-0.4.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-macros-2.5.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-1.47.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-sink-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-h2-0.4.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-h2-0.4.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--urlencoded-0.7.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-compression-core-0.4.29",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-async-compression-0.4.32"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-darling--core-0.21.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-darling--macro-0.21.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--derive-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama--parser-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasi-0.11.1-plus-wasi-snapshot-preview1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-mio-1.0.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-yoke-derive-0.8.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-yoke-0.8.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-anstyle-parse-0.2.7",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-anstream-0.6.21"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-shared-0.2.104",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.9.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-openssl-0.10.73"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-icu--provider-2.0.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--normalizer-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-darling--core-0.21.3"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-simd-adler32-0.3.7",
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-miniz--oxide-0.8.9"
+      "spdxElementId": "SPDXRef-Package-signal-hook-registry-1.4.8"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-system-configuration-0.6.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bumpalo-3.19.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-backend-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-void-1.0.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-errno-0.3.14"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-getrandom-0.3.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rand--core-0.9.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-signal-hook-registry-1.4.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-1.47.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-anstyle-1.0.13",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-env--logger-0.11.8"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-hyper-1.7.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-hyper-1.7.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-displaydoc-0.2.5",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tinystr-0.8.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-rayon-1.11.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-log-0.4.28",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-form--urlencoded-1.2.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--urlencoded-0.7.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-openssl-sys-0.9.109",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-openssl-0.10.73"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-memchr-2.7.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-interface-0.59.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-getrandom-0.3.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tempfile-3.23.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-openssl-sys-0.9.109",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-yoke-0.8.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-syn-2.0.106"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-macro-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-deranged-0.5.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-time-0.3.44"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-deflate64-0.1.10",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zip-6.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-memchr-2.7.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama--parser-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-synstructure-0.13.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerofrom-derive-0.1.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-memchr-2.7.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-iri-string-0.7.8"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--path--to--error-0.1.20",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-memchr-2.7.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-include--dir--macros-0.7.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows--aarch64--gnullvm-0.52.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-displaydoc-0.2.5",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--collections-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-flate2-1.1.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zip-6.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tempfile-3.23.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-system-configuration-sys-0.6.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerofrom-derive-0.1.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-executor-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--with-3.15.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-chrono-0.4.42"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-core-foundation-sys-0.8.7",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-iana-time-zone-0.1.64"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.11.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--yaml-0.9.34-plus-deprecated"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zerovec-0.11.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--collections-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-memchr-2.7.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-winnow-0.7.13"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-macro-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.9.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-http-1.3.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-urlencoding-2.1.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-targets-0.53.5",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-sys-0.60.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-rustls-0.23.32",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-rustls-0.26.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bumpalo-3.19.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zopfli-0.8.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-axum-0.8.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-datastar-0.3.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-potential--utf-0.1.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--collections-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zerocopy-0.8.27",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-ppv-lite86-0.2.21"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-time-0.3.44"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tracing-core-0.1.34"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-macro-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-1.3.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-http-body-1.0.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-channel-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-atomic-waker-1.1.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-1.7.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.145",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-datastar-0.3.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-ipnet-2.11.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.1.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-strings-0.4.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-http-body-1.0.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--normalizer-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.104",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-futures-0.4.54"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-lock--api-0.4.14",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-parking--lot-0.12.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-core-0.5.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.9.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-security-framework-2.11.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-futures-0.4.54"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-semver-1.0.27",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows--i686--gnu-0.52.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-core-foundation-sys-0.8.7",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-security-framework-sys-2.15.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-core-foundation-sys-0.8.7",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-security-framework-2.11.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tower-layer-0.3.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-0.5.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-http-body-util-0.1.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-crossbeam-utils-0.8.21",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-crossbeam-deque-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.15",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--path--to--error-0.1.20"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-yoke-0.8.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--collections-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.15",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-1.7.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-web-sys-0.3.81",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zerofrom-0.1.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--collections-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-sink-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-channel-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-system-configuration-sys-0.6.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-system-configuration-0.6.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-hyper-1.7.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.15",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--urlencoded-0.7.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-io-uring-0.7.10"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-interface-0.59.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-core-0.62.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.11.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--with-3.15.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-hyper-util-0.1.17",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-errno-0.3.14",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rustix-1.1.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-mime-0.3.17",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-hex-0.4.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--with-3.15.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-chrono-0.4.42",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--with-3.15.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-clap--derive-4.5.47",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-clap-4.5.48"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-num-conv-0.1.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-time-0.3.44"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-rustls-pki-types-1.12.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-unsafe-libyaml-0.2.11",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--yaml-0.9.34-plus-deprecated"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-chrono-0.4.42",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zip-6.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-1.7.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-0.5.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-basic-toml-0.1.10"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-core-0.62.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-iana-time-zone-0.1.64"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-native-tls-0.2.14",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-quote-1.0.41"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zeroize-1.8.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rustls-0.23.32"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-getrandom-0.2.16"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-security-framework-2.11.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-percent-encoding-2.3.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-url-2.5.7"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-either-1.15.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rayon-1.11.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-httpdate-1.0.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-1.7.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-idna-1.1.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-1.7.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-yoke-derive-0.8.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-regex-1.12.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tower-http-0.6.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-1.47.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-backend-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tracing-core-0.1.34",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tracing-0.1.41"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-hyper-util-0.1.17",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-1.3.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-ref-cast-impl-1.0.25"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zlib-rs-0.5.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-libz-rs-sys-0.5.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-schannel-0.1.28"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-icu--properties-2.0.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--normalizer-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-icu--locale--core-2.0.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--properties-2.0.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-core-foundation-0.9.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zerovec-0.11.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--properties-2.0.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-1.3.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-server-0.7.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-encoding--rs-0.8.35",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows--x86--64--gnu-0.53.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.104",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-yoke-0.8.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerovec-0.11.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.15",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--yaml-0.9.34-plus-deprecated"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tracing-0.1.41"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-File-esdiag",
-      "relationshipType": "DESCRIBES",
-      "spdxElementId": "SPDXRef-DOCUMENT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-chrono-0.4.42",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-datastar-0.3.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-core-0.5.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-shared-0.2.104",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-backend-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-synstructure-0.13.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-thiserror-impl-1.0.69",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-thiserror-1.0.69"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-crc32fast-1.5.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-flate2-1.1.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.59.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-socket2-0.6.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-util-0.7.16",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-h2-0.4.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-1.7.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-h2-0.4.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.11.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-h2-0.4.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-rustls-0.26.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-linux-raw-sys-0.11.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rustix-1.1.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zerotrie-0.2.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--properties-2.0.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.104",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-web-sys-0.3.81"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-thiserror-impl-1.0.69"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-object-0.37.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-backtrace-0.3.76"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-ring-0.17.14"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-foreign-types-shared-0.1.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-foreign-types-0.3.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-log-0.4.28",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-env--logger-0.11.8"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-log-0.4.28",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zopfli-0.8.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tower-layer-0.3.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-core-0.5.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-iana-time-zone-haiku-0.1.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-iana-time-zone-0.1.64"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-mio-1.0.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-memchr-2.7.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama--derive-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-clap--derive-4.5.47"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.145",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-json-patch-4.1.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-iri-string-0.7.8"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-lazy--static-1.5.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-anstyle-wincon-3.0.10",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-anstream-0.6.21"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-icu--normalizer-2.0.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-idna--adapter-1.2.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-futures-0.4.54",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-indexmap-2.11.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-pin-utils-0.1.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-pin-utils-0.1.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-1.7.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-macros-2.5.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-mime-0.3.17",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-macro-0.2.104",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-log-0.4.28",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-openssl-macros-0.1.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-openssl-0.10.73"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-http-body-util-0.1.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.15",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--path--to--error-0.1.20"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-security-framework-sys-2.15.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-ref-cast-1.0.25",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-schemars-0.9.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.145",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-jsonptr-0.7.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerocopy-derive-0.8.27"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-server-0.7.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-jiff-0.2.15"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--json-1.0.145"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-channel-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-include--dir-0.7.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-rustls-pki-types-1.12.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasi-0.11.1-plus-wasi-snapshot-preview1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-getrandom-0.2.16"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-json-patch-4.1.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-adler2-2.0.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-miniz--oxide-0.8.9"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-darling--core-0.21.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-log-0.4.28",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tracing-0.1.41"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-1.3.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.145",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-targets-0.52.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-sys-0.52.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-datastar-0.3.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-axum-macros-0.5.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-http-body-util-0.1.3",
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
+      "spdxElementId": "SPDXRef-Package-zerocopy-derive-0.8.39"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-backend-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-hyper-rustls-0.27.7",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-displaydoc-0.2.5",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--provider-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-memchr-2.7.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-regex-1.12.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-uuid-1.18.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-jiff-static-0.2.15"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-r-efi-5.3.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-getrandom-0.3.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-executor-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-interface-0.59.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-spin-0.9.8",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.15",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-time-0.3.44"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-util-0.7.16"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.9.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-http-0.6.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-httparse-1.10.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-askama-0.14.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.60.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-anstyle-wincon-3.0.10"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-crossbeam-utils-0.8.21",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rayon-core-1.13.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-ref-cast-1.0.25",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-schemars-1.0.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-web-sys-0.3.81",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-futures-0.4.54"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-fnv-1.0.7",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-h2-0.4.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-clap-4.5.48",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows--x86--64--gnullvm-0.52.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-ring-0.17.14"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-icu--properties-2.0.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-idna--adapter-1.2.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-1.7.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-flate2-1.1.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-http-0.6.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-thiserror-impl-1.0.69"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.145",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-darling--macro-0.21.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-darling-0.21.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-regex-automata-0.4.12",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-regex-1.12.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--urlencoded-0.7.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rustix-1.1.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-hyper-1.7.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-server-0.7.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.9.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-io-uring-0.7.10"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-askama--parser-0.14.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama--derive-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-registry-0.5.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zerovec-0.11.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--provider-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-iana-time-zone-0.1.64",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-chrono-0.4.42"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-executor-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-rand--core-0.9.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rand-0.9.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT",
-      "relationshipType": "GENERATED_FROM",
-      "spdxElementId": "SPDXRef-File-esdiag"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libz-rs-sys-0.5.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-flate2-1.1.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-strings-0.4.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-registry-0.5.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-icu--provider-2.0.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--properties-2.0.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--derive-1.0.228"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-unicode-ident-1.0.19",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-proc-macro2-1.0.101"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-percent-encoding-2.3.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-form--urlencoded-1.2.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-backend-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-channel-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-1.7.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-form--urlencoded-1.2.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-url-2.5.7"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.1.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-registry-0.5.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-implement-0.60.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-synstructure-0.13.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-yoke-derive-0.8.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.145",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--with-3.15.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-1.3.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-http-body-util-0.1.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-security-framework-sys-2.15.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-server-0.7.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-powerfmt-0.2.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-time-0.3.44"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-jsonptr-0.7.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-hyper-1.7.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-anstyle-1.0.13",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-anstream-0.6.21"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-native-tls-0.3.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-log-0.4.28",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-backend-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama--derive-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama--derive-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.59.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-1.47.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-core-foundation-0.9.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-system-configuration-0.6.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-log-0.4.28",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-iana-time-zone-0.1.64"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-rand--core-0.9.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rand--chacha-0.9.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerocopy-derive-0.8.27"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerovec-derive-0.11.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-signal-hook-registry-1.4.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-body-util-0.1.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-derive--arbitrary-1.4.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-stable--deref--trait-1.2.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--provider-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-async-stream-0.3.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-indexmap-2.11.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-displaydoc-0.2.5",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerotrie-0.2.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
+      "relatedSpdxElement": "SPDXRef-Package-hyper-1.8.1",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-hyper-tls-0.6.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-try-lock-0.2.5",
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-want-0.3.1"
+      "spdxElementId": "SPDXRef-Package-clap--derive-4.5.47"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-openssl-0.10.73",
+      "relatedSpdxElement": "SPDXRef-Package-icu--provider-2.1.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
+      "spdxElementId": "SPDXRef-Package-icu--normalizer-2.1.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-time-0.3.44",
+      "relatedSpdxElement": "SPDXRef-Package-redox--syscall-0.7.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--with-3.15.0"
+      "spdxElementId": "SPDXRef-Package-libredox-0.1.12"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-futures-io-0.3.31",
+      "relatedSpdxElement": "SPDXRef-Package-hyper-util-0.1.20",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
+      "spdxElementId": "SPDXRef-Package-hyper-tls-0.6.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-sync--wrapper-1.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.17",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-0.5.2"
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.9.4",
+      "relatedSpdxElement": "SPDXRef-Package-rustls-pki-types-1.14.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rustix-1.1.2"
+      "spdxElementId": "SPDXRef-Package-rustls-0.23.36"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iana-time-zone-haiku-0.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iana-time-zone-0.1.65"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicase-2.9.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-mime--guess-2.0.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-url-2.5.8",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-askama--macros-0.15.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-askama-0.15.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-h2-0.4.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-ident-1.0.22",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-proc-macro2-1.0.106"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-parking--lot-0.12.5",
@@ -6788,149 +4776,129 @@
       "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-windows--x86--64--gnullvm-0.53.1",
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.3",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
+      "spdxElementId": "SPDXRef-Package-js-sys-0.3.85"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-core-foundation-sys-0.8.7",
+      "relatedSpdxElement": "SPDXRef-Package-simd-adler32-0.3.8",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-core-foundation-0.9.4"
+      "spdxElementId": "SPDXRef-Package-miniz--oxide-0.8.9"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-iri-string-0.7.8",
+      "relatedSpdxElement": "SPDXRef-Package-rustls-0.23.36",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-http-0.6.6"
+      "spdxElementId": "SPDXRef-Package-tokio-rustls-0.26.4"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-windows--i686--gnullvm-0.53.1",
+      "relatedSpdxElement": "SPDXRef-Package-iana-time-zone-0.1.65",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
+      "spdxElementId": "SPDXRef-Package-chrono-0.4.43"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
+      "relatedSpdxElement": "SPDXRef-Package-hyper-util-0.1.20",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-1.7.0"
+      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-basic-toml-0.1.10",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama--derive-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-core-0.5.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-result-0.3.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-registry-0.5.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-async-stream-impl-0.3.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-util-0.7.16"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-async-compression-0.4.32"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows--i686--msvc-0.52.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-native-tls-0.2.14",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-native-tls-0.3.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zerotrie-0.2.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--provider-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-android--system--properties-0.1.5",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-iana-time-zone-0.1.64"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-yoke-0.8.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--provider-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.3",
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-futures-0.4.54"
+      "spdxElementId": "SPDXRef-Package-async-compression-0.4.39"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relatedSpdxElement": "SPDXRef-Package-compression-codecs-0.4.36",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-indexmap-1.9.3"
+      "spdxElementId": "SPDXRef-Package-async-compression-0.4.39"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-shared-0.2.104",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-slab-0.4.11",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-1.47.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-displaydoc-0.2.5"
     },
     {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.10.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-http-0.6.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerovec-0.11.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-potential--utf-0.1.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-synstructure-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-yoke-derive-0.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-displaydoc-0.2.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--provider-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-askama--derive-0.15.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--derive-1.0.228"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ref-cast-1.0.25",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-schemars-1.2.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-darling--macro-0.21.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-channel-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerocopy-derive-0.8.39"
+    },
+    {
       "relatedSpdxElement": "SPDXRef-Package-httparse-1.10.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-1.7.0"
+      "spdxElementId": "SPDXRef-Package-hyper-1.8.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-memchr-2.7.6",
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-object-0.37.3"
+      "spdxElementId": "SPDXRef-Package-serde--with--macros-3.16.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-dyn-clone-1.0.20",
+      "relatedSpdxElement": "SPDXRef-Package-time-core-0.1.8",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-schemars-0.9.0"
+      "spdxElementId": "SPDXRef-Package-time-0.3.47"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-windows--x86--64--gnu-0.52.6",
+      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.17",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
+      "spdxElementId": "SPDXRef-Package-serde--yaml-0.9.34-plus-deprecated"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.9.4",
+      "relatedSpdxElement": "SPDXRef-Package-getrandom-0.3.4",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-system-configuration-0.6.1"
+      "spdxElementId": "SPDXRef-Package-rand--core-0.9.5"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.41",
+      "relatedSpdxElement": "SPDXRef-Package-tower-0.5.3",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-0.5.2"
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-windows--x86--64--msvc-0.53.1",
@@ -6938,9 +4906,114 @@
       "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-foreign-types-0.3.2",
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-openssl-0.10.73"
+      "spdxElementId": "SPDXRef-Package-async-compression-0.4.39"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-android--system--properties-0.1.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iana-time-zone-0.1.65"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tower-0.5.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-http-0.6.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-util-0.7.18",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-http-0.6.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--with-3.16.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerocopy-0.8.39",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ppv-lite86-0.2.21"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-result-0.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-registry-0.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hyper-util-0.1.20",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-tls-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-openssl-0.10.75",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.10.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-openssl-0.10.75"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-idna-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-url-2.5.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-yoke-0.8.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerotrie-0.2.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-core-0.5.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.108",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-web-sys-0.3.85"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-percent-encoding-2.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-form--urlencoded-1.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-clap--derive-4.5.47",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-clap-4.5.48"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--derive-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-url-2.5.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--x86--64--msvc-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-File-esdiag",
+      "relationshipType": "DESCRIBES",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-askama-0.15.4"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-anstyle-1.0.13",
@@ -6948,249 +5021,279 @@
       "spdxElementId": "SPDXRef-Package-anstyle-wincon-3.0.10"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-regex-1.12.1",
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-env--filter-0.1.3"
+      "spdxElementId": "SPDXRef-Package-iri-string-0.7.10"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-memchr-2.7.6",
+      "relatedSpdxElement": "SPDXRef-Package-aho-corasick-1.1.4",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-compression-codecs-0.4.31"
+      "spdxElementId": "SPDXRef-Package-regex-1.12.3"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-time-0.3.44",
+      "relatedSpdxElement": "SPDXRef-Package-windows--x86--64--gnullvm-0.52.6",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zip-6.0.0"
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-hyper-util-0.1.17",
+      "relatedSpdxElement": "SPDXRef-Package-windows--x86--64--gnu-0.52.6",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-tls-0.6.0"
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-regex-syntax-0.8.7",
+      "relatedSpdxElement": "SPDXRef-Package-hashbrown-0.16.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-regex-automata-0.4.12"
+      "spdxElementId": "SPDXRef-Package-indexmap-2.13.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-slab-0.4.11",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-h2-0.4.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-indenter-0.3.4",
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.3",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-eyre-0.6.12"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-serde--derive-1.0.228",
+      "relatedSpdxElement": "SPDXRef-Package-futures-task-0.3.31",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--core-1.0.228"
+      "spdxElementId": "SPDXRef-Package-futures-executor-0.3.31"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-openssl-sys-0.9.109"
+      "spdxElementId": "SPDXRef-Package-askama--derive-0.15.4"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-zerovec-0.11.4",
+      "relatedSpdxElement": "SPDXRef-Package-serde--urlencoded-0.7.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tinystr-0.8.1"
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-addr2line-0.25.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-backtrace-0.3.76"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-crossbeam-deque-0.8.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rayon-core-1.13.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-h2-0.4.12",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-1.7.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-io-uring-0.7.10",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-1.47.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-backend-0.2.104",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.81",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-1.3.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-core-0.62.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zeroize-1.8.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rustls-pki-types-1.12.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-axum-0.8.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-async-stream-impl-0.3.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-async-stream-impl-0.3.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-rustls-webpki-0.103.7",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rustls-0.23.32"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-ref-cast-impl-1.0.25"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-unicode-ident-1.0.19",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-shared-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-log-0.4.28",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-synstructure-0.13.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerofrom-derive-0.1.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-schemars-1.0.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows--i686--gnu-0.53.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-darling-0.21.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--with--macros-3.15.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-log-0.4.28",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-jiff-0.2.15"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.11.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zip-6.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasip2-1.0.1-plus-wasi-0.2.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasi-0.14.7-plus-wasi-0.2.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-derive--arbitrary-1.4.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-url-2.5.7",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.104",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-uuid-1.18.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.9.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-url-2.5.7",
+      "relatedSpdxElement": "SPDXRef-Package-percent-encoding-2.3.2",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.145",
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iana-time-zone-0.1.65"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-strsim-0.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-clap--builder-4.5.48"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wit-bindgen-0.51.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasip2-1.0.2-plus-wasi-0.2.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tokio-macros-2.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-core-0.5.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-compression-core-0.4.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-compression-0.4.39"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-sync--wrapper-1.0.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-0.5.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-1.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-datastar-0.3.1",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.52.0",
+      "relatedSpdxElement": "SPDXRef-Package-core-foundation-sys-0.8.7",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-ring-0.17.14"
+      "spdxElementId": "SPDXRef-Package-iana-time-zone-0.1.65"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-http-1.3.1",
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-h2-0.4.12"
+      "spdxElementId": "SPDXRef-Package-tokio-1.49.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-ref-cast-impl-1.0.25",
+      "relatedSpdxElement": "SPDXRef-Package-reqwest-0.12.28",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-ref-cast-1.0.25"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-writeable-0.6.1",
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--locale--core-2.0.0"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
+      "relatedSpdxElement": "SPDXRef-Package-lazy--static-1.5.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-include--dir--macros-0.7.4"
+      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-zerofrom-0.1.6",
+      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerovec-0.11.4"
+      "spdxElementId": "SPDXRef-Package-axum-server-0.8.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-displaydoc-0.2.5",
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--locale--core-2.0.0"
+      "spdxElementId": "SPDXRef-Package-tower-http-0.6.8"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
+      "relatedSpdxElement": "SPDXRef-Package-errno-0.3.14",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-server-0.7.2"
+      "spdxElementId": "SPDXRef-Package-rustix-1.1.3"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
+      "relatedSpdxElement": "SPDXRef-Package-httparse-1.10.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-0.5.2"
+      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerovec-derive-0.11.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tar-0.4.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jsonptr-0.7.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-targets-0.53.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-sys-0.60.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-thiserror-impl-1.0.69"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tracing-0.1.44"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--path--to--error-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-litemap-0.8.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--locale--core-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.10.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-libredox-0.1.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.85",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-uuid-1.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zip-8.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-core-foundation-sys-0.8.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-security-framework-sys-2.15.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-ident-1.0.22",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-askama--parser-0.15.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ryu-1.0.22",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--urlencoded-0.7.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-h2-0.4.13",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-darling--core-0.21.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-darling-0.21.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--json-1.0.149"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-http-body-util-0.1.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-executor-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ppv-lite86-0.2.21",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rand--chacha-0.9.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-errno-0.3.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jiff-static-0.2.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-subtle-2.6.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustls-0.23.36"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-is--terminal--polyfill-1.70.1",
@@ -7198,29 +5301,1709 @@
       "spdxElementId": "SPDXRef-Package-anstream-0.6.21"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
+      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-syn-2.0.106"
+      "spdxElementId": "SPDXRef-Package-hyper-1.8.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-h2-0.4.12"
+      "spdxElementId": "SPDXRef-Package-hyper-1.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-1.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hyper-1.8.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-openssl-sys-0.9.111",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-openssl-0.10.75"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tower-layer-0.3.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-http-0.6.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-1.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-utf8--iter-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-idna-1.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-task-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-schannel-0.1.28",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iri-string-0.7.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-http-0.6.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.108"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-flate2-1.1.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zip-8.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-uuid-1.20.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.9.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--with--macros-3.16.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--with-3.16.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-web-sys-0.3.85",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-futures-0.4.58"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-executor-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-icu--provider-2.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--properties-2.1.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-filetime-0.2.27"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hyper-1.8.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-percent-encoding-2.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-miniz--oxide-0.8.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-flate2-1.1.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-http-body-util-0.1.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-mime-0.3.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-libredox-0.1.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-http-body-1.0.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-server-0.8.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-core-0.5.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-clap-4.5.48",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tokio-util-0.7.18"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-sync--wrapper-1.0.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-num-conv-0.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-time-0.3.47"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-body-util-0.1.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-http-0.6.8"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.3",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-0.2.104"
+      "spdxElementId": "SPDXRef-Package-tracing-core-0.1.36"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
+      "relatedSpdxElement": "SPDXRef-Package-crossbeam-epoch-0.9.18",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
+      "spdxElementId": "SPDXRef-Package-crossbeam-deque-0.8.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-implement-0.60.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tokio-util-0.7.18"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-chrono-0.4.43"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-openssl-sys-0.9.111"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-socket2-0.6.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rayon-1.11.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tokio-native-tls-0.3.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-adler2-2.0.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-miniz--oxide-0.8.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-thiserror-impl-1.0.69"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-security-framework-sys-2.15.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-json-patch-4.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rand--core-0.9.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rand-0.9.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-regex-1.12.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tokio-1.49.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-implement-0.60.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hyper-rustls-0.27.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-heck-0.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-clap--derive-4.5.47"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-try-lock-0.2.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-want-0.3.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-core-0.62.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iana-time-zone-0.1.65"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.108",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-0.2.108"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasi-0.11.1-plus-wasi-snapshot-preview1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.2.17"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-yoke-derive-0.8.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-yoke-0.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerofrom-0.1.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerotrie-0.2.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-h2-0.4.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.3.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-time-0.3.47"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zeroize-1.8.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustls-0.23.36"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-openssl-0.10.75"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-sys-0.61.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--json-1.0.149"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-core-foundation-sys-0.8.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-core-foundation-0.9.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-tls-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-writeable-0.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--provider-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ref-cast-1.0.25",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-schemars-0.9.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-web-sys-0.3.85",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-semver-1.0.27"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasi-0.11.1-plus-wasi-snapshot-preview1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-mio-1.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-regex-automata-0.4.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-darling-0.21.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--with--macros-3.16.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-base64-0.22.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-slab-0.4.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustls-0.23.36"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-time-macros-0.2.27",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-time-0.3.47"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-sink-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-portable-atomic-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-portable-atomic-util-0.2.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-stream-0.3.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-redox--syscall-0.5.18",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.9.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-icu--locale--core-2.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--provider-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-darling--core-0.21.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-darling--macro-0.21.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-flate2-1.1.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerovec-0.11.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--properties-2.1.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--path--to--error-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-want-0.3.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-1.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-openssl-probe-0.1.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-openssl-macros-0.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-schannel-0.1.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ref-cast-impl-1.0.25"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-time-0.3.47"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-shared-0.2.108",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.108"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-portable-atomic-util-0.2.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jiff-0.2.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-interface-0.59.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-core-0.62.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hyper-1.8.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-server-0.8.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-indexmap-1.9.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-indexmap-2.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-foreign-types-0.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-openssl-0.10.75"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-semver-1.0.27",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-icu--normalizer-2.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-idna--adapter-1.2.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-util-0.7.18",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-h2-0.4.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-r-efi-5.3.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.3.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-urlencoding-2.1.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerovec-0.11.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--collections-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerofrom-derive-0.1.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-chrono-0.4.43",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--with-3.16.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-macros-0.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-io-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-server-0.8.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-fs-err-3.3.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-http-body-util-0.1.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-registry-0.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-0.5.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.149",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-schemars-1.2.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-signal-hook-registry-1.4.8",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tokio-1.49.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-http-0.6.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-encoding--rs-0.8.35"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-regex-syntax-0.8.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-regex-1.12.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-atomic-waker-1.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-h2-0.4.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-anstyle-1.0.13",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-clap--builder-4.5.48"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-linux-raw-sys-0.11.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustix-1.1.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-sync--wrapper-1.0.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-core-0.5.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-channel-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tempfile-3.24.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-schemars-0.9.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--with-3.16.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-core-0.62.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustc-hash-2.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-askama--derive-0.15.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-0.2.108"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ring-0.17.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustls-webpki-0.103.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-synstructure-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winnow-0.7.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-askama--parser-0.15.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-base64-0.22.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-typed-path-0.12.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zip-8.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-0.5.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.108",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-futures-0.4.58"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-httpdate-1.0.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-1.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-json-patch-4.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-ident-1.0.22",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-syn-2.0.114"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasip2-1.0.2-plus-wasi-0.2.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.3.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-icu--properties--data-2.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--properties-2.1.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.2.17"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.149",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-askama-0.15.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--urlencoded-0.7.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-either-1.15.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-server-0.8.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-flate2-1.1.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-compression-codecs-0.4.36"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--yaml-0.9.34-plus-deprecated",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-interface-0.59.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-datastar-0.3.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-http-0.6.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerofrom-0.1.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-yoke-0.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-writeable-0.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--locale--core-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-core-foundation-sys-0.8.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-security-framework-2.11.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rayon-core-1.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rayon-1.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.108"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-idna--adapter-1.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-idna-1.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--path--to--error-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ryu-1.0.22",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--yaml-0.9.34-plus-deprecated"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-interface-0.59.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-registry-0.6.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--with--macros-3.16.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tokio-util-0.7.18"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-executor-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell--polyfill-1.70.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-anstyle-wincon-3.0.10"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerocopy-derive-0.8.39"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.108",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-sync--wrapper-1.0.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-icu--locale--core-2.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--properties-2.1.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--i686--gnu-0.53.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zip-8.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.9.12"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-windows-strings-0.5.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-core-0.62.2"
+      "spdxElementId": "SPDXRef-Package-windows-registry-0.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.10.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustix-1.1.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-http-0.6.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-stable--deref--trait-1.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-yoke-0.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-thiserror-impl-1.0.69"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-potential--utf-0.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--collections-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-dyn-clone-1.0.20",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-schemars-1.2.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-dyn-clone-1.0.20",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-schemars-0.9.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ring-0.17.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-idna-1.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tempfile-3.24.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-body-util-0.1.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-tls-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerofrom-derive-0.1.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.85",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-web-sys-0.3.85"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-0.5.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-system-configuration-0.7.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hyper-util-0.1.20",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-semver-1.0.27"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-android--system--properties-0.1.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustls-pki-types-1.14.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-tls-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.10.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-security-framework-2.11.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--aarch64--msvc-0.53.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-http-body-util-0.1.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-security-framework-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tower-layer-0.3.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-core-0.5.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde-1.0.228"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--i686--gnullvm-0.53.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-1.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-h2-0.4.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-io-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-0.2.108"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--derive-1.0.228"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-anstyle-parse-0.2.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-anstream-0.6.21"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-1.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-core-0.5.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-encoding--rs-0.8.35",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-yoke-derive-0.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-axum-macros-0.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-crossbeam-utils-0.8.21",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rayon-core-1.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-security-framework-2.11.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerocopy-derive-0.8.39",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerocopy-0.8.39"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-http-0.6.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-task-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-askama--derive-0.15.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-futures-0.4.58",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerovec-derive-0.11.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-multer-3.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-yoke-derive-0.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-channel-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-1.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--i686--gnu-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-yoke-derive-0.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-time-0.3.47",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--with-3.16.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-stream-impl-0.3.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-stream-impl-0.3.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-getrandom-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ring-0.17.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hashbrown-0.12.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-indexmap-1.9.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-anstyle-1.0.13",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-anstream-0.6.21"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.60.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-socket2-0.6.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-clap--derive-4.5.47"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-0.5.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-security-framework-sys-2.15.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-security-framework-2.11.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-jiff-0.2.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-env--logger-0.11.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-security-framework-sys-2.15.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-aho-corasick-1.1.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-openssl-sys-0.9.111",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-deranged-0.5.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-time-0.3.47"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-openssl-macros-0.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-askama--parser-0.15.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-askama--derive-0.15.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-chrono-0.4.43"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--with-3.16.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-result-0.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--aarch64--gnullvm-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-mime--guess-2.0.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iri-string-0.7.10"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-sync--wrapper-1.0.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-errno-0.3.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-signal-hook-registry-1.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zmij-1.0.19",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--json-1.0.149"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tracing-0.1.44"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-utils-0.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-form--urlencoded-1.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--urlencoded-0.7.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--json-1.0.149"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--with-3.16.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-lock--api-0.4.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot-0.12.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zeroize-1.8.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustls-pki-types-1.14.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-schemars-0.9.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-0.2.108"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-portable-atomic-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jiff-0.2.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.149",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--with-3.16.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tokio-util-0.7.18"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-clap--builder-4.5.48",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-clap-4.5.48"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-implement-0.60.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-channel-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.149",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rand-0.9.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-uuid-1.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-schemars-1.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--with-3.16.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-h2-0.4.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-askama--derive-0.15.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-askama-0.15.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.149",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-time-core-0.1.8",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-time-macros-0.2.27"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-chrono-0.4.43",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jiff-0.2.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-targets-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-sys-0.52.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.149",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-num-conv-0.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-time-macros-0.2.27"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-env--logger-0.11.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-void-1.0.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-mime-0.3.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-powerfmt-0.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-deranged-0.5.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zip-8.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerovec-0.11.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--provider-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-darling--macro-0.21.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libredox-0.1.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-filetime-0.2.27"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-rustls-0.26.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-synstructure-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-base64-0.22.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerovec-0.11.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--normalizer-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-mio-1.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tokio-1.49.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tempfile-3.24.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-1.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-http-0.6.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tar-0.4.44"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-syn-2.0.114"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-strsim-0.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-darling--core-0.21.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-icu--collections-2.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--properties-2.1.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-form--urlencoded-1.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--urlencoded-0.7.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-native-tls-0.2.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--yaml-0.9.34-plus-deprecated"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-sink-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-1.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hex-0.4.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--with-3.16.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-displaydoc-0.2.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--locale--core-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-compression-codecs-0.4.36"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-darling--core-0.21.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-mime-0.3.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--aarch64--msvc-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--yaml-0.9.34-plus-deprecated"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerofrom-derive-0.1.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustls-pki-types-1.14.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustls-webpki-0.103.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-jiff-static-0.2.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jiff-0.2.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-stream-impl-0.3.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-stream-0.3.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--i686--msvc-0.53.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-anstream-0.6.21",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-clap--builder-4.5.48"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-percent-encoding-2.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-anstyle-query-1.1.4",
@@ -7228,57 +7011,197 @@
       "spdxElementId": "SPDXRef-Package-anstream-0.6.21"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
+      "relatedSpdxElement": "SPDXRef-Package-tinystr-0.8.2",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-http-0.6.6"
+      "spdxElementId": "SPDXRef-Package-icu--locale--core-2.1.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
+      "relatedSpdxElement": "SPDXRef-Package-atomic-waker-1.1.2",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
+      "spdxElementId": "SPDXRef-Package-hyper-1.8.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.3",
+      "relatedSpdxElement": "SPDXRef-Package-serde--derive-1.0.228",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-openssl-0.10.73"
+      "spdxElementId": "SPDXRef-Package-serde--core-1.0.228"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ipnet-2.11.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.9.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.108",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-js-sys-0.3.85"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bumpalo-3.19.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.108"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.9.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-core-0.5.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-1.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-base64-0.22.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-1.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-sink-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-channel-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-mio-1.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-0.5.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-1.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-server-0.8.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-quote-1.0.44"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerofrom-0.1.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--collections-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-displaydoc-0.2.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--collections-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.149",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-schemars-0.9.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jiff-static-0.2.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rand--core-0.9.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rand--chacha-0.9.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--i686--msvc-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-macros-0.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerovec-0.11.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--locale--core-2.1.1"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-http-0.6.6"
+      "spdxElementId": "SPDXRef-Package-tokio-1.49.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-icu--locale--core-2.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--provider-2.0.0"
+      "spdxElementId": "SPDXRef-Package-clap--derive-4.5.47"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-yoke-0.8.0",
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.3",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerotrie-0.2.2"
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-futures-0.4.58"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-schemars-1.0.4",
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--with-3.15.0"
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-dyn-clone-1.0.20",
+      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.17",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-schemars-1.0.4"
+      "spdxElementId": "SPDXRef-Package-serde--json-1.0.149"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-futures-channel-0.3.31",
+      "relatedSpdxElement": "SPDXRef-Package-url-2.5.8",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tokio-macros-2.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-1.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-chrono-0.4.43",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-datastar-0.3.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ring-0.17.14"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-percent-encoding-2.3.2",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama-0.14.0"
+      "spdxElementId": "SPDXRef-Package-url-2.5.8"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-ident--case-1.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-fnv-1.0.7",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-darling--core-0.21.3"
     },
@@ -7288,349 +7211,64 @@
       "spdxElementId": "SPDXRef-Package-env--logger-0.11.8"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-rustc-demangle-0.1.26",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-backtrace-0.3.76"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-1.3.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
       "relatedSpdxElement": "SPDXRef-Package-futures-sink-0.3.31",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-util-0.7.16"
+      "spdxElementId": "SPDXRef-Package-tokio-util-0.7.18"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-util-0.7.16"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-miniz--oxide-0.8.9",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-backtrace-0.3.76"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-android--system--properties-0.1.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.145",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-async-compression-0.4.32",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-openssl-0.10.73"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerovec-derive-0.11.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-ppv-lite86-0.2.21",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rand--chacha-0.9.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-simd-adler32-0.3.7",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zopfli-0.8.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-fs-err-3.1.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-server-0.7.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-yoke-derive-0.8.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-reqwest-0.12.23",
+      "relatedSpdxElement": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-fnv-1.0.7",
+      "relatedSpdxElement": "SPDXRef-Package-regex-automata-0.4.14",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-http-1.3.1"
+      "spdxElementId": "SPDXRef-Package-regex-1.12.3"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
+      "relatedSpdxElement": "SPDXRef-Package-foreign-types-shared-0.1.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+      "spdxElementId": "SPDXRef-Package-foreign-types-0.3.2"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
+      "relatedSpdxElement": "SPDXRef-Package-askama--derive-0.15.4",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.104"
+      "spdxElementId": "SPDXRef-Package-askama--macros-0.15.4"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-multer-3.1.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-macros-0.5.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-socket2-0.6.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-rustls-0.23.32",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-rustls-pki-types-1.12.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rustls-0.23.32"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows--x86--64--msvc-0.52.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zerofrom-0.1.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerotrie-0.2.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--with--macros-3.15.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-memchr-2.7.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-thiserror-impl-1.0.69"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-synstructure-0.13.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-getrandom-0.2.16"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zerofrom-derive-0.1.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerofrom-0.1.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-rand--chacha-0.9.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rand-0.9.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--with--macros-3.15.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tower-layer-0.3.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.81",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-uuid-1.18.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.15",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-1.47.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-fnv-1.0.7",
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-darling--core-0.21.3"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relatedSpdxElement": "SPDXRef-Package-env--logger-0.11.8",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-chrono-0.4.42"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-implement-0.60.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-native-tls-0.3.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-macros-2.5.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-miniz--oxide-0.8.9",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-flate2-1.1.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-io-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-security-framework-2.11.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-schemars-0.9.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--with-3.15.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-http-body-util-0.1.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-backtrace-0.3.76"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-security-framework-sys-2.15.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-security-framework-2.11.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-semver-1.0.27"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerocopy-derive-0.8.27"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-backtrace-0.3.76"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-semver-1.0.27"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-0.5.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-crossbeam-utils-0.8.21",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-crossbeam-epoch-0.9.18"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rustls-0.23.32"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-time-macros-0.2.24",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-time-0.3.44"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-getrandom-0.3.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--urlencoded-0.7.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-memchr-2.7.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--json-1.0.145"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-macro-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-crc32fast-1.5.0"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
+      "spdxElementId": "SPDXRef-Package-async-stream-0.3.6"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-shared-0.2.108",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-tls-0.6.0"
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-0.2.108"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-http-1.3.1",
+      "relatedSpdxElement": "SPDXRef-Package-icu--properties-2.1.2",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-http-0.6.6"
+      "spdxElementId": "SPDXRef-Package-idna--adapter-1.2.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-jiff-static-0.2.15",
+      "relatedSpdxElement": "SPDXRef-Package-rustls-0.23.36",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-jiff-0.2.15"
+      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-http-body-util-0.1.3",
+      "relatedSpdxElement": "SPDXRef-Package-system-configuration-sys-0.6.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-core-0.5.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-ryu-1.0.20",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--json-1.0.145"
+      "spdxElementId": "SPDXRef-Package-system-configuration-0.7.0"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-core-foundation-0.9.4",
@@ -7638,764 +7276,49 @@
       "spdxElementId": "SPDXRef-Package-security-framework-2.11.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-jiff-static-0.2.15"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-backtrace-0.3.76",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-1.47.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-clap--builder-4.5.48",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-clap-4.5.48"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-axum-macros-0.5.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-axum-core-0.5.5",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.9.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-redox--syscall-0.5.18"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-openssl-macros-0.1.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-implement-0.60.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-http-0.6.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-yoke-derive-0.8.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-channel-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-mio-1.0.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-1.47.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-1.47.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.59.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-mio-1.0.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.81",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-futures-0.4.54"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-targets-0.52.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-sys-0.59.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-memchr-2.7.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-regex-automata-0.4.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-utf8parse-0.2.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-anstyle-parse-0.2.7"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-portable-atomic-util-0.2.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-jiff-0.2.15"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-task-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-arbitrary-1.4.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zip-6.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-datastar-0.3.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-openssl-probe-0.1.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-colorchoice-1.0.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-anstream-0.6.21"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-openssl-macros-0.1.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-unicase-2.8.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-mime--guess-2.0.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--yaml-0.9.34-plus-deprecated"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-want-0.3.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-1.7.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-darling--macro-0.21.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-core-0.5.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-slab-0.4.11",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-base64-0.22.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-encoding--rs-0.8.35"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-server-0.7.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-async-stream-0.3.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows--aarch64--gnullvm-0.53.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tempfile-3.23.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-http-0.6.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-sync--wrapper-1.0.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-base64-0.22.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-displaydoc-0.2.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-regex-syntax-0.8.7",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-regex-1.12.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-clap--derive-4.5.47"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-schannel-0.1.28",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-mime-0.3.17",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-rustls-pki-types-1.12.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rustls-webpki-0.103.7"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-litemap-0.8.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--locale--core-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-strsim-0.11.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-darling--core-0.21.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-portable-atomic-1.11.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-portable-atomic-util-0.2.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows--i686--gnullvm-0.52.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-darling--core-0.21.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-darling-0.21.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.81",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-iana-time-zone-0.1.64"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-1.3.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-flate2-1.1.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-compression-codecs-0.4.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-clap--lex-0.7.5",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-clap--builder-4.5.48"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-clap--derive-4.5.47"
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-futures-0.4.58"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--path--to--error-0.1.20"
+      "spdxElementId": "SPDXRef-Package-deranged-0.5.5"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
+      "relatedSpdxElement": "SPDXRef-Package-windows-strings-0.5.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
+      "spdxElementId": "SPDXRef-Package-windows-core-0.62.2"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-compression-core-0.4.29",
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-compression-codecs-0.4.31"
+      "spdxElementId": "SPDXRef-Package-filetime-0.2.27"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-icu--properties--data-2.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-serde--path--to--error-0.1.20",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--properties-2.0.1"
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.104",
+      "relatedSpdxElement": "SPDXRef-Package-yoke-0.8.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-js-sys-0.3.81"
+      "spdxElementId": "SPDXRef-Package-icu--collections-2.1.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-native-tls-0.2.14",
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-tls-0.6.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tower-0.5.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tinystr-0.8.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--locale--core-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-task-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-executor-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-include--dir--macros-0.7.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-include--dir-0.7.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows--i686--msvc-0.53.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-mime--guess-2.0.5",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zerofrom-0.1.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-yoke-0.8.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-reqwest-0.12.23",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama--derive-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zerofrom-0.1.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--provider-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--json-1.0.145"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zopfli-0.8.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zip-6.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tower-0.5.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-getrandom-0.2.16",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-ring-0.17.14"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-eyre-0.6.12",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde-1.0.228"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-once--cell--polyfill-1.70.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-anstyle-wincon-3.0.10"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-unicode-ident-1.0.19",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-syn-2.0.106"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-mime-0.3.17",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-core-0.5.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-wasm-bindgen-0.2.104"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-percent-encoding-2.3.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.15",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-http-1.3.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows--aarch64--msvc-0.52.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.15",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--json-1.0.145"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-icu--collections-2.0.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--properties-2.0.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-powerfmt-0.2.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-deranged-0.5.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-jiff-static-0.2.15"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-memchr-2.7.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-aho-corasick-1.1.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama--derive-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-equivalent-1.0.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-indexmap-2.11.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows--aarch64--msvc-0.53.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-rand-0.9.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-uuid-1.18.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-http-body-util-0.1.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-displaydoc-0.2.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tempfile-3.23.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.177",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-errno-0.3.14"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-anstream-0.6.21",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-clap--builder-4.5.48"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-zerocopy-derive-0.8.27",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerocopy-0.8.27"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-h2-0.4.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-memchr-2.7.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zip-6.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-interface-0.59.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-hyper-tls-0.6.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.104",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-iana-time-zone-0.1.64"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-native-tls-0.3.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-tls-0.6.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-winnow-0.7.13",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama--parser-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-socket2-0.6.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-bytes-1.10.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-tls-0.6.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tempfile-3.23.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tower-0.5.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-http-0.6.6"
+      "spdxElementId": "SPDXRef-Package-mio-1.1.1"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-crc32fast-1.5.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zopfli-0.8.2"
+      "spdxElementId": "SPDXRef-Package-zip-8.1.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-askama--derive-0.14.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama--parser-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-json-patch-4.1.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerovec-derive-0.11.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-base64-0.22.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.9.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-hyper-util-0.1.17",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.60.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-anstyle-query-1.1.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tower-layer-0.3.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tower-http-0.6.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-anstream-0.6.21",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-env--logger-0.11.8"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-socket2-0.6.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-1.47.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-ring-0.17.14",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rustls-webpki-0.103.7"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-1.47.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-fs-err-3.1.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-untrusted-0.9.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-ring-0.17.14"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-sync--wrapper-1.0.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-anstyle-1.0.13",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-clap--builder-4.5.48"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-async-stream-impl-0.3.6",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-async-stream-0.3.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-writeable-0.6.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--provider-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-eyre-0.6.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-wasi-0.14.7-plus-wasi-0.2.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-getrandom-0.3.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-getrandom-0.3.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-json-patch-4.1.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--yaml-0.9.34-plus-deprecated",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-indexmap-1.9.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--with-3.15.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-1.3.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-core-0.5.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-matchit-0.8.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tokio-rustls-0.26.4",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-openssl-0.10.73"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-sink-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-fastrand-2.3.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tempfile-3.23.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--with-3.15.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-ref-cast-impl-1.0.25"
+      "relatedSpdxElement": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT",
+      "relationshipType": "GENERATED_FROM",
+      "spdxElementId": "SPDXRef-File-esdiag"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
@@ -8403,69 +7326,19 @@
       "spdxElementId": "SPDXRef-Package-async-stream-0.3.6"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-displaydoc-0.2.5",
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--properties-2.0.1"
+      "spdxElementId": "SPDXRef-Package-rustix-1.1.3"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.3",
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-backtrace-0.3.76"
+      "spdxElementId": "SPDXRef-Package-serde--with--macros-3.16.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
+      "relatedSpdxElement": "SPDXRef-Package-core-foundation-0.9.4",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-core-0.5.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-core-foundation-sys-0.8.7",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-system-configuration-sys-0.6.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-strsim-0.11.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-clap--builder-4.5.48"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-percent-encoding-2.3.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-h2-0.4.12",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-getrandom-0.3.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-uuid-1.18.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-util-0.7.16"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zerofrom-derive-0.1.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-body-util-0.1.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-tls-0.6.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.145",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-schemars-1.0.4"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-aho-corasick-1.1.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-regex-1.12.1"
+      "spdxElementId": "SPDXRef-Package-system-configuration-0.7.0"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-scopeguard-1.2.0",
@@ -8473,164 +7346,119 @@
       "spdxElementId": "SPDXRef-Package-lock--api-0.4.14"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-percent-encoding-2.3.2",
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
+      "spdxElementId": "SPDXRef-Package-winnow-0.7.14"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-portable-atomic-1.11.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-jiff-0.2.15"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-form--urlencoded-1.2.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-macros-0.5.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-1.3.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-1.7.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-gimli-0.32.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-addr2line-0.25.1"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-js-sys-0.3.81"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-windows-result-0.4.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-core-0.62.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-http-body-1.0.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-1.7.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-redox--syscall-0.5.18",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.9.12"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.145",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-percent-encoding-2.3.2",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-icu--collections-2.0.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--normalizer-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-displaydoc-0.2.5",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--normalizer-2.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--with--macros-3.15.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-parking--lot--core-0.9.12",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-parking--lot-0.12.5"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-darling--core-0.21.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-rayon-core-1.13.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rayon-1.11.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-hyper-util-0.1.17",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-server-0.7.2"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-task-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-url-2.5.7"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-base64-0.22.1",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--derive-1.0.228",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-askama--derive-0.14.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.41",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-axum-0.8.6"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-futures-channel-0.3.31",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-crc32fast-1.5.0",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-zip-6.0.0"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-hashbrown-0.12.3",
-      "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-indexmap-1.9.3"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-serde--with-3.15.0",
+      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.149",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
+      "relatedSpdxElement": "SPDXRef-Package-http-body-util-0.1.3",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-windows-strings-0.5.1"
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-serde--derive-1.0.228",
+      "relatedSpdxElement": "SPDXRef-Package-askama-0.15.4",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde-1.0.228"
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-idna-1.1.0",
+      "relatedSpdxElement": "SPDXRef-Package-fnv-1.0.7",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-url-2.5.7"
+      "spdxElementId": "SPDXRef-Package-h2-0.4.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-native-tls-0.2.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-tls-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerotrie-0.2.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--properties-2.1.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-aho-corasick-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-regex-automata-0.4.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-mime-0.3.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-mime--guess-2.0.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-yoke-0.8.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerovec-0.11.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.149",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-json-patch-4.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-h2-0.4.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--x86--64--gnu-0.53.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-anstyle-wincon-3.0.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-anstream-0.6.21"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--normalizer-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerofrom-derive-0.1.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerofrom-0.1.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-powerfmt-0.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-time-0.3.47"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-sink-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-h2-0.4.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tower-layer-0.3.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-encoding--rs-0.8.35",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-utils-0.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-1.8.1"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-utf8parse-0.2.2",
@@ -8638,64 +7466,809 @@
       "spdxElementId": "SPDXRef-Package-anstream-0.6.21"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
+      "relatedSpdxElement": "SPDXRef-Package-axum-0.8.8",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-async-compression-0.4.32"
+      "spdxElementId": "SPDXRef-Package-datastar-0.3.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-subtle-2.6.1",
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.108",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rustls-0.23.32"
+      "spdxElementId": "SPDXRef-Package-iana-time-zone-0.1.65"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.106",
+      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-tokio-macros-2.5.0"
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-futures-0.4.58"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.101",
+      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.149",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--derive-1.0.228"
+      "spdxElementId": "SPDXRef-Package-jsonptr-0.7.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-icu--normalizer--data-2.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-icu--normalizer-2.0.0"
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.108"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.41",
+      "relatedSpdxElement": "SPDXRef-Package-tokio-native-tls-0.3.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.17"
+      "spdxElementId": "SPDXRef-Package-hyper-tls-0.6.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-schemars-0.9.0"
+      "spdxElementId": "SPDXRef-Package-async-stream-impl-0.3.6"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.145",
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-schemars-0.9.0"
+      "spdxElementId": "SPDXRef-Package-displaydoc-0.2.5"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-ryu-1.0.20",
+      "relatedSpdxElement": "SPDXRef-Package-indexmap-1.9.3",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-serde--urlencoded-0.7.1"
+      "spdxElementId": "SPDXRef-Package-serde--with-3.16.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-url-2.5.7",
+      "relatedSpdxElement": "SPDXRef-Package-regex-syntax-0.8.9",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
+      "spdxElementId": "SPDXRef-Package-regex-automata-0.4.14"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.16",
+      "relatedSpdxElement": "SPDXRef-Package-crossbeam-utils-0.8.21",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-reqwest-0.12.23"
+      "spdxElementId": "SPDXRef-Package-crossbeam-deque-0.8.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.10.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-system-configuration-0.7.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-1.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-http-body-1.0.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-result-0.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-core-0.62.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hyper-1.8.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-untrusted-0.9.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-rustls-webpki-0.103.7"
+      "spdxElementId": "SPDXRef-Package-ring-0.17.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hyper-util-0.1.20",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-server-0.8.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-equivalent-1.0.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-indexmap-2.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--aarch64--gnullvm-0.53.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-system-configuration-sys-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerovec-0.11.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tinystr-0.8.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-yoke-0.8.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--provider-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-0.5.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-crc32fast-1.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-icu--normalizer--data-2.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--normalizer-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jiff-0.2.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-macro-0.2.108",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-0.2.108"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-json-patch-4.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.85",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-futures-0.4.58"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.60.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-anstyle-wincon-3.0.10"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-core-foundation-sys-0.8.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-system-configuration-sys-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hyper-tls-0.6.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-jsonptr-0.7.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-json-patch-4.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustls-webpki-0.103.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustls-0.23.36"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--x86--64--gnullvm-0.53.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--derive-1.0.228"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-macro-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--urlencoded-0.7.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-axum-core-0.5.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-macro-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tower-0.5.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-native-tls-0.2.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tokio-native-tls-0.3.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-http-0.6.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-socket2-0.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-compression-core-0.4.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-compression-codecs-0.4.36"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ident--case-1.0.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-darling--core-0.21.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-channel-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-crossbeam-deque-0.8.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rayon-core-1.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-1.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-errno-0.3.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustls-pki-types-1.14.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-h2-0.4.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unsafe-libyaml-0.2.11",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--yaml-0.9.34-plus-deprecated"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-dyn-clone-1.0.20",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.10.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-redox--syscall-0.5.18"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.10.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-redox--syscall-0.7.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--with-3.16.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-utf8parse-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-anstyle-parse-0.2.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-clap--lex-0.7.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-clap--builder-4.5.48"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerofrom-0.1.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerovec-0.11.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-crossbeam-utils-0.8.21",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-crossbeam-epoch-0.9.18"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tower-http-0.6.8",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-darling--macro-0.21.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-darling-0.21.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-macro-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.53.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tower-layer-0.3.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-0.5.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-url-2.5.8",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-synstructure-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerofrom-derive-0.1.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-displaydoc-0.2.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tinystr-0.8.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerofrom-0.1.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--provider-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-untrusted-0.9.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustls-webpki-0.103.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerovec-derive-0.11.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerovec-0.11.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-native-tls-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-parking--lot--core-0.9.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot-0.12.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-native-tls-0.3.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-synstructure-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-displaydoc-0.2.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerotrie-0.2.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerotrie-0.2.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--provider-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-anstyle-1.0.13",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-env--logger-0.11.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-env--filter-0.1.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-core-foundation-0.9.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jiff-static-0.2.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-flate2-1.1.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--derive-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde-1.0.228"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.108",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-uuid-1.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-displaydoc-0.2.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-reqwest-0.12.28",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-elasticsearch-9.1.0-alpha.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-num-traits-0.2.19",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-chrono-0.4.43"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.2.17"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-core-0.5.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.85",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iana-time-zone-0.1.65"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-axum-server-0.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-axum-0.8.8",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-syn-2.0.114"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-1.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-channel-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-regex-1.12.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-env--filter-0.1.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ref-cast-impl-1.0.25"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-schemars-1.2.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-anstream-0.6.21",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-env--logger-0.11.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.3.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-getrandom-0.3.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tempfile-3.24.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tempfile-3.24.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tokio-rustls-0.26.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-impl-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-thiserror-1.0.69"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.149",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-datastar-0.3.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ref-cast-impl-1.0.25",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ref-cast-1.0.25"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-interface-0.59.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-openssl-macros-0.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-indenter-0.3.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-eyre-0.6.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustc-hash-2.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-askama--parser-0.15.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-body-util-0.1.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-getrandom-0.3.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-uuid-1.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.180",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-compression-0.4.39",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-http-0.6.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-form--urlencoded-1.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-url-2.5.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-socket2-0.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tokio-1.49.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-macro-0.3.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.60.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-anstyle-query-1.1.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-percent-encoding-2.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.52.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ring-0.17.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-spin-0.9.8",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-slab-0.4.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-h2-0.4.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-openssl-0.10.75"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tower-http-0.6.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-base64-0.22.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--with-3.16.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.114",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ref-cast-impl-1.0.25"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-server-0.8.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-either-1.15.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rayon-1.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tokio-1.49.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-1.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tokio-macros-2.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-matchit-0.8.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-0.8.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hyper-1.8.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-url-2.5.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-mime-0.3.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-core-0.5.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-rustls-0.27.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-icu--collections-2.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-icu--normalizer-2.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-body-util-0.1.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-axum-core-0.5.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-eyre-0.6.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-esdiag-0.14.0-SNAPSHOT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-strings-0.5.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-fastrand-2.3.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tempfile-3.24.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-http-1.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-percent-encoding-2.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-askama-0.15.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.85",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-reqwest-0.12.28"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-1.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-1.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-h2-0.4.13",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-1.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-http-1.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-http-body-util-0.1.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--i686--gnullvm-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tokio-1.49.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tower-service-0.3.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hyper-util-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-indexmap-2.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-regex-1.12.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rand--chacha-0.9.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rand-0.9.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-multer-3.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tracing-core-0.1.36",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tracing-0.1.44"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-http-1.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustix-1.1.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-ident-1.0.22",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-shared-0.2.108"
     }
   ],
   "spdxVersion": "SPDX-2.3"


### PR DESCRIPTION
## Summary
- Updated `build.rs` to automatically generate `NOTICE.txt` (via `cargo about`) and `esdiag.spdx.json` (via `cargo sbom`) when dependencies change.
- Included mtime-based logic to skip generation if artifacts are up-to-date, supporting environments where these tools might not be installed (e.g., CI/CD containers).
- Added `about.hbs` and `about.toml` configuration for `cargo about`.