### PR TITLE
feat: add esdiag operational skill

### DIFF
--- a/skills/esdiag/SKILL.md
+++ b/skills/esdiag/SKILL.md
@@ -8,6 +8,7 @@ description: Operate Elastic Stack Diagnostics (`esdiag`) end-to-end for host co
 Use this skill to choose and run the right `esdiag` command sequence quickly and safely.
 
 Prefer command output from `esdiag help` and `esdiag <command> --help` over memory when behavior is unclear.
+Use `--sources <path/to/sources.yml>` when diagnostics API selection must follow a custom or version-specific sources definition.
 
 ## Workflow Decision Tree
 
@@ -59,11 +60,16 @@ Prefer command output from `esdiag help` and `esdiag <command> --help` over memo
   - `--case`
   - `--opportunity`
   - `--user`
+- Use `--sources` to override endpoint source definitions when testing new API mappings or reproducing source-selection behavior.
 
 ## Step 4: Collect Then Process (Optional)
 
-- Use `esdiag collect <HOST> <OUTPUT>` when the user needs fresh API diagnostics.
+- Use `esdiag collect [OPTIONS] <HOST> <OUTPUT>` when the user needs fresh API diagnostics.
 - Ensure `<OUTPUT>` already exists; command creates a diagnostic subdirectory within it.
+- Use `--type` to control collection level (`minimal`, `light`, `standard`, `support`).
+- Use `--include` and `--exclude` to explicitly control which APIs are collected.
+- Use metadata options (`--account`, `--case`, `--opportunity`, `--user`) when collected artifacts should carry report context.
+- Use `--sources` when the collection endpoints should come from a non-default `sources.yml`.
 - For repeated captures, use `bin/min-diag.sh watch` and process each generated directory with `esdiag process`.
 
 ## Step 5: Run Upload Service (Optional)

--- a/skills/esdiag/SKILL.md
+++ b/skills/esdiag/SKILL.md
@@ -3,7 +3,7 @@ name: esdiag
 description: Operate Elastic Stack Diagnostics (`esdiag`) end-to-end for host configuration, asset setup, diagnostic collection, processing, and upload-service workflows. Use when a user asks to run or troubleshoot `esdiag` commands (`host`, `setup`, `collect`, `process`, `serve`), wire output targets via known hosts or `ESDIAG_OUTPUT_*` environment variables, process support-diagnostics archives/directories/upload links, or expose the local web/API service.
 ---
 
-# Esdiag
+# ESDiag
 
 Use this skill to choose and run the right `esdiag` command sequence quickly and safely.
 
@@ -49,11 +49,11 @@ Prefer command output from `esdiag help` and `esdiag <command> --help` over memo
   - Unpacked diagnostic directory
   - Known host name from `~/.esdiag/hosts.yml`
   - Elastic Upload URL (`https://token:...@upload.elastic.co/d/...`)
-- Resolve `[OUTPUT]` in this order:
-  - Known host name
-  - Filename fallback
-  - `-` for stdout
-  - Environment-variable output target if omitted
+- Resolve `[OUTPUT]` using these rules:
+  - If `[OUTPUT]` is `-`, write to stdout.
+  - Otherwise, if it matches a saved host name, use that host.
+  - Otherwise, treat it as a URL when it starts with `http://` or `https://`; treat remaining values as file/directory targets.
+  - If `[OUTPUT]` is omitted entirely, fall back to `ESDIAG_OUTPUT_*` environment variables.
 - Attach report metadata when provided by user:
   - `--account`
   - `--case`

--- a/skills/esdiag/SKILL.md
+++ b/skills/esdiag/SKILL.md
@@ -31,7 +31,7 @@ Use `--sources <path/to/sources.yml>` when diagnostics API selection must follow
 - Use `--apikey` for API key auth or `--username`/`--password` for basic auth.
 - Use `--accept-invalid-certs` for lab/self-signed environments.
 - Use `--nosave` for connectivity tests that should not persist.
-- Use `.env`/environment variables when the user does not want a saved host.
+- Use environment variables (optionally by sourcing a `.env` file in the shell) when the user does not want a saved host.
 
 ## Step 2: Setup Output Cluster
 
@@ -41,6 +41,8 @@ Use `--sources <path/to/sources.yml>` when diagnostics API selection must follow
   - `ESDIAG_OUTPUT_APIKEY`
   - `ESDIAG_OUTPUT_USERNAME`
   - `ESDIAG_OUTPUT_PASSWORD`
+  - `ESDIAG_KIBANA_URL` (required for Kibana asset setup in host-omitted mode)
+- In host-omitted mode, `setup` attempts both Elasticsearch and Kibana asset setup.
 
 ## Step 3: Process Diagnostics
 
@@ -53,8 +55,9 @@ Use `--sources <path/to/sources.yml>` when diagnostics API selection must follow
 - Resolve `[OUTPUT]` using these rules:
   - If `[OUTPUT]` is `-`, write to stdout.
   - Otherwise, if it matches a saved host name, use that host.
-  - Otherwise, treat it as a URL when it starts with `http://` or `https://`; treat remaining values as file/directory targets.
-  - If `[OUTPUT]` is omitted entirely, fall back to `ESDIAG_OUTPUT_*` environment variables.
+  - Otherwise, treat it as a filesystem target (file or directory).
+  - If `[OUTPUT]` is omitted entirely, fall back to `ESDIAG_OUTPUT_*` environment variables (Elasticsearch output target).
+  - Do not treat raw `http(s)` output strings as valid output targets unless they are saved and resolved as known hosts.
 - Attach report metadata when provided by user:
   - `--account`
   - `--case`

--- a/skills/esdiag/SKILL.md
+++ b/skills/esdiag/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: esdiag
+description: Operate Elastic Stack Diagnostics (`esdiag`) end-to-end for host configuration, asset setup, diagnostic collection, processing, and upload-service workflows. Use when a user asks to run or troubleshoot `esdiag` commands (`host`, `setup`, `collect`, `process`, `serve`), wire output targets via known hosts or `ESDIAG_OUTPUT_*` environment variables, process support-diagnostics archives/directories/upload links, or expose the local web/API service.
+---
+
+# Esdiag
+
+Use this skill to choose and run the right `esdiag` command sequence quickly and safely.
+
+Prefer command output from `esdiag help` and `esdiag <command> --help` over memory when behavior is unclear.
+
+## Workflow Decision Tree
+
+- If the task is "save/test a connection", run `esdiag host`.
+- If the task is "install templates/pipelines/assets", run `esdiag setup`.
+- If the task is "transform diagnostics into documents and send somewhere", run `esdiag process`.
+- If the task is "collect API diagnostics from a host into local files", run `esdiag collect`.
+- If the task is "accept browser uploads or API submissions", run `esdiag serve`.
+
+## Standard Flow
+
+1. Configure output host or output environment variables.
+2. Run `esdiag setup` against the Elasticsearch output target.
+3. Ingest diagnostics via `esdiag process` or `esdiag serve`.
+4. Confirm completion output and share destination details (host/file/stdout).
+
+## Step 1: Configure Hosts and Auth
+
+- Use `esdiag host [OPTIONS] <NAME> [APP] [URL]` to test and save host configuration to `~/.esdiag/hosts.yml`.
+- Use `--apikey` for API key auth or `--username`/`--password` for basic auth.
+- Use `--accept-invalid-certs` for lab/self-signed environments.
+- Use `--nosave` for connectivity tests that should not persist.
+- Use `.env`/environment variables when the user does not want a saved host.
+
+## Step 2: Setup Output Cluster
+
+- Run `esdiag setup [HOST]` before first ingestion into a cluster.
+- If `[HOST]` is omitted, rely on:
+  - `ESDIAG_OUTPUT_URL`
+  - `ESDIAG_OUTPUT_APIKEY`
+  - `ESDIAG_OUTPUT_USERNAME`
+  - `ESDIAG_OUTPUT_PASSWORD`
+
+## Step 3: Process Diagnostics
+
+- Use `esdiag process [OPTIONS] <INPUT> [OUTPUT]`.
+- Accept these input patterns:
+  - Support diagnostics `.zip` archive
+  - Unpacked diagnostic directory
+  - Known host name from `~/.esdiag/hosts.yml`
+  - Elastic Upload URL (`https://token:...@upload.elastic.co/d/...`)
+- Resolve `[OUTPUT]` in this order:
+  - Known host name
+  - Filename fallback
+  - `-` for stdout
+  - Environment-variable output target if omitted
+- Attach report metadata when provided by user:
+  - `--account`
+  - `--case`
+  - `--opportunity`
+  - `--user`
+
+## Step 4: Collect Then Process (Optional)
+
+- Use `esdiag collect <HOST> <OUTPUT>` when the user needs fresh API diagnostics.
+- Ensure `<OUTPUT>` already exists; command creates a diagnostic subdirectory within it.
+- For repeated captures, use `bin/min-diag.sh watch` and process each generated directory with `esdiag process`.
+
+## Step 5: Run Upload Service (Optional)
+
+- Use `esdiag serve [OPTIONS] [OUTPUT]` to host upload and API endpoints.
+- Default port is `2501`; override with `--port`.
+- Pass `--kibana <URL>` (or set `ESDIAG_KIBANA_URL`) to show direct links in UI flows.
+- Use output resolution rules from `process`.
+
+## Troubleshooting Rules
+
+- If command behavior looks inconsistent with docs, trust live help output first.
+- If auth fails, re-check saved host/app/url/auth mode and whether cert validation is required.
+- If output is not where expected, verify `[OUTPUT]` parsing and known-host name collisions with filenames.
+- If setup or ingest fails after version changes, rerun `esdiag setup` before retrying `process`.
+
+## References
+
+- Use `references/cli.md` for command syntax and option details.

--- a/skills/esdiag/agents/openai.yaml
+++ b/skills/esdiag/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "ESDiag CLI"
+  short_description: "Run and operate esdiag diagnostic workflows"
+  default_prompt: "Use $esdiag to configure hosts, run setup, and process diagnostics with the right command sequence."

--- a/skills/esdiag/references/cli.md
+++ b/skills/esdiag/references/cli.md
@@ -17,6 +17,7 @@ Commands:
 
 Options:
       --debug
+      --sources <SOURCES>
   -h, --help
   -V, --version
 ```
@@ -29,7 +30,15 @@ Usage: esdiag collect [OPTIONS] <HOST> <OUTPUT>
 
 - `<HOST>`: known Elasticsearch host to collect from.
 - `<OUTPUT>`: existing directory where a diagnostic directory is created.
-- For complete option support (including future flags), check `esdiag collect --help`.
+- Common options:
+  - `--type <TYPE>` (`minimal`, `light`, `standard`, `support`; default `standard`)
+  - `--include <INCLUDE>` (comma-separated APIs)
+  - `--exclude <EXCLUDE>` (comma-separated APIs)
+  - `-a, --account <ACCOUNT>`
+  - `-c, --case <CASE>`
+  - `-o, --opportunity <OPPORTUNITY>`
+  - `-u, --user <USER>`
+- Use `esdiag collect --help` for the full version-specific option list.
 
 ## host
 
@@ -43,6 +52,7 @@ Key options:
 - `-u, --username <USERNAME>`
 - `-p, --password <PASSWORD>`
 - `-n, --nosave`
+- `--sources <SOURCES>`
 
 ## process
 
@@ -58,6 +68,7 @@ Report options:
 - `-c, --case <CASE>`
 - `-o, --opportunity <OPPORTUNITY>`
 - `-u, --user <USER>`
+- `--sources <SOURCES>`
 
 ## serve
 
@@ -68,12 +79,16 @@ Usage: esdiag serve [OPTIONS] [OUTPUT]
 Key options:
 - `-p, --port <PORT>` (default `2501`)
 - `--kibana <KIBANA>`
+- `--sources <SOURCES>`
 
 ## setup
 
 ```text
 Usage: esdiag setup [OPTIONS] [HOST]
 ```
+
+Key options:
+- `--sources <SOURCES>`
 
 If `[HOST]` is omitted, resolve output from:
 - `ESDIAG_OUTPUT_URL`

--- a/skills/esdiag/references/cli.md
+++ b/skills/esdiag/references/cli.md
@@ -95,3 +95,4 @@ If `[HOST]` is omitted, resolve output from:
 - `ESDIAG_OUTPUT_APIKEY`
 - `ESDIAG_OUTPUT_USERNAME`
 - `ESDIAG_OUTPUT_PASSWORD`
+- `ESDIAG_KIBANA_URL` (required for Kibana asset setup when host is omitted)

--- a/skills/esdiag/references/cli.md
+++ b/skills/esdiag/references/cli.md
@@ -1,6 +1,6 @@
 # ESDiag CLI Reference
 
-Use this file for exact command syntax when building or checking command lines.
+Use this file as a concise command map. For complete and version-accurate options, run `esdiag --help` and `esdiag <command> --help`.
 
 ## Top-level
 
@@ -14,6 +14,11 @@ Commands:
   process
   setup
   help
+
+Options:
+      --debug
+  -h, --help
+  -V, --version
 ```
 
 ## collect
@@ -24,6 +29,7 @@ Usage: esdiag collect [OPTIONS] <HOST> <OUTPUT>
 
 - `<HOST>`: known Elasticsearch host to collect from.
 - `<OUTPUT>`: existing directory where a diagnostic directory is created.
+- For complete option support (including future flags), check `esdiag collect --help`.
 
 ## host
 

--- a/skills/esdiag/references/cli.md
+++ b/skills/esdiag/references/cli.md
@@ -1,0 +1,76 @@
+# ESDiag CLI Reference
+
+Use this file for exact command syntax when building or checking command lines.
+
+## Top-level
+
+```text
+Usage: esdiag [OPTIONS] <COMMAND>
+
+Commands:
+  collect
+  serve
+  host
+  process
+  setup
+  help
+```
+
+## collect
+
+```text
+Usage: esdiag collect [OPTIONS] <HOST> <OUTPUT>
+```
+
+- `<HOST>`: known Elasticsearch host to collect from.
+- `<OUTPUT>`: existing directory where a diagnostic directory is created.
+
+## host
+
+```text
+Usage: esdiag host [OPTIONS] <NAME> [APP] [URL]
+```
+
+Key options:
+- `--accept-invalid-certs`
+- `-a, --apikey <APIKEY>`
+- `-u, --username <USERNAME>`
+- `-p, --password <PASSWORD>`
+- `-n, --nosave`
+
+## process
+
+```text
+Usage: esdiag process [OPTIONS] <INPUT> [OUTPUT]
+```
+
+- `<INPUT>`: archive, directory, known host, or Elastic uploader URL.
+- `[OUTPUT]`: known host, file, `-` for stdout, or environment fallback.
+
+Report options:
+- `-a, --account <ACCOUNT>`
+- `-c, --case <CASE>`
+- `-o, --opportunity <OPPORTUNITY>`
+- `-u, --user <USER>`
+
+## serve
+
+```text
+Usage: esdiag serve [OPTIONS] [OUTPUT]
+```
+
+Key options:
+- `-p, --port <PORT>` (default `2501`)
+- `--kibana <KIBANA>`
+
+## setup
+
+```text
+Usage: esdiag setup [OPTIONS] [HOST]
+```
+
+If `[HOST]` is omitted, resolve output from:
+- `ESDIAG_OUTPUT_URL`
+- `ESDIAG_OUTPUT_APIKEY`
+- `ESDIAG_OUTPUT_USERNAME`
+- `ESDIAG_OUTPUT_PASSWORD`


### PR DESCRIPTION
  ## Summary
  - add a new `esdiag` skill under `skills/esdiag`
  - document end-to-end operational workflows for `esdiag` CLI in `SKILL.md`
  - add concise command syntax reference in `references/cli.md`
  - include UI metadata in `agents/openai.yaml`

  ## What the skill covers
  - host configuration and auth (`esdiag host`)
  - output cluster setup (`esdiag setup`)
  - diagnostic processing flows (`esdiag process`)
  - optional collection-first flow (`esdiag collect`)
  - optional upload/API service flow (`esdiag serve`)
  - troubleshooting rules and output resolution behavior

  ## Validation
  - `python3 /home/reno/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/esdiag`
  - result: `Skill is valid!`
