### PR TITLE
chore: clean up clippy warnings and formatting

### DIFF
--- a/src/client/elasticsearch.rs
+++ b/src/client/elasticsearch.rs
@@ -61,7 +61,7 @@ impl ElasticsearchBuilder {
             headers::AUTHORIZATION,
             headers::HeaderValue::from_str(&format!(
                 "Basic {}",
-                STANDARD.encode(&format!("{}:{}", username, password))
+                STANDARD.encode(format!("{}:{}", username, password))
             ))
             .expect("Invalid basic auth"),
         );

--- a/src/client/kibana.rs
+++ b/src/client/kibana.rs
@@ -55,7 +55,7 @@ impl KibanaClient {
         body: Option<&[u8]>,
     ) -> Result<reqwest::Response> {
         let mut headers: reqwest::header::HeaderMap = headers
-            .into_iter()
+            .iter()
             .map(|(k, v)| (k.parse().unwrap(), v.parse().unwrap()))
             .collect();
         let use_form_data = match headers.get("Content-Type") {
@@ -119,7 +119,7 @@ impl TryFrom<KnownHost> for KibanaClient {
     fn try_from(host: KnownHost) -> Result<Self> {
         let url = host.get_url();
         let auth = host.get_auth();
-        Ok(KibanaClient::try_new(url, auth)?)
+        KibanaClient::try_new(url, auth)
     }
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -54,9 +54,9 @@ impl Client {
                     .collect();
                 use es::http::request::JsonBody;
                 let body: Option<JsonBody<serde_json::Value>> = body
-                    .map(|b| serde_json::from_slice(b))
+                    .map(serde_json::from_slice)
                     .transpose()?
-                    .map(|v| JsonBody::new(v));
+                    .map(JsonBody::new);
                 let response = client
                     .send(
                         method,

--- a/src/data/auth.rs
+++ b/src/data/auth.rs
@@ -25,7 +25,7 @@ impl Auth {
         match (r#type, username, password, apikey) {
             (AuthType::Apikey, _, _, Some(apikey)) => Self::Apikey(apikey),
             (AuthType::Basic, Some(username), Some(password), _) => Self::Basic(username, password),
-            (AuthType::None, _, _, _) | _ => Self::None,
+            _ => Self::None,
         }
     }
 }

--- a/src/data/known_host.rs
+++ b/src/data/known_host.rs
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use crate::data::{Auth, Product};
-use eyre::{eyre, Result};
+use eyre::{Result, eyre};
 use serde::{Deserialize, Serialize};
 use serde_yaml;
 use std::{
@@ -114,7 +114,7 @@ impl KnownHostBuilder {
         let new_segments: Vec<&str> = match self.product {
             Product::Elasticsearch => {
                 let product = match url.domain() {
-                    Some(domain) if domain == "admin.found.no" => "main-elasticsearch",
+                    Some("admin.found.no") => "main-elasticsearch",
                     _ => "elasticsearch",
                 };
                 vec![
@@ -219,7 +219,7 @@ impl KnownHost {
         }
     }
 
-    pub fn save(self, name: &String) -> Result<String> {
+    pub fn save(self, name: &str) -> Result<String> {
         // parse the ~/.esdiag/hosts.yml file into a HashMap<String, Host>
         let mut hosts = match KnownHost::parse_hosts_yml() {
             Ok(hosts) => hosts,
@@ -230,13 +230,13 @@ impl KnownHost {
         };
         match self {
             Self::ApiKey { .. } => {
-                hosts.insert(name.clone(), self);
+                hosts.insert(name.to_owned(), self);
             }
             Self::Basic { .. } => {
-                hosts.insert(name.clone(), self);
+                hosts.insert(name.to_owned(), self);
             }
             Self::NoAuth { .. } => {
-                hosts.insert(name.clone(), self);
+                hosts.insert(name.to_owned(), self);
             }
         }
         KnownHost::write_hosts_yml(&hosts)
@@ -255,8 +255,7 @@ impl KnownHost {
             "Known hosts: {}",
             hosts
                 .clone()
-                .into_iter()
-                .map(|(k, _)| k)
+                .into_keys()
                 .collect::<Vec<String>>()
                 .join(", ")
         );
@@ -292,8 +291,8 @@ impl KnownHost {
                 if !esdiag.exists() {
                     std::fs::create_dir(&esdiag).expect("Failed to create ~/.esdiag directory");
                 }
-                let path = home_dir.join(".esdiag").join("hosts.yml");
-                path
+
+                home_dir.join(".esdiag").join("hosts.yml")
             }
         }
     }
@@ -323,8 +322,7 @@ impl KnownHost {
             "Writing hosts: {} to {:?}",
             hosts
                 .clone()
-                .into_iter()
-                .map(|(k, _)| k)
+                .into_keys()
                 .collect::<Vec<String>>()
                 .join(", "),
             path

--- a/src/data/uri.rs
+++ b/src/data/uri.rs
@@ -5,7 +5,7 @@
 use crate::data::Product;
 
 use super::{ElasticCloud, KnownHost, KnownHostBuilder};
-use eyre::{eyre, OptionExt, Report, Result};
+use eyre::{OptionExt, Report, Result, eyre};
 use serde::{Deserialize, Deserializer};
 use std::{
     path::{Path, PathBuf},
@@ -14,7 +14,7 @@ use std::{
 
 use url::Url;
 /// The different types of supported URIs
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub enum Uri {
     /// Known host saved in the ~/.esdiag/hosts.yml by default
     KnownHost(KnownHost),
@@ -35,6 +35,7 @@ pub enum Uri {
     /// File on the local filesystem
     File(PathBuf),
     /// An input/output stream (stdin/stdout)
+    #[default]
     Stream,
 }
 
@@ -98,12 +99,6 @@ impl<'de> Deserialize<'de> for Uri {
     }
 }
 
-impl Default for Uri {
-    fn default() -> Self {
-        Uri::Stream
-    }
-}
-
 impl From<Uri> for Url {
     fn from(uri: Uri) -> Self {
         match uri {
@@ -148,12 +143,12 @@ impl TryFrom<&str> for Uri {
             return Ok(Uri::Stream);
         }
 
-        if let Ok(host) = KnownHost::from_str(&uri) {
+        if let Ok(host) = KnownHost::from_str(uri) {
             return host.try_into();
         }
         log::debug!("No known host for {uri}");
 
-        if let Ok(url) = Url::parse(&uri) {
+        if let Ok(url) = Url::parse(uri) {
             let domain = url.domain().ok_or_eyre("URL is missing a domain")?;
             match (domain, url.username(), url.password()) {
                 ("upload.elastic.co", "token", Some(_)) => {
@@ -176,7 +171,7 @@ impl TryFrom<&str> for Uri {
             false => log::debug!("Not an existing directory {uri}"),
             true => {
                 log::debug!("Directory {uri}");
-                let path_buf = PathBuf::from_str(&uri)?;
+                let path_buf = PathBuf::from_str(uri)?;
                 return Ok(Uri::Directory(path_buf));
             }
         }
@@ -185,14 +180,14 @@ impl TryFrom<&str> for Uri {
             false => {
                 if path.extension().is_none() {
                     log::debug!("No extension, creating directory: {uri}");
-                    let path_buf = PathBuf::from_str(&uri)?;
-                    return Ok(Uri::Directory(path_buf));
+                    let path_buf = PathBuf::from_str(uri)?;
+                    Ok(Uri::Directory(path_buf))
                 } else {
                     log::debug!("File did not exist: {uri}");
-                    return Ok(Uri::File(PathBuf::from_str(&uri)?));
+                    Ok(Uri::File(PathBuf::from_str(uri)?))
                 }
             }
-            true => return Ok(Uri::File(PathBuf::from_str(&uri)?)),
+            true => Ok(Uri::File(PathBuf::from_str(uri)?)),
         }
     }
 }

--- a/src/exporter/directory.rs
+++ b/src/exporter/directory.rs
@@ -12,13 +12,13 @@ use std::sync::Arc;
 use std::{
     fs::{File, OpenOptions},
     io::{BufWriter, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 use tokio::sync::{RwLock, mpsc, oneshot};
 
 type Writers = HashMap<String, Arc<RwLock<BufWriter<File>>>>;
 
-fn create_writer(path: &PathBuf, index: &str) -> Result<Arc<RwLock<BufWriter<File>>>> {
+fn create_writer(path: &Path, index: &str) -> Result<Arc<RwLock<BufWriter<File>>>> {
     let filename = format!("{}.ndjson", index);
     let file = OpenOptions::new()
         .create(true)
@@ -30,7 +30,7 @@ fn create_writer(path: &PathBuf, index: &str) -> Result<Arc<RwLock<BufWriter<Fil
 
 async fn get_writer(
     writers: Arc<RwLock<Writers>>,
-    path: &PathBuf,
+    path: &Path,
     index: &str,
 ) -> Result<Arc<RwLock<BufWriter<File>>>> {
     let mut writers = writers.write().await;

--- a/src/exporter/elasticsearch.rs
+++ b/src/exporter/elasticsearch.rs
@@ -74,10 +74,7 @@ impl ElasticsearchExporter {
             "DELETE" => Method::Delete,
             _ => Method::Get,
         };
-        let body = match value {
-            Some(value) => Some(JsonBody::new(value)),
-            None => None,
-        };
+        let body = value.map(JsonBody::new);
         timeout(
             Self::request_timeout(),
             self.client.send(
@@ -161,7 +158,10 @@ impl Export for ElasticsearchExporter {
 
         let response = timeout(
             Self::request_timeout(),
-            self.client.bulk(BulkParts::Index(&index)).body(batch).send(),
+            self.client
+                .bulk(BulkParts::Index(&index))
+                .body(batch)
+                .send(),
         )
         .await
         .map_err(|_| {
@@ -221,10 +221,8 @@ impl Export for ElasticsearchExporter {
                 Ok(batch_response) => {
                     if tx.send(batch_response).is_err() {
                         log::error!("Failed to send batch response: receiver dropped");
-                    } else {
-                        if let Some(tx) = docs_tx {
-                            let _ = tx.send(doc_count).await;
-                        }
+                    } else if let Some(tx) = docs_tx {
+                        let _ = tx.send(doc_count).await;
                     }
                 }
                 Err(e) => {
@@ -256,27 +254,28 @@ impl Export for ElasticsearchExporter {
                 Self::request_timeout()
             )),
             Ok(res) => match res {
-            Ok(res) => {
-                let status_code = res.status_code().as_u16();
-                let body = res.json::<Value>().await?;
-                match status_code {
-                    200 | 201 => {
-                        log::info!(
-                            "metrics-diagnostic-esdiag, created diagnostic report {}",
-                            diagnostic_id
-                        );
-                        log::trace!("response body: {body}");
-                        Ok(())
+                Ok(res) => {
+                    let status_code = res.status_code().as_u16();
+                    let body = res.json::<Value>().await?;
+                    match status_code {
+                        200 | 201 => {
+                            log::info!(
+                                "metrics-diagnostic-esdiag, created diagnostic report {}",
+                                diagnostic_id
+                            );
+                            log::trace!("response body: {body}");
+                            Ok(())
+                        }
+                        400..600 => Err(eyre!("http {status_code}: {body}")),
+                        _ => Err(eyre!("unexpected response: http {status_code}: {body}")),
                     }
-                    400..600 => Err(eyre!("http {status_code}: {body}")),
-                    _ => Err(eyre!("unexpected response: http {status_code}: {body}")),
                 }
-            }
-            Err(e) => {
-                log::error!("{e}");
-                Err(e.into())
-            }
-        }}
+                Err(e) => {
+                    log::error!("{e}");
+                    Err(e.into())
+                }
+            },
+        }
     }
 }
 

--- a/src/exporter/stream.rs
+++ b/src/exporter/stream.rs
@@ -14,6 +14,12 @@ pub struct StreamExporter {
     docs_tx: Option<mpsc::Sender<usize>>,
 }
 
+impl Default for StreamExporter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl StreamExporter {
     pub fn new() -> Self {
         StreamExporter { docs_tx: None }

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,7 +234,9 @@ async fn run(cli: Cli) -> Result<&'static str> {
         use clap::CommandFactory;
         let mut cmd = Cli::command();
         cmd.print_help()?;
-        return Err(eyre!("No subcommand provided. Use --help for usage information."));
+        return Err(eyre!(
+            "No subcommand provided. Use --help for usage information."
+        ));
     }
 
     if let Some(command) = cli.command {
@@ -259,7 +261,8 @@ async fn run(cli: Cli) -> Result<&'static str> {
                     }
                 });
 
-                let (mut server, _bound_addr) = Server::start([0, 0, 0, 0], port, exporter, kibana_url).await?;
+                let (mut server, _bound_addr) =
+                    Server::start([0, 0, 0, 0], port, exporter, kibana_url).await?;
 
                 tokio::select! {
                     _ = tokio::signal::ctrl_c() => {
@@ -290,13 +293,17 @@ async fn run(cli: Cli) -> Result<&'static str> {
                 let known_host = Uri::try_from(host)?;
                 let output = Uri::try_from(output)?;
                 match known_host {
-                    Uri::KnownHost(_) | Uri::ElasticCloudAdmin(_) | Uri::ElasticGovCloudAdmin(_) => {
+                    Uri::KnownHost(_)
+                    | Uri::ElasticCloudAdmin(_)
+                    | Uri::ElasticGovCloudAdmin(_) => {
                         log::info!("Collecting diagnostic from {known_host}");
                         log::info!("Saving diagnostic to {output}");
                         let receiver = Receiver::try_from(known_host)?;
                         let output_dir = match output {
                             Uri::Directory(path) | Uri::File(path) => path,
-                            _ => return Err(eyre!("Collect output must be a local directory path")),
+                            _ => {
+                                return Err(eyre!("Collect output must be a local directory path"));
+                            }
                         };
                         let exporter = Exporter::for_collect_archive(output_dir)?;
 
@@ -448,14 +455,16 @@ async fn run(cli: Cli) -> Result<&'static str> {
                 .plugin(tauri_plugin_opener::init())
                 .setup(|app| {
                     use tauri::Manager;
-                    
+
                     let handle = app.handle().clone();
-                    
+
                     tauri::async_runtime::spawn(async move {
                         let settings = esdiag::data::Settings::load().unwrap_or_default();
-                        
+
                         let exporter = if let Some(target) = &settings.active_target {
-                            if let Ok(host) = esdiag::data::KnownHost::get_known(target).ok_or_else(|| eyre::eyre!("Host not found")) {
+                            if let Ok(host) = esdiag::data::KnownHost::get_known(target)
+                                .ok_or_else(|| eyre::eyre!("Host not found"))
+                            {
                                 if let Ok(uri) = Uri::try_from(host) {
                                     Exporter::try_from(uri).unwrap_or_default()
                                 } else {
@@ -467,7 +476,7 @@ async fn run(cli: Cli) -> Result<&'static str> {
                         } else {
                             Exporter::default()
                         };
-                        
+
                         let kibana_url = settings.kibana_url.unwrap_or_else(|| {
                             let url = esdiag::env::get_string("ESDIAG_KIBANA_URL")
                                 .unwrap_or_else(|_| "http://localhost:5601".to_string());
@@ -476,17 +485,18 @@ async fn run(cli: Cli) -> Result<&'static str> {
                                 None => url,
                             }
                         });
-                        
-                        let (mut server, bound_addr) = match Server::start([127, 0, 0, 1], 0, exporter, kibana_url).await {
-                            Ok(res) => res,
-                            Err(e) => {
-                                log::error!("Failed to start embedded server: {}", e);
-                                return;
-                            }
-                        };
-                        
+
+                        let (mut server, bound_addr) =
+                            match Server::start([127, 0, 0, 1], 0, exporter, kibana_url).await {
+                                Ok(res) => res,
+                                Err(e) => {
+                                    log::error!("Failed to start embedded server: {}", e);
+                                    return;
+                                }
+                            };
+
                         let url = format!("http://localhost:{}", bound_addr.port());
-                        
+
                         if let Ok(url) = tauri::Url::parse(&url) {
                             // Wait a tiny bit to ensure server is ready
                             tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
@@ -501,12 +511,12 @@ async fn run(cli: Cli) -> Result<&'static str> {
                                 let _ = window.set_focus();
                             }
                         }
-                        
+
                         // Wait for Tauri exit signal
                         let _ = shutdown_rx.recv().await;
                         server.shutdown().await;
                     });
-                    
+
                     Ok(())
                 })
                 .on_window_event(move |_window, event| {
@@ -518,7 +528,7 @@ async fn run(cli: Cli) -> Result<&'static str> {
                 })
                 .run(tauri::generate_context!())
                 .expect("error while running tauri application");
-            
+
             Ok("tauri")
         }
         #[cfg(not(all(feature = "server", feature = "desktop")))]
@@ -526,7 +536,9 @@ async fn run(cli: Cli) -> Result<&'static str> {
             use clap::CommandFactory;
             let mut cmd = Cli::command();
             cmd.print_help()?;
-            Err(eyre!("No command provided. If you want to use the Desktop UI, compile with the 'desktop' feature."))
+            Err(eyre!(
+                "No command provided. If you want to use the Desktop UI, compile with the 'desktop' feature."
+            ))
         }
     }
 }

--- a/src/processor/api.rs
+++ b/src/processor/api.rs
@@ -102,7 +102,7 @@ impl ElasticsearchApi {
         }
     }
 
-    pub fn from_str(s: &str) -> Result<Self> {
+    pub fn parse(s: &str) -> Result<Self> {
         match s {
             "alias" => Ok(ElasticsearchApi::AliasList),
             "cluster" => Ok(ElasticsearchApi::Cluster),
@@ -148,6 +148,14 @@ impl ElasticsearchApi {
     }
 }
 
+impl std::str::FromStr for ElasticsearchApi {
+    type Err = eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::parse(s)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum LogstashApi {
     Node,
@@ -169,12 +177,20 @@ impl LogstashApi {
         }
     }
 
-    pub fn from_str(s: &str) -> Result<Self> {
+    pub fn parse(s: &str) -> Result<Self> {
         match s {
             "node" => Ok(LogstashApi::Node),
             "node_stats" => Ok(LogstashApi::NodeStats),
             _ => Err(eyre!("Invalid Logstash API: {}", s)),
         }
+    }
+}
+
+impl std::str::FromStr for LogstashApi {
+    type Err = eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::parse(s)
     }
 }
 
@@ -274,14 +290,14 @@ impl ApiResolver {
 
         if let Some(incs) = include {
             for api in incs {
-                ElasticsearchApi::from_str(api)?;
+                ElasticsearchApi::parse(api)?;
                 requested.insert(api.to_string());
             }
         }
 
         if let Some(excs) = exclude {
             for api in excs {
-                ElasticsearchApi::from_str(api)?;
+                ElasticsearchApi::parse(api)?;
                 requested.swap_remove(api);
             }
         }
@@ -318,7 +334,7 @@ impl ApiResolver {
 
         let mut api_set: IndexSet<ElasticsearchApi> = IndexSet::new();
         for api in final_set.iter() {
-            api_set.insert(ElasticsearchApi::from_str(api)?);
+            api_set.insert(ElasticsearchApi::parse(api)?);
         }
 
         let apis: Vec<ElasticsearchApi> = api_set.into_iter().collect();
@@ -343,14 +359,14 @@ impl ApiResolver {
 
         if let Some(incs) = include {
             for api in incs {
-                LogstashApi::from_str(api)?;
+                LogstashApi::parse(api)?;
                 requested.insert(api.to_string());
             }
         }
 
         if let Some(excs) = exclude {
             for api in excs {
-                LogstashApi::from_str(api)?;
+                LogstashApi::parse(api)?;
                 requested.swap_remove(api);
             }
         }
@@ -387,7 +403,7 @@ impl ApiResolver {
 
         let mut apis = Vec::new();
         for api in final_set.iter() {
-            apis.push(LogstashApi::from_str(api)?);
+            apis.push(LogstashApi::parse(api)?);
         }
 
         Ok(apis)

--- a/src/processor/diagnostic/data_source.rs
+++ b/src/processor/diagnostic/data_source.rs
@@ -53,7 +53,7 @@ pub trait DataSource {
             PathType::File => Ok(source_conf.get_file_path(matched_name)),
             PathType::Url => {
                 let v = version.ok_or_else(|| eyre!("Version required for URL"))?;
-                source_conf.get_url(v).map_err(Into::into)
+                source_conf.get_url(v)
             }
         }
     }
@@ -167,13 +167,11 @@ fn convert_npm_semver_to_cargo(req: &str) -> String {
         out.push_str(parts[i]);
         if i + 1 < parts.len() {
             // If current part starts with a digit and next starts with an operator, insert comma.
-            if parts[i]
-                .chars()
-                .next()
-                .map_or(false, |c| c.is_ascii_digit())
-                && parts[i + 1].chars().next().map_or(false, |c| {
-                    c == '<' || c == '>' || c == '=' || c == '~' || c == '^'
-                })
+            if parts[i].chars().next().is_some_and(|c| c.is_ascii_digit())
+                && parts[i + 1]
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c == '<' || c == '>' || c == '=' || c == '~' || c == '^')
             {
                 out.push_str(", ");
             } else {

--- a/src/processor/diagnostic/data_stream_name.rs
+++ b/src/processor/diagnostic/data_stream_name.rs
@@ -22,8 +22,8 @@ impl From<&str> for DataStreamName {
     }
 }
 
-impl ToString for DataStreamName {
-    fn to_string(&self) -> String {
-        format!("{}-{}-{}", self.r#type, self.dataset, self.namespace)
+impl std::fmt::Display for DataStreamName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}-{}-{}", self.r#type, self.dataset, self.namespace)
     }
 }

--- a/src/processor/diagnostic/diagnostic_manifest.rs
+++ b/src/processor/diagnostic/diagnostic_manifest.rs
@@ -71,6 +71,7 @@ impl Clone for DiagnosticManifest {
 }
 
 impl DiagnosticManifest {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         collection_date: String,
         diagnostic: Option<String>,
@@ -82,7 +83,7 @@ impl DiagnosticManifest {
         runner: Option<String>,
         version: Option<String>,
     ) -> Self {
-        let collection_date_millis = Some(0 as u64);
+        let collection_date_millis = Some(0_u64);
         let diagnostic_id = RwLock::new(None);
         let name = r#type.clone().unwrap_or("diagnostic".to_string());
 
@@ -117,7 +118,7 @@ impl DiagnosticManifest {
         }
     }
 
-    pub fn diagnostic_id(&self, uuid: &String) -> String {
+    pub fn diagnostic_id(&self, uuid: &str) -> String {
         let mut id = self
             .diagnostic_id
             .write()

--- a/src/processor/diagnostic/doc.rs
+++ b/src/processor/diagnostic/doc.rs
@@ -43,7 +43,7 @@ impl TryFrom<DiagnosticManifest> for DiagnosticMetadata {
 
         Ok(DiagnosticMetadata::new(
             manifest.collection_date_in_millis(),
-            manifest.diagnostic_id(&uuid).clone(),
+            manifest.diagnostic_id(&uuid),
             runner,
             uuid,
         ))

--- a/src/processor/diagnostic/lookup.rs
+++ b/src/processor/diagnostic/lookup.rs
@@ -74,6 +74,11 @@ where
         self.entries.len()
     }
 
+    /// True when the lookup table has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
     /// Push a new entry into the lookup table
     pub fn add(&mut self, value: T) -> &mut Self {
         self.entries.push(value);

--- a/src/processor/diagnostic/manifest.rs
+++ b/src/processor/diagnostic/manifest.rs
@@ -35,6 +35,12 @@ pub struct ManifestBuilder {
     included_diagnostics: Option<Vec<DiagPath>>,
 }
 
+impl Default for ManifestBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ManifestBuilder {
     pub fn new() -> Self {
         Self {

--- a/src/processor/elasticsearch/cluster_settings/data.rs
+++ b/src/processor/elasticsearch/cluster_settings/data.rs
@@ -46,9 +46,7 @@ impl ClusterSettingsDefaults {
         };
 
         let name = name.as_str()?.chars().take(8).collect::<String>();
-        let project_type = project_type
-            .as_str()?
-            .trim_start_matches("elasticsearch_");
+        let project_type = project_type.as_str()?.trim_start_matches("elasticsearch_");
         Some(format!("{project_type}-{name}"))
     }
 }
@@ -76,10 +74,7 @@ mod tests {
             "transient": {}
         }"#;
         let settings: ClusterSettings = serde_json::from_str(json).expect("cluster settings parse");
-        assert_eq!(
-            settings.get_display_name().as_deref(),
-            Some("prod-cluster")
-        );
+        assert_eq!(settings.get_display_name().as_deref(), Some("prod-cluster"));
     }
 
     #[test]

--- a/src/processor/elasticsearch/cluster_settings/processor.rs
+++ b/src/processor/elasticsearch/cluster_settings/processor.rs
@@ -69,21 +69,21 @@ async fn export_cluster_settings_docs(
                 "cluster.max_shards_per_node.frozen": null,
                 "cluster.max_shards_per_node": null,
                 "cluster" : {
-                    "max_shards_per_node_frozen": settings.get("cluster.max_shards_per_node.frozen").take(),
-                    "max_shards_per_node": settings.get("cluster.max_shards_per_node").take(),
+                    "max_shards_per_node_frozen": settings.get("cluster.max_shards_per_node.frozen"),
+                    "max_shards_per_node": settings.get("cluster.max_shards_per_node"),
                     "routing" :{
                         "allocation" :{
                             "disk" : {
                                 "watermark" : {
-                                    "enable_for_single_data_node" : settings.get("cluster.routing.allocation.disk.watermark.enable_for_single_data_node").take(),
-                                    "flood_stage" : settings.get("cluster.routing.allocation.disk.watermark.flood_stage").take(),
-                                    "flood_stage.frozen" : settings.get("cluster.routing.allocation.disk.watermark.flood_stage.frozen").take(),
-                                    "flood_stage.frozen.max_headroom" : settings.get("cluster.routing.allocation.disk.watermark.flood_stage.frozen.max_headroom").take(),
-                                    "flood_stage.max_headroom" : settings.get("cluster.routing.allocation.disk.watermark.flood_stage.max_headroom").take(),
-                                    "high" : settings.get("cluster.routing.allocation.disk.watermark.high").take(),
-                                    "high.max_headroom" : settings.get("cluster.routing.allocation.disk.watermark.high.max_headroom").take(),
-                                    "low" : settings.get("cluster.routing.allocation.disk.watermark.low").take(),
-                                    "low_max_headroom" : settings.get("cluster.routing.allocation.disk.watermark.low.max_headroom").take(),
+                                    "enable_for_single_data_node" : settings.get("cluster.routing.allocation.disk.watermark.enable_for_single_data_node"),
+                                    "flood_stage" : settings.get("cluster.routing.allocation.disk.watermark.flood_stage"),
+                                    "flood_stage.frozen" : settings.get("cluster.routing.allocation.disk.watermark.flood_stage.frozen"),
+                                    "flood_stage.frozen.max_headroom" : settings.get("cluster.routing.allocation.disk.watermark.flood_stage.frozen.max_headroom"),
+                                    "flood_stage.max_headroom" : settings.get("cluster.routing.allocation.disk.watermark.flood_stage.max_headroom"),
+                                    "high" : settings.get("cluster.routing.allocation.disk.watermark.high"),
+                                    "high.max_headroom" : settings.get("cluster.routing.allocation.disk.watermark.high.max_headroom"),
+                                    "low" : settings.get("cluster.routing.allocation.disk.watermark.low"),
+                                    "low_max_headroom" : settings.get("cluster.routing.allocation.disk.watermark.low.max_headroom"),
                                 }
                             }
 
@@ -93,15 +93,15 @@ async fn export_cluster_settings_docs(
                 "http.type": null,
                 "http.type.default": null,
                 "http": {
-                    "type.current": settings.get("http.type").take(),
-                    "type.default": settings.get("http.type.default").take(),
+                    "type.current": settings.get("http.type"),
+                    "type.default": settings.get("http.type.default"),
                 },
                 "thread_pool.estimated_time_interval.warn_threshold": null,
                 "transport.type": null,
                 "transport.type.default": null,
                 "transport": {
-                    "type.current": settings.get("transport.type").take(),
-                    "type.default": settings.get("transport.type.default").take(),
+                    "type.current": settings.get("transport.type"),
+                    "type.default": settings.get("transport.type.default"),
                 },
                 "xpack.searchable.snapshot.shared_cache.size.max_headroom": null,
             });

--- a/src/processor/elasticsearch/collector.rs
+++ b/src/processor/elasticsearch/collector.rs
@@ -260,7 +260,7 @@ impl ElasticsearchCollector {
         }
     }
 
-    async fn save_diagnostic_manifest(&self, apis: &Vec<ElasticsearchApi>) -> Result<usize> {
+    async fn save_diagnostic_manifest(&self, apis: &[ElasticsearchApi]) -> Result<usize> {
         let cluster = self.receiver.get::<Cluster>().await?;
         let collected_api_names: Vec<String> =
             apis.iter().map(|a| a.as_str().to_string()).collect();

--- a/src/processor/elasticsearch/data_stream/lookup.rs
+++ b/src/processor/elasticsearch/data_stream/lookup.rs
@@ -119,14 +119,14 @@ mod tests {
             .by_id(".ds-metrics-index-esdiag-2025.11.20-000004")
             .unwrap();
         assert_eq!(doc_base.name, "metrics-index-esdiag");
-        assert_eq!(doc_base.is_write_index, false);
+        assert!(!doc_base.is_write_index);
 
         // Check write backing index (last in the list)
         let doc_write = lookup
             .by_id(".ds-metrics-index-esdiag-2025.11.21-000005")
             .unwrap();
         assert_eq!(doc_write.name, "metrics-index-esdiag");
-        assert_eq!(doc_write.is_write_index, true);
+        assert!(doc_write.is_write_index);
 
         // Check failure store index
         let doc_fs = lookup
@@ -136,10 +136,10 @@ mod tests {
         assert_eq!(doc_fs.r#type, "metrics");
         assert_eq!(doc_fs.dataset, "index");
         assert_eq!(doc_fs.namespace, "esdiag");
-        assert_eq!(doc_fs.is_write_index, false);
+        assert!(!doc_fs.is_write_index);
 
         // Check by_name returns the write document (the last one mapped to the name)
         let doc_name = lookup.by_name("metrics-index-esdiag").unwrap();
-        assert_eq!(doc_name.is_write_index, true);
+        assert!(doc_name.is_write_index);
     }
 }

--- a/src/processor/elasticsearch/health_report/processor.rs
+++ b/src/processor/elasticsearch/health_report/processor.rs
@@ -18,13 +18,13 @@ impl DocumentExporter<Lookups, ElasticsearchMetadata> for HealthReport {
     ) -> ProcessorSummary {
         log::debug!("processing pending tasks");
         let metadata_indicator = metadata
-            .for_data_stream(&"health-indicator-esdiag".to_string())
+            .for_data_stream("health-indicator-esdiag")
             .as_meta_doc();
         let metadata_impact = metadata
-            .for_data_stream(&"health-impact-esdiag".to_string())
+            .for_data_stream("health-impact-esdiag")
             .as_meta_doc();
         let metadata_diagnosis = metadata
-            .for_data_stream(&"health-diagnosis-esdiag".to_string())
+            .for_data_stream("health-diagnosis-esdiag")
             .as_meta_doc();
 
         let mut indicators: Vec<(String, HealthIndicator)> =
@@ -38,40 +38,37 @@ impl DocumentExporter<Lookups, ElasticsearchMetadata> for HealthReport {
 
                 if let Some(mut impacts) = indicator.impacts.take() {
                     impacts.drain(..).for_each(|impact| {
-                        match serde_json::to_value(HealthImpactDoc {
+                        if let Ok(value) = serde_json::to_value(HealthImpactDoc {
                             health: Impact {
                                 indicator: named_health_indicator.clone(),
                                 impact,
                             },
                             metadata: metadata_impact.clone(),
                         }) {
-                            Ok(value) => docs.push(value),
-                            Err(_) => {}
+                            docs.push(value)
                         }
                     });
                 };
 
                 if let Some(mut diagnosis) = indicator.diagnosis.take() {
                     diagnosis.drain(..).for_each(|diagnosis| {
-                        match serde_json::to_value(HealthDiagnosisDoc {
+                        if let Ok(value) = serde_json::to_value(HealthDiagnosisDoc {
                             health: Diagnosis {
                                 diagnosis,
                                 indicator: named_health_indicator.clone(),
                             },
                             metadata: metadata_diagnosis.clone(),
                         }) {
-                            Ok(value) => docs.push(value),
-                            Err(_) => {}
+                            docs.push(value)
                         }
                     });
                 }
 
-                match serde_json::to_value(HealthIndicatorDoc {
+                if let Ok(value) = serde_json::to_value(HealthIndicatorDoc {
                     health: named_health_indicator,
                     metadata: metadata_indicator.clone(),
                 }) {
-                    Ok(value) => docs.push(value),
-                    Err(_) => {}
+                    docs.push(value)
                 };
                 docs
             })

--- a/src/processor/elasticsearch/indices_settings/data.rs
+++ b/src/processor/elasticsearch/indices_settings/data.rs
@@ -106,7 +106,7 @@ impl IndexSettings {
 
     /// Sets the data stream for the index
     pub fn data_stream(self, data_stream: Option<DataStreamDocument>) -> Self {
-        let is_data_stream_write_index = data_stream.as_ref().map_or(false, |ds| ds.is_write_index);
+        let is_data_stream_write_index = data_stream.as_ref().is_some_and(|ds| ds.is_write_index);
         Self {
             data_stream,
             is_write_index: self.is_write_index || is_data_stream_write_index,

--- a/src/processor/elasticsearch/indices_stats/processor.rs
+++ b/src/processor/elasticsearch/indices_stats/processor.rs
@@ -651,7 +651,7 @@ impl TryFrom<Stats> for EnrichedStats {
             bulk: EnrichedBulk::from(stats.bulk),
             completion: stats.completion,
             dense_vector: stats.dense_vector,
-            docs: stats.docs.map(|docs| EnrichedDocs::from(docs)),
+            docs: stats.docs.map(EnrichedDocs::from),
             fielddata: stats.fielddata,
             flush: stats.flush,
             get: stats.get,

--- a/src/processor/elasticsearch/indices_stats/tests.rs
+++ b/src/processor/elasticsearch/indices_stats/tests.rs
@@ -80,7 +80,6 @@ async fn test_streaming_deserialization() {
     handle.await.unwrap();
 }
 
-
 #[tokio::test]
 async fn test_streaming_deserialization_handles_receiver_closed_mid_stream() {
     use crate::processor::diagnostic::data_source::StreamingDataSource;

--- a/src/processor/elasticsearch/nodes_stats/data.rs
+++ b/src/processor/elasticsearch/nodes_stats/data.rs
@@ -148,7 +148,7 @@ struct LoadAverage {
     fifteen: f64,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Default)]
 struct LoadPercent {
     #[serde(rename = "1m")]
     one: usize,
@@ -156,16 +156,6 @@ struct LoadPercent {
     five: usize,
     #[serde(rename = "15m")]
     fifteen: usize,
-}
-
-impl Default for LoadPercent {
-    fn default() -> Self {
-        LoadPercent {
-            one: 0,
-            five: 0,
-            fifteen: 0,
-        }
-    }
 }
 
 #[derive(Deserialize, Serialize)]

--- a/src/processor/elasticsearch/nodes_stats/processor.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor.rs
@@ -59,7 +59,7 @@ async fn process_node(
                 // Since actions_metadata is pre-serialized, we need a Value for merge in transport_actions::extract
                 // For now, transport_actions::extract still expects &Value.
                 // We'll convert it back if needed or update the helper.
-                let actions_meta_val = serde_json::to_value(&ctx.actions_metadata).unwrap();
+                let actions_meta_val = serde_json::to_value(ctx.actions_metadata).unwrap();
                 if let Err(e) = transport_actions::extract(
                     ctx.actions_tx,
                     actions,
@@ -93,7 +93,7 @@ async fn process_node(
     if let Ok(mut http_val) = serde_json::from_str::<Value>(node_stats.http.get()) {
         let clients = http_val["clients"].take();
         if !clients.is_null() {
-            let http_meta_val = serde_json::to_value(&ctx.http_clients_metadata).unwrap();
+            let http_meta_val = serde_json::to_value(ctx.http_clients_metadata).unwrap();
             if let Err(e) =
                 http_clients::extract(ctx.http_clients_tx, clients, &http_meta_val, node_metadata)
                     .await
@@ -110,20 +110,20 @@ async fn process_node(
     }
 
     // Extract adaptive replica selection stats
-    if let Some(adaptive_raw) = node_stats.adaptive_selection.take() {
-        if let Ok(adaptive_val) = serde_json::from_str::<Value>(adaptive_raw.get()) {
-            let adaptive_meta_val = serde_json::to_value(&ctx.adaptive_metadata).unwrap();
-            if let Err(e) = adaptive_selections::extract(
-                ctx.adaptive_tx,
-                Some(adaptive_val),
-                &adaptive_meta_val,
-                node_metadata,
-                lookup_node,
-            )
-            .await
-            {
-                log::error!("Error extracting adaptive selection stats: {}", e);
-            }
+    if let Some(adaptive_raw) = node_stats.adaptive_selection.take()
+        && let Ok(adaptive_val) = serde_json::from_str::<Value>(adaptive_raw.get())
+    {
+        let adaptive_meta_val = serde_json::to_value(ctx.adaptive_metadata).unwrap();
+        if let Err(e) = adaptive_selections::extract(
+            ctx.adaptive_tx,
+            Some(adaptive_val),
+            &adaptive_meta_val,
+            node_metadata,
+            lookup_node,
+        )
+        .await
+        {
+            log::error!("Error extracting adaptive selection stats: {}", e);
         }
     }
 
@@ -131,7 +131,7 @@ async fn process_node(
     if let Ok(mut discovery_val) = serde_json::from_str::<Value>(node_stats.discovery.get()) {
         let cluster_applier_stats = discovery_val["cluster_applier_stats"].take();
         if !cluster_applier_stats.is_null() {
-            let applier_meta_val = serde_json::to_value(&ctx.applier_metadata).unwrap();
+            let applier_meta_val = serde_json::to_value(ctx.applier_metadata).unwrap();
             if let Err(e) = cluster_applier_stats::extract(
                 ctx.applier_tx,
                 cluster_applier_stats,
@@ -152,8 +152,8 @@ async fn process_node(
     }
 
     // Extract ingest pipeline stats, but only on nodes with the `ingest` role
-    if node_stats.roles.contains(&*INGEST_ROLE) {
-        if let Err(e) = ingest_pipelines::extract(
+    if node_stats.roles.contains(&*INGEST_ROLE)
+        && let Err(e) = ingest_pipelines::extract(
             ctx.pipelines_tx,
             ctx.processors_tx,
             node_stats.ingest.pipelines.take(),
@@ -161,9 +161,8 @@ async fn process_node(
             node_metadata,
         )
         .await
-        {
-            log::error!("Error extracting ingest pipelines stats: {}", e);
-        }
+    {
+        log::error!("Error extracting ingest pipelines stats: {}", e);
     }
 
     // Final node_stats document
@@ -179,7 +178,7 @@ async fn process_node(
     });
 
     let node_summary_patch = json!({"node": node_metadata});
-    let node_stats_meta_val = serde_json::to_value(&ctx.node_stats_metadata).unwrap();
+    let node_stats_meta_val = serde_json::to_value(ctx.node_stats_metadata).unwrap();
 
     merge(&mut doc, &node_stats_meta_val);
     merge(&mut doc, &node_summary_patch);

--- a/src/processor/elasticsearch/nodes_stats/processor/adaptive_selections.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/adaptive_selections.rs
@@ -40,7 +40,7 @@ pub async fn extract(
                 });
 
                 merge(&mut doc, &peer_node_patch);
-                merge(&mut doc, &metadata);
+                merge(&mut doc, metadata);
                 doc
             }),
     );

--- a/src/processor/elasticsearch/nodes_stats/processor/cluster_applier_stats.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/cluster_applier_stats.rs
@@ -26,7 +26,7 @@ pub async fn extract(
             "node": node_metadata,
         });
 
-        merge(&mut doc, &metadata);
+        merge(&mut doc, metadata);
         doc
     }));
 

--- a/src/processor/elasticsearch/nodes_stats/processor/http_clients.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/http_clients.rs
@@ -23,7 +23,7 @@ pub async fn extract(
     let mut docs = Vec::<Value>::with_capacity(200);
     docs.par_extend(clients.par_drain(..).map(|client| {
         let mut doc = json!({ "node": node_metadata, "http": { "client": client }});
-        merge(&mut doc, &metadata);
+        merge(&mut doc, metadata);
         doc
     }));
 

--- a/src/processor/elasticsearch/nodes_stats/processor/transport_actions.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/transport_actions.rs
@@ -9,7 +9,6 @@ use serde_json::{Value, json};
 use tokio::sync::mpsc::Sender;
 
 /// Extract transport.actions
-
 pub async fn extract(
     sender: &Sender<Value>,
     mut actions: Value,
@@ -43,7 +42,7 @@ pub async fn extract(
                 });
 
                 merge(&mut action, &action_patch);
-                merge(&mut action, &metadata);
+                merge(&mut action, metadata);
                 action
             }),
     );

--- a/src/processor/elasticsearch/tasks/processor.rs
+++ b/src/processor/elasticsearch/tasks/processor.rs
@@ -118,18 +118,15 @@ pub struct TaskWithParent {
 
 impl TaskData {
     pub fn new((action, description): (String, Option<String>)) -> Option<Self> {
-        let description = match description {
-            Some(description) => description,
-            None => return None,
-        };
+        let description = description?;
 
         let action = match action.split_once(":") {
-            Some((target, action)) if target == "indices" => action,
+            Some(("indices", action)) => action,
             _ => return None,
         };
 
         let kind = match action.splitn(3, "/").collect::<Vec<&str>>()[1..] {
-            [operation, kind] if operation == "write" => kind,
+            ["write", kind] => kind,
             _ => return None,
         };
 
@@ -166,7 +163,7 @@ impl TaskData {
                         bulk: None,
                     }),
                     shard: Some(TaskShard {
-                        number: number,
+                        number,
                         primary: Some(is_primary),
                         bulk: Some(BulkDocs { docs }),
                     }),

--- a/src/processor/logstash/metadata.rs
+++ b/src/processor/logstash/metadata.rs
@@ -27,7 +27,7 @@ pub struct MetadataDoc {
 
 impl Metadata for MetadataDoc {
     fn as_meta_doc(&self) -> Value {
-        serde_json::to_value(&self).expect("Failed to serialize metadata")
+        serde_json::to_value(self).expect("Failed to serialize metadata")
     }
 }
 

--- a/src/processor/logstash/node/data.rs
+++ b/src/processor/logstash/node/data.rs
@@ -25,10 +25,7 @@ impl Node {
     }
 
     pub fn take_pipelines(&mut self) -> HashMap<String, Pipeline> {
-        match self.pipelines.take() {
-            Some(pipelines) => pipelines,
-            None => HashMap::new(),
-        }
+        self.pipelines.take().unwrap_or_default()
     }
 }
 

--- a/src/processor/logstash/node/processor.rs
+++ b/src/processor/logstash/node/processor.rs
@@ -55,7 +55,7 @@ struct Count {
 impl LogstashNodeDoc {
     fn new(node: Node, metadata: Value, plugin_count: u32) -> Self {
         let pipeline_count = node.get_pipeline_count();
-        let mut node_with_metadata = json!(metadata.get("node").take());
+        let mut node_with_metadata = json!(metadata.get("node"));
         json_patch::merge(&mut node_with_metadata, &json!(node));
 
         Self {

--- a/src/processor/logstash/node_stats/processor.rs
+++ b/src/processor/logstash/node_stats/processor.rs
@@ -17,10 +17,10 @@ impl DocumentExporter<Lookups, LogstashMetadata> for NodeStats {
         metadata: &LogstashMetadata,
     ) -> ProcessorSummary {
         let mut docs: Vec<Value> = Vec::new();
-        self.take_pipelines().map(|pipelines| {
+        if let Some(pipelines) = self.take_pipelines() {
             let mut pipeline_docs = generate_pipeline_docs(metadata, pipelines);
             docs.append(&mut pipeline_docs);
-        });
+        }
 
         let data_stream = "metrics-logstash.node-esdiag".to_string();
         let metadata_doc = metadata.for_data_stream(&data_stream).as_meta_doc();
@@ -45,7 +45,7 @@ struct NodeStatsDoc {
 
 impl NodeStatsDoc {
     fn new(node: NodeStats, metadata: Value) -> Self {
-        let mut node_with_metadata = json!(metadata.get("node").take());
+        let mut node_with_metadata = json!(metadata.get("node"));
         json_patch::merge(&mut node_with_metadata, &json!(node));
 
         Self {
@@ -67,10 +67,10 @@ fn generate_pipeline_docs(
     let mut pipeline_docs: Vec<Value> = pipelines
         .into_iter()
         .map(|(name, mut stats)| {
-            stats.take_plugins().map(|plugins| {
+            if let Some(plugins) = stats.take_plugins() {
                 let mut docs = generate_plugin_docs(metadata, plugins);
                 plugin_docs.append(&mut docs);
-            });
+            }
             json!(PipelineDoc::new(name, stats, pipeline_metadata_doc.clone()))
         })
         .collect();

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -331,7 +331,7 @@ impl Processor<Processing> {
                 / (1000 * 60 * 60 * 24);
             let time_filter = match days_since_collection {
                 x if x < 90 => "from:now-90d,to:now",
-                x if x >= 90 && x < 365 => "from:now-1y,to:now",
+                x if (90..365).contains(&x) => "from:now-1y,to:now",
                 x => &format!("from:now-{}d,to:now", x + 1),
             };
             let kibana_link = format!(

--- a/src/receiver/archive.rs
+++ b/src/receiver/archive.rs
@@ -7,7 +7,11 @@ use async_stream::stream;
 use eyre::Result;
 use futures::stream::BoxStream;
 use serde::de::DeserializeOwned;
-use std::{io::{BufReader, Read, Seek}, path::PathBuf, sync::Arc};
+use std::{
+    io::{BufReader, Read, Seek},
+    path::PathBuf,
+    sync::Arc,
+};
 use tokio::sync::{RwLock, mpsc};
 use zip::ZipArchive;
 
@@ -52,7 +56,8 @@ where
             Ok(file) => {
                 let reader = BufReader::new(file);
                 let mut deserializer = serde_json::Deserializer::from_reader(reader);
-                T::deserialize_stream(&mut deserializer, tx.clone()).map_err(|e| eyre::eyre!(e.to_string()))
+                T::deserialize_stream(&mut deserializer, tx.clone())
+                    .map_err(|e| eyre::eyre!(e.to_string()))
             }
             Err(e) => Err(eyre::eyre!(e)),
         };
@@ -64,12 +69,12 @@ where
     });
 
     tokio::spawn(async move {
-        if let Err(e) = handle.await {
-            if e.is_panic() {
-                let _ = tx_err
-                    .send(Err(eyre::eyre!("Streaming task panicked")))
-                    .await;
-            }
+        if let Err(e) = handle.await
+            && e.is_panic()
+        {
+            let _ = tx_err
+                .send(Err(eyre::eyre!("Streaming task panicked")))
+                .await;
         }
     });
 
@@ -82,7 +87,7 @@ where
 
 pub fn trim_to_working_directory(path: &mut PathBuf) {
     // Drop any filename
-    if path.extension() != None {
+    if path.extension().is_some() {
         path.pop();
     }
     // Drop any known subdirectories

--- a/src/receiver/archive/bytes.rs
+++ b/src/receiver/archive/bytes.rs
@@ -74,7 +74,10 @@ impl Receive for ArchiveBytesReceiver {
 
         match last_resolve_error {
             Some(e) => Err(e),
-            None => Err(eyre!("No candidate source files available for {}", T::name())),
+            None => Err(eyre!(
+                "No candidate source files available for {}",
+                T::name()
+            )),
         }
     }
 

--- a/src/receiver/archive/file.rs
+++ b/src/receiver/archive/file.rs
@@ -103,7 +103,10 @@ impl Receive for ArchiveFileReceiver {
 
         match last_resolve_error {
             Some(e) => Err(e),
-            None => Err(eyre!("No candidate source files available for {}", T::name())),
+            None => Err(eyre!(
+                "No candidate source files available for {}",
+                T::name()
+            )),
         }
     }
 
@@ -144,7 +147,10 @@ impl ReceiveRaw for ArchiveFileReceiver {
 
         match last_resolve_error {
             Some(e) => Err(e),
-            None => Err(eyre!("No candidate source files available for {}", T::name())),
+            None => Err(eyre!(
+                "No candidate source files available for {}",
+                T::name()
+            )),
         }
     }
 }

--- a/src/receiver/directory.rs
+++ b/src/receiver/directory.rs
@@ -4,10 +4,10 @@
 
 use super::super::processor::{DataSource, PathType, StreamingDataSource};
 use super::{Receive, ReceiveMultiple, ReceiveRaw};
+use crate::processor::diagnostic::data_source::get_source;
 use async_stream::stream;
 use eyre::{Result, eyre};
 use futures::stream::BoxStream;
-use crate::processor::diagnostic::data_source::get_source;
 use serde::de::DeserializeOwned;
 use std::{
     fs::File,
@@ -90,7 +90,10 @@ impl Receive for DirectoryReceiver {
 
         match last_open_error {
             Some(e) => Err(e.into()),
-            None => Err(eyre!("No candidate source files available for {}", T::name())),
+            None => Err(eyre!(
+                "No candidate source files available for {}",
+                T::name()
+            )),
         }
     }
 
@@ -165,7 +168,10 @@ impl ReceiveRaw for DirectoryReceiver {
 
         match last_open_error {
             Some(e) => Err(e.into()),
-            None => Err(eyre!("No candidate source files available for {}", T::name())),
+            None => Err(eyre!(
+                "No candidate source files available for {}",
+                T::name()
+            )),
         }
     }
 }

--- a/src/receiver/elastic_cloud_admin.rs
+++ b/src/receiver/elastic_cloud_admin.rs
@@ -135,7 +135,7 @@ impl Receive for ElasticCloudAdminReceiver {
             .runner("esdiag")
             .collection_date(collection_date)
             .build();
-        Ok(manifest.try_into()?)
+        Ok(manifest.into())
     }
 }
 

--- a/src/receiver/elasticsearch.rs
+++ b/src/receiver/elasticsearch.rs
@@ -207,7 +207,7 @@ impl Receive for ElasticsearchReceiver {
             .runner("esdiag")
             .collection_date(collection_date)
             .build();
-        Ok(manifest.try_into()?)
+        Ok(manifest.into())
     }
 }
 

--- a/src/receiver/mod.rs
+++ b/src/receiver/mod.rs
@@ -55,7 +55,7 @@ pub trait Receive {
         match self.get::<Manifest>().await {
             Ok(manifest) => {
                 log::warn!("Falling back to manifest.json");
-                return Ok(manifest.try_into()?);
+                return Ok(manifest.into());
             }
             Err(e) => log::debug!("Error reading manifest.json: {e}"),
         }
@@ -65,7 +65,7 @@ pub trait Receive {
         Ok(ManifestBuilder::from(cluster)
             .collection_date(collection_date)
             .build()
-            .try_into()?)
+            .into())
     }
 }
 

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -42,7 +42,7 @@ pub async fn service_link(
                     })),
                 );
             }
-            if &payload.token == "" {
+            if payload.token.is_empty() {
                 return (
                     StatusCode::BAD_REQUEST,
                     Json(json!({
@@ -210,9 +210,12 @@ pub async fn api_key(
         // Create and start the processor
         let processor = match Processor::try_new(receiver, exporter, identifiers).await {
             Ok(processor) => {
-                log::debug!("[fsm][api.api_key] try_new ok: processor_id={}, job_id={job_id}", processor.id);
+                log::debug!(
+                    "[fsm][api.api_key] try_new ok: processor_id={}, job_id={job_id}",
+                    processor.id
+                );
                 processor
-            },
+            }
             Err(error) => {
                 log::error!("Failed to create processor: {}", error);
                 state.record_failure().await;
@@ -225,12 +228,18 @@ pub async fn api_key(
             }
         };
 
-        log::debug!("[fsm][api.api_key] ready->start: processor_id={}, job_id={job_id}", processor.id);
+        log::debug!(
+            "[fsm][api.api_key] ready->start: processor_id={}, job_id={job_id}",
+            processor.id
+        );
         let processing = match processor.start().await {
             Ok(processing) => {
-                log::debug!("[fsm][api.api_key] start ok -> processing: processor_id={}, job_id={job_id}", processing.id);
+                log::debug!(
+                    "[fsm][api.api_key] start ok -> processing: processor_id={}, job_id={job_id}",
+                    processing.id
+                );
                 processing
-            },
+            }
             Err(failed) => {
                 log::error!("Failed to start processor: {}", failed.state.error);
                 state.record_failure().await;
@@ -244,10 +253,16 @@ pub async fn api_key(
         };
 
         // Process the job
-        log::debug!("[fsm][api.api_key] processing->process await: processor_id={}, job_id={job_id}", processing.id);
+        log::debug!(
+            "[fsm][api.api_key] processing->process await: processor_id={}, job_id={job_id}",
+            processing.id
+        );
         match processing.process().await {
             Ok(completed) => {
-                log::debug!("[fsm][api.api_key] process ok -> completed: processor_id={}, job_id={job_id}", completed.id);
+                log::debug!(
+                    "[fsm][api.api_key] process ok -> completed: processor_id={}, job_id={job_id}",
+                    completed.id
+                );
                 let report = &completed.state.report;
                 state
                     .record_success(report.diagnostic.docs.total, report.diagnostic.docs.errors)
@@ -266,7 +281,10 @@ pub async fn api_key(
                 (StatusCode::OK, Json(response))
             }
             Err(failed) => {
-                log::debug!("[fsm][api.api_key] process failed -> failed: processor_id={}, job_id={job_id}", failed.id);
+                log::debug!(
+                    "[fsm][api.api_key] process failed -> failed: processor_id={}, job_id={job_id}",
+                    failed.id
+                );
                 log::error!("Processing failed: {}", failed.state.error);
                 state.record_failure().await;
                 (

--- a/src/server/docs.rs
+++ b/src/server/docs.rs
@@ -179,7 +179,7 @@ fn generate_toc() -> Vec<TocEntry> {
             .map(|c| c.as_os_str().to_string_lossy().into_owned())
             .unwrap_or_default();
 
-        if path.parent().map_or(true, |p| p.as_os_str().is_empty()) {
+        if path.parent().is_none_or(|p| p.as_os_str().is_empty()) {
             root_files.push(file.trim_end_matches(".md").to_string());
         } else {
             let display_path = file.trim_end_matches(".md").to_string();

--- a/src/server/file_upload.rs
+++ b/src/server/file_upload.rs
@@ -148,7 +148,7 @@ pub async fn process(
             None =>{
                 yield patch_signals(r#"{"processing":false}"#);
                 yield patch_template(template::JobFailed {
-                    job_id: job_id,
+                    job_id,
                     error: "Failed to upload file",
                     source: "User upload",
                 });
@@ -163,7 +163,7 @@ pub async fn process(
             log::error!("{}", error);
             yield patch_signals(r#"{"processing":false}"#);
             yield patch_template(template::JobFailed {
-                job_id: job_id,
+                job_id,
                 error: "Failed to stage uploaded file",
                 source: &filename,
             });
@@ -181,7 +181,7 @@ pub async fn process(
                 log::error!("{}", error);
                 yield patch_signals(r#"{"processing":false}"#);
                 yield patch_template(template::JobFailed {
-                    job_id: job_id,
+                    job_id,
                     error: "Failed to create file receiver",
                     source: &filename,
                 });
@@ -220,7 +220,7 @@ pub async fn process(
                         let report = &completed.state.report;
                         state.record_success(report.diagnostic.docs.total, report.diagnostic.docs.errors).await;
                         yield patch_template(template::JobCompleted {
-                            job_id: job_id,
+                            job_id,
                             diagnostic_id: &report.diagnostic.metadata.id,
                             docs_created: &report.diagnostic.docs.created,
                             duration: &format!("{:.3}", report.diagnostic.processing_duration as f64 / 1000.0),
@@ -232,7 +232,7 @@ pub async fn process(
                     Err(failed) => {
                         state.record_failure().await;
                         yield patch_template(template::JobFailed {
-                            job_id: job_id,
+                            job_id,
                             error: &failed.state.error,
                             source: &filename,
                         });
@@ -242,7 +242,7 @@ pub async fn process(
             Err(failed) => {
                 state.record_failure().await;
                 yield patch_template(template::JobFailed {
-                    job_id: job_id,
+                    job_id,
                     error: &failed.state.error,
                     source: &filename,
                 });

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -35,10 +35,12 @@ use axum::{
 };
 use bytes::Bytes;
 use datastar::prelude::{ElementPatchMode, PatchElements, PatchSignals};
-use serde::{Deserialize, Serialize};
 use eyre::Result;
+use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::Infallible, net::SocketAddr, sync::Arc};
 use tokio::sync::{RwLock, mpsc};
+
+type UploadReceiver = Arc<RwLock<mpsc::Receiver<(Identifiers, Bytes)>>>;
 
 #[derive(Deserialize, Serialize)]
 struct UploadServiceRequest {
@@ -69,11 +71,16 @@ impl From<ApiKeyRequest> for Identifiers {
 #[derive(Clone)]
 pub struct Server {
     server_handle: Option<Arc<tokio::task::JoinHandle<()>>>,
-    pub rx: Option<Arc<RwLock<mpsc::Receiver<(Identifiers, Bytes)>>>>,
+    pub rx: Option<UploadReceiver>,
 }
 
 impl Server {
-    pub async fn start(bind_addr: [u8; 4], port: u16, mut exporter: Exporter, kibana_url: String) -> Result<(Self, std::net::SocketAddr)> {
+    pub async fn start(
+        bind_addr: [u8; 4],
+        port: u16,
+        mut exporter: Exporter,
+        kibana_url: String,
+    ) -> Result<(Self, std::net::SocketAddr)> {
         let (_, rx) = mpsc::channel::<(Identifiers, Bytes)>(1);
         let rx = Arc::new(RwLock::new(rx));
         let rx_clone = rx.clone();
@@ -154,10 +161,13 @@ impl Server {
             .ok_or_else(|| eyre::eyre!("Server failed to bind"))?;
         log::info!("Listening on port {}", bound_addr.port());
 
-        Ok((Self {
-            server_handle: Some(Arc::new(server_handle)),
-            rx: Some(rx_clone),
-        }, bound_addr))
+        Ok((
+            Self {
+                server_handle: Some(Arc::new(server_handle)),
+                rx: Some(rx_clone),
+            },
+            bound_addr,
+        ))
     }
 
     pub async fn shutdown(&mut self) {
@@ -409,7 +419,7 @@ pub(super) fn get_user_email(headers: &HeaderMap) -> (bool, Option<String>) {
                 .and_then(|value| value.to_str().ok())
                 .map(|email| {
                     // Google auth headers are typically in format "accounts.google.com:email"
-                    email.split(':').last().unwrap_or(email).to_string()
+                    email.split(':').next_back().unwrap_or(email).to_string()
                 });
             (has_header, email)
         }
@@ -473,20 +483,16 @@ async fn add_client_hint_headers(mut response: Response) -> Response {
 #[cfg(test)]
 mod tests {
     use super::Server;
-    use crate::exporter::Exporter;
     #[cfg(feature = "desktop")]
     use super::Signals;
+    use crate::exporter::Exporter;
 
     #[tokio::test]
     async fn start_with_ephemeral_port_binds_and_reports_socket() {
-        let (mut server, bound_addr) = Server::start(
-            [127, 0, 0, 1],
-            0,
-            Exporter::default(),
-            String::new(),
-        )
-        .await
-        .expect("server should bind on ephemeral port");
+        let (mut server, bound_addr) =
+            Server::start([127, 0, 0, 1], 0, Exporter::default(), String::new())
+                .await
+                .expect("server should bind on ephemeral port");
 
         assert!(bound_addr.ip().is_loopback());
         assert!(bound_addr.port() > 0);

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -1,7 +1,7 @@
 use super::ServerState;
-use crate::server::template::SettingsModal;
 use crate::data::{KnownHost, KnownHostBuilder, Settings, Uri};
 use crate::exporter::Exporter;
+use crate::server::template::SettingsModal;
 use askama::Template;
 use async_stream::stream;
 use axum::{
@@ -14,10 +14,10 @@ use std::sync::Arc;
 
 pub async fn get_modal(State(state): State<Arc<ServerState>>) -> impl IntoResponse {
     let settings = Settings::load().unwrap_or_default();
-    
+
     // Get list of known hosts from file
     let hosts = KnownHost::list_all().unwrap_or_default();
-    
+
     let active_target = settings.active_target.clone().unwrap_or_default();
     let kibana_url = state.kibana_url.read().await.clone();
 
@@ -56,77 +56,80 @@ pub async fn update_settings(
     // 1. Process target selection
     if form.target == "new_host" {
         // Build new host
-        if let (Some(name), Some(url)) = (&form.new_host_name, &form.new_host_url) {
-            if !name.is_empty() && !url.is_empty() {
-                match url.parse() {
-                    Ok(parsed_url) => {
-                        let mut builder = KnownHostBuilder::new(parsed_url);
-                        
-                        if let Some(apikey) = &form.new_host_apikey {
-                            if !apikey.is_empty() {
-                                builder = builder.apikey(Some(apikey.clone()));
-                            }
-                        } else if let (Some(user), Some(pass)) = (&form.new_host_username, &form.new_host_password) {
-                            if !user.is_empty() && !pass.is_empty() {
-                                builder = builder.username(Some(user.clone())).password(Some(pass.clone()));
-                            }
+        if let (Some(name), Some(url)) = (&form.new_host_name, &form.new_host_url)
+            && !name.is_empty()
+            && !url.is_empty()
+        {
+            match url.parse() {
+                Ok(parsed_url) => {
+                    let mut builder = KnownHostBuilder::new(parsed_url);
+
+                    if let Some(apikey) = &form.new_host_apikey {
+                        if !apikey.is_empty() {
+                            builder = builder.apikey(Some(apikey.clone()));
                         }
-                        
-                        match builder.build() {
-                            Ok(host) => {
-                                // Validate connection before saving
-                                let is_valid = match Uri::try_from(host.clone()) {
-                                    Ok(uri) => {
-                                        match crate::client::Client::try_from(uri) {
-                                            Ok(client) => {
-                                                match client.test_connection().await {
-                                                    Ok(_) => true,
-                                                    Err(e) => {
-                                                        let err_msg = format!("Failed to connect to new host: {}", e);
-                                                        log::error!("{}", err_msg);
-                                                        return settings_error_response(err_msg);
-                                                    }
-                                                }
-                                            },
-                                            Err(e) => {
-                                                let err_msg = format!("Failed to construct client: {}", e);
-                                                log::error!("{}", err_msg);
-                                                return settings_error_response(err_msg);
-                                            }
-                                        }
-                                    },
-                                    Err(e) => {
-                                        let err_msg = format!("Failed to parse host into URI: {}", e);
-                                        log::error!("{}", err_msg);
-                                        return settings_error_response(err_msg);
-                                    }
-                                };
-                                
-                                if is_valid {
-                                    match host.save(name) {
-                                        Ok(_) => {
-                                            settings.active_target = Some(name.clone());
-                                        }
+                    } else if let (Some(user), Some(pass)) =
+                        (&form.new_host_username, &form.new_host_password)
+                        && !user.is_empty()
+                        && !pass.is_empty()
+                    {
+                        builder = builder
+                            .username(Some(user.clone()))
+                            .password(Some(pass.clone()));
+                    }
+
+                    match builder.build() {
+                        Ok(host) => {
+                            // Validate connection before saving
+                            let is_valid = match Uri::try_from(host.clone()) {
+                                Ok(uri) => match crate::client::Client::try_from(uri) {
+                                    Ok(client) => match client.test_connection().await {
+                                        Ok(_) => true,
                                         Err(e) => {
-                                            let err_msg = format!("Failed to save host to hosts.yml: {}", e);
+                                            let err_msg =
+                                                format!("Failed to connect to new host: {}", e);
                                             log::error!("{}", err_msg);
                                             return settings_error_response(err_msg);
                                         }
+                                    },
+                                    Err(e) => {
+                                        let err_msg = format!("Failed to construct client: {}", e);
+                                        log::error!("{}", err_msg);
+                                        return settings_error_response(err_msg);
+                                    }
+                                },
+                                Err(e) => {
+                                    let err_msg = format!("Failed to parse host into URI: {}", e);
+                                    log::error!("{}", err_msg);
+                                    return settings_error_response(err_msg);
+                                }
+                            };
+
+                            if is_valid {
+                                match host.save(name) {
+                                    Ok(_) => {
+                                        settings.active_target = Some(name.clone());
+                                    }
+                                    Err(e) => {
+                                        let err_msg =
+                                            format!("Failed to save host to hosts.yml: {}", e);
+                                        log::error!("{}", err_msg);
+                                        return settings_error_response(err_msg);
                                     }
                                 }
                             }
-                            Err(e) => {
-                                let err_msg = format!("Failed to configure host: {}", e);
-                                log::error!("{}", err_msg);
-                                return settings_error_response(err_msg);
-                            }
+                        }
+                        Err(e) => {
+                            let err_msg = format!("Failed to configure host: {}", e);
+                            log::error!("{}", err_msg);
+                            return settings_error_response(err_msg);
                         }
                     }
-                    Err(e) => {
-                        let err_msg = format!("Invalid URL provided for new host: {}", e);
-                        log::error!("{}", err_msg);
-                        return settings_error_response(err_msg);
-                    }
+                }
+                Err(e) => {
+                    let err_msg = format!("Invalid URL provided for new host: {}", e);
+                    log::error!("{}", err_msg);
+                    return settings_error_response(err_msg);
                 }
             }
         }
@@ -150,27 +153,23 @@ pub async fn update_settings(
     // 4. Update the active Exporter in ServerState
     if let Some(target) = &settings.active_target {
         match KnownHost::get_known(target).ok_or_else(|| eyre::eyre!("Host not found")) {
-            Ok(host) => {
-                match Uri::try_from(host) {
-                    Ok(uri) => {
-                        match Exporter::try_from(uri) {
-                            Ok(new_exporter) => {
-                                *state.exporter.write().await = new_exporter;
-                            }
-                            Err(e) => {
-                                let err_msg = format!("Failed to construct exporter: {}", e);
-                                log::error!("{}", err_msg);
-                                return settings_error_response(err_msg);
-                            }
-                        }
+            Ok(host) => match Uri::try_from(host) {
+                Ok(uri) => match Exporter::try_from(uri) {
+                    Ok(new_exporter) => {
+                        *state.exporter.write().await = new_exporter;
                     }
                     Err(e) => {
-                        let err_msg = format!("Invalid Host URI: {}", e);
+                        let err_msg = format!("Failed to construct exporter: {}", e);
                         log::error!("{}", err_msg);
                         return settings_error_response(err_msg);
                     }
+                },
+                Err(e) => {
+                    let err_msg = format!("Invalid Host URI: {}", e);
+                    log::error!("{}", err_msg);
+                    return settings_error_response(err_msg);
                 }
-            }
+            },
             Err(e) => {
                 let err_msg = format!("Could not find Target in hosts.yml: {}", e);
                 log::error!("{}", err_msg);
@@ -178,7 +177,7 @@ pub async fn update_settings(
             }
         }
     }
-    
+
     // 5. Build response to remove modal and update exporter text
     Sse::new(stream! {
         yield Ok::<_, std::convert::Infallible>(PatchElements::new(r#"
@@ -186,7 +185,8 @@ pub async fn update_settings(
             Reloading...
         </div>
         "#).write_as_axum_sse_event());
-    }).into_response()
+    })
+    .into_response()
 }
 
 fn settings_error_response(err_msg: String) -> Response {

--- a/src/server/theme.rs
+++ b/src/server/theme.rs
@@ -33,15 +33,21 @@ pub async fn set_theme(ReadSignals(signals): ReadSignals<ThemeSignals>) -> impl 
         }
     })
     .to_string();
-    let mut body = datastar::prelude::PatchSignals::new(payload)
+    let body = datastar::prelude::PatchSignals::new(payload)
         .as_datastar_event()
         .to_string();
 
     #[cfg(feature = "desktop")]
-    {
+    let body = {
+        let mut body = body;
         // In desktop mode, we need a hard reload so the Tauri window frame reads the new theme_dark cookie
-        body.push_str(&datastar::prelude::ExecuteScript::new("window.location.reload();").as_datastar_event().to_string());
-    }
+        body.push_str(
+            &datastar::prelude::ExecuteScript::new("window.location.reload();")
+                .as_datastar_event()
+                .to_string(),
+        );
+        body
+    };
 
     let mut headers = HeaderMap::new();
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));


### PR DESCRIPTION
## Summary
- run a repo-wide hygiene pass with `cargo fmt` and `cargo clippy --fix`, then manually resolve the remaining strict clippy findings
- address residual warning categories across client, data, processor, receiver, and server modules (API parsing helpers, signature cleanup, conversion simplifications, and small structural refactors)
- ensure the workspace is warning-free under strict checks and still builds cleanly

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo build --workspace --all-targets`


Made with [Cursor](https://cursor.com)