### PR TITLE
feat: add host secrets keystore and role-constrained auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm-siv"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "polyval",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +316,28 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -635,6 +693,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +713,16 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -813,6 +892,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -900,6 +989,15 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -986,6 +1084,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1233,7 +1332,9 @@ dependencies = [
 name = "esdiag"
 version = "0.15.0-SNAPSHOT"
 dependencies = [
+ "aes-gcm-siv",
  "askama",
+ "async-stream",
  "axum",
  "axum-server",
  "base64 0.22.1",
@@ -1250,17 +1351,21 @@ dependencies = [
  "json-patch 4.1.0",
  "log",
  "mimalloc",
+ "pbkdf2",
  "portpicker",
  "pulldown-cmark",
+ "rand 0.10.0",
  "rayon",
  "regex",
  "reqwest 0.12.28",
+ "rpassword",
  "rust-embed",
  "semver",
  "serde",
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "sha2",
  "tar",
  "tauri",
  "tauri-build",
@@ -1717,6 +1822,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -1937,6 +2043,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "html5ever"
@@ -2296,6 +2411,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -3089,6 +3213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3219,6 +3349,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3436,6 +3576,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3646,6 +3798,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3701,6 +3864,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_hc"
@@ -3920,6 +4089,27 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rust-embed"
@@ -4356,7 +4546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5416,6 +5606,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ server = []
 desktop = ["server", "dep:tauri", "dep:tauri-build", "dep:tauri-plugin-opener"]
 
 [dependencies]
+aes-gcm-siv = "0.11.1"
 askama = { version = "0.15.4", default-features = false, features = ["derive", "std", "serde_json"] }
+async-stream = "0.3.6"
 axum = { version = "0.8.8", features = ["multipart", "macros"] }
 axum-server = "0.8.0"
 base64 = "0.22.1"
@@ -29,16 +31,20 @@ indexmap = "2.13.0"
 json-patch = "4.1"
 log = "0.4"
 mimalloc = "0.1.48"
+pbkdf2 = "0.12.2"
 pulldown-cmark = "0.13.1"
+rand = "0.10.0"
 rayon = "1.11"
 regex = "1.12"
 reqwest = { version = "0.12.28", features = ["json", "blocking", "multipart"] }
+rpassword = "7.4.0"
 rust-embed = { version = "8.9.0", features = ["compression", "debug-embed"] }
 semver = { version = "1.0.27", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = { version = "1.0.149", features = ["float_roundtrip", "raw_value"] }
 serde_with = { version = "3.16.1", default-features = false, features = ["macros"] }
 serde_yaml = "0.9"
+sha2 = "0.10.9"
 tar = { version = "0.4.44", optional = true, default-features = false }
 tauri = { version = "2.10.2", optional = true , features = [] }
 tauri-plugin-opener = { version = "2", optional = true }

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -5,10 +5,10 @@ Copyright 2012-2025 Elasticsearch B.V.
 This document lists the licenses of the projects used in esdiag.
 
 ## Overview of licenses
-- [Apache License 2.0](#Apache-2.0) (215)
-- [MIT License](#MIT) (64)
+- [Apache License 2.0](#Apache-2.0) (243)
+- [MIT License](#MIT) (66)
 - [Unicode License v3](#Unicode-3.0) (19)
-- [BSD 3-Clause "New" or "Revised" License](#BSD-3-Clause) (2)
+- [BSD 3-Clause "New" or "Revised" License](#BSD-3-Clause) (3)
 - [zlib License](#Zlib) (2)
 - [BSD Zero Clause License](#0BSD) (1)
 - [Elastic License 2.0](#Elastic-2.0) (1)
@@ -264,16 +264,27 @@ Apache License 2.0
 - [windows-registry]( https://github.com/microsoft/windows-rs ) 0.6.1
 - [windows-result]( https://github.com/microsoft/windows-rs ) 0.4.1
 - [windows-strings]( https://github.com/microsoft/windows-rs ) 0.5.1
+- [windows-sys]( https://github.com/microsoft/windows-rs ) 0.52.0
+- [windows-sys]( https://github.com/microsoft/windows-rs ) 0.59.0
 - [windows-sys]( https://github.com/microsoft/windows-rs ) 0.60.2
 - [windows-sys]( https://github.com/microsoft/windows-rs ) 0.61.2
+- [windows-targets]( https://github.com/microsoft/windows-rs ) 0.52.6
 - [windows-targets]( https://github.com/microsoft/windows-rs ) 0.53.5
+- [windows_aarch64_gnullvm]( https://github.com/microsoft/windows-rs ) 0.52.6
 - [windows_aarch64_gnullvm]( https://github.com/microsoft/windows-rs ) 0.53.1
+- [windows_aarch64_msvc]( https://github.com/microsoft/windows-rs ) 0.52.6
 - [windows_aarch64_msvc]( https://github.com/microsoft/windows-rs ) 0.53.1
+- [windows_i686_gnu]( https://github.com/microsoft/windows-rs ) 0.52.6
 - [windows_i686_gnu]( https://github.com/microsoft/windows-rs ) 0.53.1
+- [windows_i686_gnullvm]( https://github.com/microsoft/windows-rs ) 0.52.6
 - [windows_i686_gnullvm]( https://github.com/microsoft/windows-rs ) 0.53.1
+- [windows_i686_msvc]( https://github.com/microsoft/windows-rs ) 0.52.6
 - [windows_i686_msvc]( https://github.com/microsoft/windows-rs ) 0.53.1
+- [windows_x86_64_gnu]( https://github.com/microsoft/windows-rs ) 0.52.6
 - [windows_x86_64_gnu]( https://github.com/microsoft/windows-rs ) 0.53.1
+- [windows_x86_64_gnullvm]( https://github.com/microsoft/windows-rs ) 0.52.6
 - [windows_x86_64_gnullvm]( https://github.com/microsoft/windows-rs ) 0.53.1
+- [windows_x86_64_msvc]( https://github.com/microsoft/windows-rs ) 0.52.6
 - [windows_x86_64_msvc]( https://github.com/microsoft/windows-rs ) 0.53.1
 
 #### License
@@ -3975,11 +3986,23 @@ limitations under the License.
 Apache License 2.0
 
 #### Used by
+- [aes-gcm-siv]( https://github.com/RustCrypto/AEADs ) 0.11.1
+- [aes]( https://github.com/RustCrypto/block-ciphers ) 0.8.4
 - [block-buffer]( https://github.com/RustCrypto/utils ) 0.10.4
+- [chacha20]( https://github.com/RustCrypto/stream-ciphers ) 0.10.0
+- [cipher]( https://github.com/RustCrypto/traits ) 0.4.4
 - [cpufeatures]( https://github.com/RustCrypto/utils ) 0.2.17
+- [cpufeatures]( https://github.com/RustCrypto/utils ) 0.3.0
 - [crypto-common]( https://github.com/RustCrypto/traits ) 0.1.7
+- [ctr]( https://github.com/RustCrypto/block-modes ) 0.9.2
 - [digest]( https://github.com/RustCrypto/traits ) 0.10.7
+- [hmac]( https://github.com/RustCrypto/MACs ) 0.12.1
+- [inout]( https://github.com/RustCrypto/utils ) 0.1.4
+- [opaque-debug]( https://github.com/RustCrypto/utils ) 0.3.1
+- [pbkdf2]( https://github.com/RustCrypto/password-hashes/tree/master/pbkdf2 ) 0.12.2
+- [polyval]( https://github.com/RustCrypto/universal-hashes ) 0.6.2
 - [sha2]( https://github.com/RustCrypto/hashes ) 0.10.9
+- [universal-hash]( https://github.com/RustCrypto/traits ) 0.5.1
 
 #### License
 ```
@@ -4190,6 +4213,219 @@ limitations under the License.
 Apache License 2.0
 
 #### Used by
+- [aead]( https://github.com/RustCrypto/traits ) 0.5.2
+
+#### License
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+```
+### Apache-2.0
+Apache License 2.0
+
+#### Used by
+- [rand_core]( https://github.com/rust-random/rand_core ) 0.10.0
 - [rand_core]( https://github.com/rust-random/rand ) 0.6.4
 - [rand_core]( https://github.com/rust-random/rand ) 0.9.5
 
@@ -5468,10 +5704,13 @@ Apache License 2.0
 - [proc-macro2]( https://github.com/dtolnay/proc-macro2 ) 1.0.106
 - [quote]( https://github.com/dtolnay/quote ) 1.0.44
 - [r-efi]( https://github.com/r-efi/r-efi ) 5.3.0
+- [rand]( https://github.com/rust-random/rand ) 0.10.0
 - [rand]( https://github.com/rust-random/rand ) 0.8.5
 - [rand]( https://github.com/rust-random/rand ) 0.9.2
 - [rand_chacha]( https://github.com/rust-random/rand ) 0.9.0
 - [rle-decode-fast]( https://github.com/WanzenBug/rle-decode-helper ) 1.0.3
+- [rpassword]( https://github.com/conradkleinespel/rpassword ) 7.4.0
+- [rtoolbox]( https://github.com/conradkleinespel/duck ) 0.0.3
 - [rustc-hash]( https://github.com/rust-lang/rustc-hash ) 2.1.1
 - [rustversion]( https://github.com/dtolnay/rustversion ) 1.0.22
 - [ryu]( https://github.com/dtolnay/ryu ) 1.0.23
@@ -5860,6 +6099,45 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+```
+### BSD-3-Clause
+BSD 3-Clause "New" or "Revised" License
+
+#### Used by
+- [subtle]( https://github.com/dalek-cryptography/subtle ) 2.6.1
+
+#### License
+```
+Copyright (c) 2016-2017 Isis Agora Lovecruft, Henry de Valence. All rights reserved.
+Copyright (c) 2016-2024 Isis Agora Lovecruft. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 
 ```
 ### BSD-3-Clause
@@ -6894,6 +7172,8 @@ SOFTWARE.
 MIT License
 
 #### Used by
+- [async-stream-impl]( https://github.com/tokio-rs/async-stream ) 0.3.6
+- [async-stream]( https://github.com/tokio-rs/async-stream ) 0.3.6
 - [void]( https://github.com/reem/rust-void.git ) 1.0.2
 
 #### License

--- a/docs/hosts-keystore.md
+++ b/docs/hosts-keystore.md
@@ -1,0 +1,76 @@
+# Host Keystore Migration
+
+`esdiag` supports two host auth models:
+
+- Legacy plaintext credentials in `hosts.yml`
+- Secret references from `hosts.yml` into an encrypted keystore
+
+The keystore flow is optional and additive. Existing `hosts.yml` entries continue to work.
+
+## Set Keystore Password
+
+Set the keystore password in your shell before keystore operations:
+
+```bash
+export ESDIAG_KEYSTORE_PASSWORD="change-me"
+```
+
+## Add Secrets
+
+Add a basic-auth secret:
+
+```bash
+esdiag keystore add prod-es-basic --user elastic --password changeme
+```
+
+Add an API key secret:
+
+```bash
+esdiag keystore add prod-es-apikey --apikey BASE64_ENCODED_KEY
+```
+
+## Reference Secrets from hosts.yml
+
+Use `--secret` when creating/updating hosts:
+
+```bash
+esdiag host prod-es elasticsearch http://localhost:9200 --secret prod-es-apikey
+```
+
+The stored host entry keeps `secret` and omits plaintext auth values.
+
+You can combine secret references with host roles:
+
+```bash
+esdiag host prod-es elasticsearch http://localhost:9200 --secret prod-es-apikey --roles collect,send
+```
+
+Role values are `collect`, `send`, and `view`.
+
+## Migrate Existing hosts.yml
+
+Migrate all legacy plaintext credentials into the keystore:
+
+```bash
+esdiag keystore migrate
+```
+
+Migration behavior:
+
+- Uses each host name as `secret_id`
+- Copies legacy `apikey` or `username/password` into keystore
+- Rewrites host entries with `secret: <hostname>`
+- Leaves hosts without legacy auth unchanged
+
+## Optional Legacy Mode
+
+If you do not use keystore secrets, keep legacy auth fields in `hosts.yml`.
+`esdiag` continues to resolve auth from plaintext fields.
+
+## Related CLI Arguments
+
+- `esdiag host --secret <secret_id>` stores a secret reference instead of plaintext credentials
+- `esdiag host --roles collect,send,view` assigns workflow roles to a host
+- `esdiag host --user <name> --password <value>` stores legacy basic auth fields (alias: `--username`)
+- `esdiag host --apikey <value>` stores a legacy API key field
+- `esdiag keystore add/remove <secret_id> --user/--password/--apikey` manages encrypted secret entries

--- a/openspec/changes/host-secrets/.openspec.yaml
+++ b/openspec/changes/host-secrets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-04

--- a/openspec/changes/host-secrets/design.md
+++ b/openspec/changes/host-secrets/design.md
@@ -1,0 +1,82 @@
+## Context
+
+`hosts.yml` currently mixes host metadata and authentication secrets, including plaintext passwords and API keys. This is acceptable for local development but does not meet security requirements for stricter environments. The same host definitions are also being prepared for future workflow and UI selection flows that distinguish collect, process/send, and optional view targets.
+
+The change introduces two cross-cutting concerns in configuration: secure secret storage and role-based host targeting. Both affect parsing, validation, runtime resolution of credentials, and user-facing configuration behavior. The implementation must remain cross-platform and self-contained.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Store host credentials in an encrypted keystore rather than plaintext `hosts.yml` values.
+- Keep secret storage optional so existing low-security/dev usage continues to work.
+- Add host role metadata with validation rules:
+  - `collect` default and valid for any host type.
+  - `send` valid only for Elasticsearch hosts.
+  - `view` valid only for Kibana hosts.
+- Preserve backwards compatibility with existing auth fields while enabling migration to `secret` references.
+- Prepare config semantics to support role-filtered workflow steps in upcoming UI refactors.
+
+**Non-Goals:**
+- Full UI implementation for role-based selection workflows.
+- Removing plaintext auth fields in this change.
+- Introducing external secret manager dependencies (cloud KMS, Vault, etc.).
+
+## Decisions
+
+1. **Split host config and secret material**
+   - Decision: Keep non-secret host config in `hosts.yml` and move secret values to a dedicated encrypted secrets file.
+   - Rationale: Least disruptive migration path and clear separation of concerns for secure handling.
+   - Alternatives considered:
+     - Encrypt fields inline in `hosts.yml`: rejected because mixed concerns complicate editing and validation.
+     - Require secrets-only mode immediately: rejected because it would break existing workflows.
+
+2. **Optional secret reference model in `hosts.yml`**
+   - Decision: Add `secret: Option<String>` as a secret identifier for each host while retaining legacy auth fields.
+   - Rationale: Supports progressive migration and backward compatibility.
+   - Alternatives considered:
+     - Replace auth fields immediately: rejected because it is a breaking change for existing configs.
+     - Multiple secret IDs per auth type: rejected for initial scope; a single secret record per host keeps shape simple.
+
+3. **Encrypted local keystore with pluggable file format**
+   - Decision: Select encryption library first, then finalize secrets file format according to library constraints (nonce/metadata framing, key derivation inputs, versioning).
+   - Rationale: Avoids locking into a format that conflicts with library APIs or security requirements.
+   - Alternatives considered:
+     - Fixed YAML/JSON schema before library selection: rejected as high rework risk.
+
+4. **Role model and validation at configuration load time**
+   - Decision: Add host `roles` with default `collect` if omitted; enforce host-type constraints during validation.
+   - Rationale: Fail fast and provide deterministic runtime behavior for target filtering.
+   - Alternatives considered:
+     - Validate only during execution: rejected due to delayed, harder-to-debug failures.
+     - Infer roles solely from host type: rejected because users need explicit selection intent.
+
+5. **Credential resolution precedence**
+   - Decision: Resolve credentials from secret store when `secret` is set; otherwise fall back to existing plaintext fields.
+   - Rationale: Predictable behavior with explicit secure opt-in and no break for legacy configs.
+   - Alternatives considered:
+     - Prefer plaintext over secrets when both exist: rejected because it undermines secure configuration intent.
+
+## Risks / Trade-offs
+
+- **[Risk] Key management ergonomics for local encryption** -> **Mitigation:** Define minimal key bootstrap flow, document defaults for dev, and keep explicit error messages for missing/invalid keys.
+- **[Risk] Backward compatibility adds branching complexity** -> **Mitigation:** Centralize credential resolution and validate mutually inconsistent config combinations early.
+- **[Risk] Role validation can reject existing configs unexpectedly** -> **Mitigation:** Default missing roles to `collect` and provide migration guidance for `send`/`view`.
+- **[Risk] Library-driven file format may evolve** -> **Mitigation:** Include format versioning field from first implementation.
+
+## Migration Plan
+
+1. Add parser support for `secret` and `roles` fields in `hosts.yml` while preserving existing auth fields.
+2. Introduce encrypted keystore read/write and secret lookup by `secret_id`.
+3. Add config validation for role-to-host-type rules and default role assignment.
+4. Implement credential resolution precedence (secret reference first, plaintext fallback).
+5. Document migration path: create keystore entries, update `hosts.yml` with `secret` IDs, then remove plaintext fields where desired.
+
+Rollback strategy:
+- Disable secret-store usage and rely on existing plaintext fields if needed.
+- Retain parser compatibility for previous `hosts.yml` shape.
+
+## Open Questions
+
+- Which encryption library best satisfies cross-platform and self-contained constraints while keeping key management practical?
+- Should one `secret_id` map to a structured credential object (username/password/api-key) or a typed union keyed by auth mode?
+- How should keystore key material be supplied in CLI and desktop contexts (env var, prompt, OS store integration)?

--- a/openspec/changes/host-secrets/proposal.md
+++ b/openspec/changes/host-secrets/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The current `hosts.yml` stores passwords and API keys in plain text, which is not acceptable in stricter environments and creates avoidable risk for credential exposure. We also need role-aware host targeting now so upcoming workflow and UI refactors can safely filter hosts for collect, send, and view operations.
+
+## What Changes
+
+- Add an optional encrypted secret store to hold host authentication values (passwords, API keys, and similar secrets) outside of `hosts.yml`.
+- Split host configuration concerns into non-secret host metadata (`hosts.yml`) and a dedicated secrets artifact/file format selected during design based on encryption library capabilities.
+- Extend host configuration with role assignments to support at least `collect`, `send`, and `view` targeting.
+- Add role validation rules:
+  - `collect` is valid for any host and is the default role.
+  - `send` is valid only for Elasticsearch hosts.
+  - `view` is valid only for Kibana hosts.
+- Update host authentication model to add `secret: Option<String>` in `hosts.yml`, where the value is a secret identifier in the secret store.
+- Preserve existing plaintext authentication fields for backward compatibility and optional operation in less secure environments (for example local development).
+
+## Capabilities
+
+### New Capabilities
+- `host-secret-store`: Encrypt and persist host secrets in a dedicated keystore, with `hosts.yml` referencing stored secret IDs.
+- `host-role-targeting`: Define and validate host roles (`collect`, `send`, `view`) for workflow and UI target selection.
+
+### Modified Capabilities
+- `collection-execution`: Host selection inputs are role-aware and constrained by validated host role assignments.
+
+## Impact
+
+- `hosts.yml` parsing, validation, and serialization logic in core configuration handling.
+- New secret-store file management and encryption/decryption integration.
+- Host model, workflow target selection, and validation paths for collect/send/view phases.
+- Potential new crypto dependency and key/keystore handling requirements.
+- Backward-compatible behavior for existing plaintext host auth fields in developer/legacy environments.

--- a/openspec/changes/host-secrets/specs/collection-execution/spec.md
+++ b/openspec/changes/host-secrets/specs/collection-execution/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+
+### Requirement: Role-Constrained Execution Targets
+The collection execution workflow SHALL resolve host targets by role before executing each workflow phase. The collect phase SHALL use only hosts with the `collect` role, the send phase SHALL use only hosts with the `send` role, and the view phase SHALL use only hosts with the `view` role.
+
+#### Scenario: Resolve targets for multi-phase workflow
+- **GIVEN** host configuration includes hosts with `collect`, `send`, and `view` roles
+- **WHEN** the workflow resolves targets for collection and output handling
+- **THEN** collection calls are executed only against `collect` hosts
+- **AND** send/output calls are executed only against `send` hosts
+- **AND** view target resolution includes only `view` hosts

--- a/openspec/changes/host-secrets/specs/host-role-targeting/spec.md
+++ b/openspec/changes/host-secrets/specs/host-role-targeting/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Host Role Assignment
+The system SHALL support host role assignments for `collect`, `send`, and `view` in host configuration. If roles are omitted, the system SHALL default the host role set to `collect`.
+
+#### Scenario: Roles omitted in host configuration
+- **GIVEN** a host entry has no explicit `roles` field
+- **WHEN** the system validates host configuration
+- **THEN** the host is assigned the `collect` role by default
+
+### Requirement: Role and Host Type Validation
+The system SHALL enforce host-type constraints for role assignment where `send` is valid only on Elasticsearch hosts and `view` is valid only on Kibana hosts.
+
+#### Scenario: Invalid send role on non-Elasticsearch host
+- **GIVEN** a Kibana host entry includes role `send`
+- **WHEN** the system validates host configuration
+- **THEN** validation fails with an error indicating `send` is only valid for Elasticsearch hosts
+
+#### Scenario: Invalid view role on non-Kibana host
+- **GIVEN** an Elasticsearch host entry includes role `view`
+- **WHEN** the system validates host configuration
+- **THEN** validation fails with an error indicating `view` is only valid for Kibana hosts
+
+### Requirement: Role-Based Target Filtering
+The system SHALL provide role-based host filtering outputs for runtime workflows so collect, send, and view phases can select only hosts matching each phase role.
+
+#### Scenario: Build collect target list
+- **GIVEN** a host inventory containing mixed role assignments
+- **WHEN** the system resolves targets for the collect phase
+- **THEN** only hosts with role `collect` are included in collect targets

--- a/openspec/changes/host-secrets/specs/host-secret-store/spec.md
+++ b/openspec/changes/host-secrets/specs/host-secret-store/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Encrypted Host Secret Storage
+The system SHALL support storing host authentication secrets in an encrypted local keystore file that is separate from `hosts.yml`. The keystore SHALL store passwords, API keys, and related authentication material using a secret identifier (`secret_id`) key.
+
+#### Scenario: Resolve credentials using secret identifier
+- **GIVEN** a host entry includes `secret: "prod-es-main"`
+- **AND** the keystore contains an encrypted secret record with ID `prod-es-main`
+- **WHEN** the system loads host configuration for an operation
+- **THEN** the system decrypts and resolves credentials from the keystore record
+- **AND** the system uses those credentials for host authentication
+
+### Requirement: Optional Secret Store Adoption
+The system SHALL keep secret-store usage optional and SHALL continue supporting existing plaintext authentication fields for environments that do not use encrypted secret storage.
+
+#### Scenario: No secret identifier provided
+- **GIVEN** a host entry does not include a `secret` value
+- **AND** the host entry includes legacy plaintext authentication fields
+- **WHEN** the system loads host configuration
+- **THEN** the system authenticates using legacy plaintext fields
+- **AND** the configuration is treated as valid when role constraints are satisfied
+
+### Requirement: Secret Identifier Integrity
+The system SHALL fail configuration validation when a host explicitly references a `secret_id` that is missing or unreadable in the keystore.
+
+#### Scenario: Referenced secret is missing
+- **GIVEN** a host entry includes `secret: "missing-secret"`
+- **AND** the keystore does not contain `missing-secret`
+- **WHEN** the system validates configuration
+- **THEN** validation fails with an explicit error that identifies the missing `secret_id`
+
+#### Scenario: Explicit secret and legacy credentials both exist
+- **GIVEN** a host entry includes `secret: "prod-es-main"`
+- **AND** the same host entry also includes legacy plaintext credentials
+- **AND** the keystore contains `prod-es-main`
+- **WHEN** the system resolves host authentication
+- **THEN** the system authenticates using the keystore secret
+- **AND** logs a warning that legacy plaintext credentials are being ignored

--- a/openspec/changes/host-secrets/tasks.md
+++ b/openspec/changes/host-secrets/tasks.md
@@ -1,0 +1,30 @@
+## 1. Host Config Model Updates
+
+- [x] 1.1 Add `secret: Option<String>` and role fields to the host configuration model while preserving legacy auth fields.
+- [x] 1.2 Update `hosts.yml` parsing/serialization to support default `collect` role assignment when roles are omitted.
+- [x] 1.3 Implement validation rules enforcing `send` only for Elasticsearch hosts and `view` only for Kibana hosts.
+
+## 2. Secret Store Foundation
+
+- [x] 2.1 Evaluate and select a cross-platform Rust encryption approach compatible with self-contained distribution constraints.
+- [x] 2.2 Define and implement the new encrypted secrets file format with versioning and `secret_id` lookup support.
+- [x] 2.3 Implement keystore read/decrypt flow and map resolved secrets into runtime auth credentials.
+
+## 3. Credential Resolution and Compatibility
+
+- [x] 3.1 Implement credential precedence so `secret` references are used first, with fallback to legacy plaintext auth fields.
+- [x] 3.2 Add validation errors for missing/unreadable `secret_id` references with clear host and secret context.
+- [x] 3.3 Add migration-oriented docs/examples showing split `hosts.yml` + secrets file usage and optional legacy mode.
+
+## 4. Role-Based Target Selection Integration
+
+- [x] 4.1 Update collection/send/view target resolution to filter hosts by assigned roles.
+- [x] 4.2 Ensure collection execution paths consume only role-constrained host lists for each workflow phase.
+- [x] 4.3 Add integration coverage for mixed-role inventories across collect, send, and view workflows.
+
+## 5. Verification
+
+- [x] 5.1 Add/extend unit tests for host parsing, role defaults, role validation, and secret reference validation.
+- [x] 5.2 Add/extend integration tests for secret-backed authentication and plaintext fallback behavior.
+- [x] 5.3 Run `cargo clippy` and resolve any new warnings in changed code.
+- [x] 5.4 Run `cargo test` and confirm all relevant suites pass.

--- a/openspec/specs/collection-execution/spec.md
+++ b/openspec/specs/collection-execution/spec.md
@@ -35,3 +35,13 @@ The system MUST implement exhaustive pattern matching when mapping the generic A
 - **GIVEN** a developer adds a new variant `IndicesRecovery` to the `ElasticsearchApi` enum
 - **WHEN** they attempt to compile the `esdiag` CLI
 - **THEN** the Rust compiler issues an error because the new variant is not handled in the exhaustive `match` statement within the collection execution loop
+
+### Requirement: Role-Constrained Execution Targets
+The collection execution workflow SHALL resolve host targets by role before executing each workflow phase. The collect phase SHALL use only hosts with the `collect` role, the send phase SHALL use only hosts with the `send` role, and the view phase SHALL use only hosts with the `view` role.
+
+#### Scenario: Resolve targets for multi-phase workflow
+- **GIVEN** host configuration includes hosts with `collect`, `send`, and `view` roles
+- **WHEN** the workflow resolves targets for collection and output handling
+- **THEN** collection calls are executed only against `collect` hosts
+- **AND** send/output calls are executed only against `send` hosts
+- **AND** view target resolution includes only `view` hosts

--- a/openspec/specs/host-role-targeting/spec.md
+++ b/openspec/specs/host-role-targeting/spec.md
@@ -1,0 +1,34 @@
+## Purpose
+
+Define host role assignment and validation for collect/send/view target selection.
+
+## ADDED Requirements
+
+### Requirement: Host Role Assignment
+The system SHALL support host role assignments for `collect`, `send`, and `view` in host configuration. If roles are omitted, the system SHALL default the host role set to `collect`.
+
+#### Scenario: Roles omitted in host configuration
+- **GIVEN** a host entry has no explicit `roles` field
+- **WHEN** the system validates host configuration
+- **THEN** the host is assigned the `collect` role by default
+
+### Requirement: Role and Host Type Validation
+The system SHALL enforce host-type constraints for role assignment where `send` is valid only on Elasticsearch hosts and `view` is valid only on Kibana hosts.
+
+#### Scenario: Invalid send role on non-Elasticsearch host
+- **GIVEN** a Kibana host entry includes role `send`
+- **WHEN** the system validates host configuration
+- **THEN** validation fails with an error indicating `send` is only valid for Elasticsearch hosts
+
+#### Scenario: Invalid view role on non-Kibana host
+- **GIVEN** an Elasticsearch host entry includes role `view`
+- **WHEN** the system validates host configuration
+- **THEN** validation fails with an error indicating `view` is only valid for Kibana hosts
+
+### Requirement: Role-Based Target Filtering
+The system SHALL provide role-based host filtering outputs for runtime workflows so collect, send, and view phases can select only hosts matching each phase role.
+
+#### Scenario: Build collect target list
+- **GIVEN** a host inventory containing mixed role assignments
+- **WHEN** the system resolves targets for the collect phase
+- **THEN** only hosts with role `collect` are included in collect targets

--- a/openspec/specs/host-secret-store/spec.md
+++ b/openspec/specs/host-secret-store/spec.md
@@ -1,0 +1,42 @@
+## Purpose
+
+Define secure, optional host credential storage and resolution behavior.
+
+## ADDED Requirements
+
+### Requirement: Encrypted Host Secret Storage
+The system SHALL support storing host authentication secrets in an encrypted local keystore file that is separate from `hosts.yml`. The keystore SHALL store passwords, API keys, and related authentication material using a secret identifier (`secret_id`) key.
+
+#### Scenario: Resolve credentials using secret identifier
+- **GIVEN** a host entry includes `secret: "prod-es-main"`
+- **AND** the keystore contains an encrypted secret record with ID `prod-es-main`
+- **WHEN** the system loads host configuration for an operation
+- **THEN** the system decrypts and resolves credentials from the keystore record
+- **AND** the system uses those credentials for host authentication
+
+### Requirement: Optional Secret Store Adoption
+The system SHALL keep secret-store usage optional and SHALL continue supporting existing plaintext authentication fields for environments that do not use encrypted secret storage.
+
+#### Scenario: No secret identifier provided
+- **GIVEN** a host entry does not include a `secret` value
+- **AND** the host entry includes legacy plaintext authentication fields
+- **WHEN** the system loads host configuration
+- **THEN** the system authenticates using legacy plaintext fields
+- **AND** the configuration is treated as valid when role constraints are satisfied
+
+### Requirement: Secret Identifier Integrity
+The system SHALL fail configuration validation when a host explicitly references a `secret_id` that is missing or unreadable in the keystore.
+
+#### Scenario: Referenced secret is missing
+- **GIVEN** a host entry includes `secret: "missing-secret"`
+- **AND** the keystore does not contain `missing-secret`
+- **WHEN** the system validates configuration
+- **THEN** validation fails with an explicit error that identifies the missing `secret_id`
+
+#### Scenario: Explicit secret and legacy credentials both exist
+- **GIVEN** a host entry includes `secret: "prod-es-main"`
+- **AND** the same host entry also includes legacy plaintext credentials
+- **AND** the keystore contains `prod-es-main`
+- **WHEN** the system resolves host authentication
+- **THEN** the system authenticates using the keystore secret
+- **AND** logs a warning that legacy plaintext credentials are being ignored

--- a/readme.md
+++ b/readme.md
@@ -156,6 +156,7 @@ Usage: esdiag <COMMAND>
 Commands:
   collect  Collect a diagnostic bundle from a known host's API endpoints, writes output to a directory
   host     Configure and test a remote host connection
+  keystore Manage encrypted secrets in the local keystore
   process  Receives a diagnostic from the input, processes it, and sends processed docs to the output
   serve    Start a web server to receive diagnostic bundle uploads
   setup    Import assets (templates, ingest pipelines, etc.) to a known Elasticsearch host
@@ -167,7 +168,7 @@ Options:
 
 #### Host
 
-The `esdiag host` command allows you configure and test authentication information. On a succesful connection test, it writes the configuration to your `~/esdiag/hosts.yml` file for easy re-use.
+The `esdiag host` command allows you configure and test authentication information. On a succesful connection test, it writes the configuration to your `~/.esdiag/hosts.yml` file for easy re-use.
 
 Alternatively you can use a `.env` file and set `ESDIAG_OUTPUT_*` values; see `example.env`.
 
@@ -184,12 +185,56 @@ Arguments:
 Options:
       --accept-invalid-certs  Accept invalid certificates
   -a, --apikey <APIKEY>       ApiKey, passed as http header
-  -c, --cloud-id <CLOUD_ID>   Elastic Cloud ID (optional)
-  -u, --username <USERNAME>   Username for authentication
+  -u, --user <USERNAME>       Username for authentication (alias: --username)
   -p, --password <PASSWORD>   Password for authentication
+      --secret <SECRET>       Secret identifier in the encrypted keystore
+      --roles <ROLES>         Comma-separated host roles (collect,send,view)
   -n, --nosave                Don't save the host configuration on succesful connection
   -h, --help                  Print help
 ```
+
+Examples:
+
+```sh
+# Host backed by a keystore secret reference
+esdiag host prod-es elasticsearch http://localhost:9200 --secret prod-es-apikey
+
+# Host with explicit roles for workflow filtering
+esdiag host prod-es elasticsearch http://localhost:9200 --roles collect,send
+```
+
+#### Keystore
+
+The `esdiag keystore` command manages encrypted local secrets used by `--secret` references in `hosts.yml`.
+
+```
+Manage encrypted secrets in the local keystore
+
+Usage: esdiag keystore <COMMAND>
+
+Commands:
+  add <SECRET_ID>       Add or update a secret in the encrypted keystore
+  remove <SECRET_ID>    Remove a secret from the encrypted keystore
+  migrate               Migrate legacy host credentials in hosts.yml into the keystore
+```
+
+Examples:
+
+```sh
+# Add a basic auth secret
+esdiag keystore add prod-es-basic --user elastic --password changeme
+
+# Add an API key secret
+esdiag keystore add prod-es-apikey --apikey BASE64_ENCODED_KEY
+
+# Remove just the API key auth from a secret
+esdiag keystore remove prod-es-apikey --apikey BASE64_ENCODED_KEY
+
+# Move plaintext hosts.yml credentials into keystore entries
+esdiag keystore migrate
+```
+
+Use `ESDIAG_KEYSTORE_PASSWORD` to provide the keystore password non-interactively. In interactive shells, `keystore add/remove` will prompt when it is unset.
 
 #### Setup
 

--- a/skills/esdiag/SKILL.md
+++ b/skills/esdiag/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: esdiag
-description: Operate Elastic Stack Diagnostics (`esdiag`) end-to-end for host configuration, asset setup, diagnostic collection, processing, and upload-service workflows. Use when a user asks to run or troubleshoot `esdiag` commands (`host`, `setup`, `collect`, `process`, `serve`), wire output targets via known hosts or `ESDIAG_OUTPUT_*` environment variables, process support-diagnostics archives/directories/upload links, or expose the local web/API service.
+description: Operate Elastic Stack Diagnostics (`esdiag`) end-to-end for host configuration, secret management, asset setup, diagnostic collection, processing, and upload-service workflows. Use when a user asks to run or troubleshoot `esdiag` commands (`host`, `keystore`, `setup`, `collect`, `process`, `serve`), wire output targets via known hosts or `ESDIAG_OUTPUT_*` environment variables, process support-diagnostics archives/directories/upload links, or expose the local web/API service.
 ---
 
 # ESDiag
@@ -13,6 +13,7 @@ Use `--sources <path/to/sources.yml>` when diagnostics API selection must follow
 ## Workflow Decision Tree
 
 - If the task is "save/test a connection", run `esdiag host`.
+- If the task is "add/remove/migrate encrypted credentials", run `esdiag keystore`.
 - If the task is "install templates/pipelines/assets", run `esdiag setup`.
 - If the task is "transform diagnostics into documents and send somewhere", run `esdiag process`.
 - If the task is "collect API diagnostics from a host into local files", run `esdiag collect`.
@@ -28,10 +29,23 @@ Use `--sources <path/to/sources.yml>` when diagnostics API selection must follow
 ## Step 1: Configure Hosts and Auth
 
 - Use `esdiag host [OPTIONS] <NAME> [APP] [URL]` to test and save host configuration to `~/.esdiag/hosts.yml`.
-- Use `--apikey` for API key auth or `--username`/`--password` for basic auth.
+- Use `--apikey` for API key auth or `--user`/`--password` for basic auth.
+- `--user` is the primary basic-auth flag (with `--username` available as an alias).
+- Use `--secret <secret_id>` to reference credentials stored in the encrypted keystore.
+- Use `--roles collect,send,view` to assign host workflow roles.
 - Use `--accept-invalid-certs` for lab/self-signed environments.
 - Use `--nosave` for connectivity tests that should not persist.
 - Use environment variables (optionally by sourcing a `.env` file in the shell) when the user does not want a saved host.
+
+## Step 1b: Manage Encrypted Secrets (Optional)
+
+- Use `esdiag keystore add <secret_id>` to add/update encrypted credentials.
+  - Basic auth: `--user <name> --password <value>`
+  - API key auth: `--apikey <value>`
+- Use `esdiag keystore remove <secret_id>` to remove encrypted credentials (optionally scoped by auth type flags).
+- Use `esdiag keystore migrate` to move legacy plaintext host credentials from `hosts.yml` into keystore entries keyed by host name.
+- Set `ESDIAG_KEYSTORE_PASSWORD` for non-interactive keystore operations.
+- In interactive shells, `keystore add/remove` can prompt for keystore password when `ESDIAG_KEYSTORE_PASSWORD` is unset.
 
 ## Step 2: Setup Output Cluster
 

--- a/src/client/elasticsearch.rs
+++ b/src/client/elasticsearch.rs
@@ -93,28 +93,13 @@ impl TryFrom<KnownHost> for ElasticsearchClient {
     type Error = eyre::Report;
 
     fn try_from(host: KnownHost) -> Result<ElasticsearchClient> {
-        let client = match host {
-            KnownHost::ApiKey {
-                apikey,
-                url,
-                accept_invalid_certs,
-                ..
-            } => ElasticsearchBuilder::new(url)
-                .apikey(apikey)
-                .insecure(accept_invalid_certs)
-                .build()?,
-            KnownHost::Basic {
-                accept_invalid_certs,
-                username,
-                password,
-                url,
-                ..
-            } => ElasticsearchBuilder::new(url)
-                .basic_auth(username, password)
-                .insecure(accept_invalid_certs)
-                .build()?,
-            KnownHost::NoAuth { url, .. } => ElasticsearchBuilder::new(url).build()?,
-        };
+        let url = host.get_url();
+        let ignore_certs = host.accept_invalid_certs();
+        let auth = host.get_auth()?;
+        let client = ElasticsearchBuilder::new(url)
+            .auth(auth)
+            .insecure(ignore_certs)
+            .build()?;
         Ok(client)
     }
 }

--- a/src/client/kibana.rs
+++ b/src/client/kibana.rs
@@ -118,7 +118,7 @@ impl TryFrom<KnownHost> for KibanaClient {
 
     fn try_from(host: KnownHost) -> Result<Self> {
         let url = host.get_url();
-        let auth = host.get_auth();
+        let auth = host.get_auth()?;
         KibanaClient::try_new(url, auth)
     }
 }

--- a/src/data/keystore.rs
+++ b/src/data/keystore.rs
@@ -1,0 +1,302 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+use crate::env::ESDIAG_KEYSTORE_PASSWORD;
+use aes_gcm_siv::{
+    Aes256GcmSiv, Nonce,
+    aead::{Aead, KeyInit},
+};
+use base64::Engine;
+use eyre::{Result, eyre};
+use pbkdf2::pbkdf2_hmac;
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use std::{
+    collections::BTreeMap,
+    env,
+    fs::File,
+    io::{BufReader, BufWriter, IsTerminal},
+    path::PathBuf,
+};
+
+const KDF_ROUNDS: u32 = 100_000;
+const KEY_SIZE: usize = 32;
+const SALT_SIZE: usize = 16;
+const NONCE_SIZE: usize = 12;
+const KEYSTORE_FILE: &str = "secrets.yml";
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum SecretAuth {
+    ApiKey { apikey: String },
+    Basic { username: String, password: String },
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct BasicSecret {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct SecretEntry {
+    #[serde(rename = "ApiKey", skip_serializing_if = "Option::is_none")]
+    pub apikey: Option<String>,
+    #[serde(rename = "Basic", skip_serializing_if = "Option::is_none")]
+    pub basic: Option<BasicSecret>,
+}
+
+impl SecretEntry {
+    pub fn is_empty(&self) -> bool {
+        self.apikey.is_none() && self.basic.is_none()
+    }
+
+    pub fn upsert_auth(&mut self, auth: SecretAuth) {
+        match auth {
+            SecretAuth::ApiKey { apikey } => self.apikey = Some(apikey),
+            SecretAuth::Basic { username, password } => {
+                self.basic = Some(BasicSecret { username, password });
+            }
+        }
+    }
+
+    pub fn remove_auth(&mut self, auth: &SecretAuth) {
+        match auth {
+            SecretAuth::ApiKey { .. } => self.apikey = None,
+            SecretAuth::Basic { .. } => self.basic = None,
+        }
+    }
+
+    pub fn resolve_auth(&self) -> Option<SecretAuth> {
+        if let Some(apikey) = &self.apikey {
+            return Some(SecretAuth::ApiKey {
+                apikey: apikey.clone(),
+            });
+        }
+        self.basic.as_ref().map(|basic| SecretAuth::Basic {
+            username: basic.username.clone(),
+            password: basic.password.clone(),
+        })
+    }
+
+    pub fn contains_auth(&self, auth: &SecretAuth) -> bool {
+        match auth {
+            SecretAuth::ApiKey { apikey } => self.apikey.as_ref() == Some(apikey),
+            SecretAuth::Basic { username, password } => self
+                .basic
+                .as_ref()
+                .is_some_and(|b| b.username == *username && b.password == *password),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct KeystoreData {
+    version: u8,
+    secrets: BTreeMap<String, SecretEntry>,
+}
+
+impl Default for KeystoreData {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            secrets: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct EncryptedKeystore {
+    version: u8,
+    salt: String,
+    nonce: String,
+    ciphertext: String,
+}
+
+pub fn get_keystore_path() -> Result<PathBuf> {
+    if let Ok(path) = env::var("ESDIAG_KEYSTORE") {
+        return Ok(PathBuf::from(path));
+    }
+    let home_dir = match std::env::consts::OS {
+        "windows" => env::var("USERPROFILE")?,
+        "linux" | "macos" => env::var("HOME")?,
+        os => return Err(eyre!("Unknown home directory for operating system: {os}")),
+    };
+    let esdiag_dir = PathBuf::from(home_dir).join(".esdiag");
+    if !esdiag_dir.exists() {
+        std::fs::create_dir_all(&esdiag_dir)?;
+    }
+    Ok(esdiag_dir.join(KEYSTORE_FILE))
+}
+
+pub fn get_password_from_env() -> Result<String> {
+    env::var(ESDIAG_KEYSTORE_PASSWORD).map_err(|_| {
+        eyre!("{ESDIAG_KEYSTORE_PASSWORD} is not set; cannot decrypt secrets from keystore.")
+    })
+}
+
+pub fn get_password_for_secret_commands() -> Result<String> {
+    if let Ok(password) = env::var(ESDIAG_KEYSTORE_PASSWORD) {
+        return Ok(password);
+    }
+
+    if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
+        let prompt = format!("Enter keystore password ({ESDIAG_KEYSTORE_PASSWORD}): ");
+        return Ok(rpassword::prompt_password(prompt)?);
+    }
+
+    Err(eyre!(
+        "{ESDIAG_KEYSTORE_PASSWORD} is not set and no interactive terminal is available."
+    ))
+}
+
+pub fn add_secret(
+    secret_id: &str,
+    username: Option<String>,
+    password: Option<String>,
+    apikey: Option<String>,
+    keystore_password: &str,
+) -> Result<String> {
+    let auth = match (apikey, username, password) {
+        (Some(apikey), None, None) => SecretAuth::ApiKey { apikey },
+        (None, Some(username), Some(password)) => SecretAuth::Basic { username, password },
+        _ => {
+            return Err(eyre!(
+                "Invalid secret auth: use either --apikey or --user with --password"
+            ));
+        }
+    };
+
+    upsert_secret_auth(secret_id, auth, keystore_password)?;
+    Ok(get_keystore_path()?.display().to_string())
+}
+
+pub fn remove_secret(
+    secret_id: &str,
+    expected: Option<SecretAuth>,
+    keystore_password: &str,
+) -> Result<String> {
+    let mut store = read_store(keystore_password)?;
+    let entry = store
+        .secrets
+        .get_mut(secret_id)
+        .ok_or_else(|| eyre!("Secret '{secret_id}' not found"))?;
+
+    if let Some(expected) = expected {
+        if !entry.contains_auth(&expected) {
+            return Err(eyre!(
+                "Provided auth options do not match the stored secret for '{secret_id}'"
+            ));
+        }
+        entry.remove_auth(&expected);
+        if entry.is_empty() {
+            store.secrets.remove(secret_id);
+        }
+    } else {
+        store.secrets.remove(secret_id);
+    }
+
+    write_store(&store, keystore_password)?;
+    Ok(get_keystore_path()?.display().to_string())
+}
+
+pub fn get_secret(secret_id: &str, keystore_password: &str) -> Result<Option<SecretEntry>> {
+    let store = read_store(keystore_password)?;
+    Ok(store.secrets.get(secret_id).cloned())
+}
+
+pub fn upsert_secret_auth(
+    secret_id: &str,
+    auth: SecretAuth,
+    keystore_password: &str,
+) -> Result<()> {
+    let mut store = read_store(keystore_password)?;
+    let entry = store
+        .secrets
+        .entry(secret_id.to_string())
+        .or_insert_with(SecretEntry::default);
+    entry.upsert_auth(auth);
+    write_store(&store, keystore_password)?;
+    Ok(())
+}
+
+pub fn resolve_secret_auth(secret_id: &str, keystore_password: &str) -> Result<Option<SecretAuth>> {
+    let store = read_store(keystore_password)?;
+    Ok(store
+        .secrets
+        .get(secret_id)
+        .and_then(SecretEntry::resolve_auth))
+}
+
+fn read_store(keystore_password: &str) -> Result<KeystoreData> {
+    let path = get_keystore_path()?;
+    if !path.is_file() {
+        return Ok(KeystoreData::default());
+    }
+
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let encrypted: EncryptedKeystore = serde_yaml::from_reader(reader)?;
+    if encrypted.version != 1 {
+        return Err(eyre!(
+            "Unsupported keystore version {}",
+            encrypted.version
+        ));
+    }
+
+    let salt = base64::engine::general_purpose::STANDARD.decode(encrypted.salt)?;
+    let nonce = base64::engine::general_purpose::STANDARD.decode(encrypted.nonce)?;
+    let ciphertext = base64::engine::general_purpose::STANDARD.decode(encrypted.ciphertext)?;
+    if salt.len() != SALT_SIZE {
+        return Err(eyre!(
+            "Invalid keystore salt length {}, expected {}",
+            salt.len(),
+            SALT_SIZE
+        ));
+    }
+    if nonce.len() != NONCE_SIZE {
+        return Err(eyre!(
+            "Invalid keystore nonce length {}, expected {}",
+            nonce.len(),
+            NONCE_SIZE
+        ));
+    }
+
+    let key = derive_key(keystore_password, &salt);
+    let cipher = Aes256GcmSiv::new_from_slice(&key)?;
+    let plaintext = cipher
+        .decrypt(Nonce::from_slice(&nonce), ciphertext.as_ref())
+        .map_err(|_| eyre!("Failed to decrypt keystore. Check keystore password."))?;
+    Ok(serde_yaml::from_slice(&plaintext)?)
+}
+
+fn write_store(store: &KeystoreData, keystore_password: &str) -> Result<()> {
+    let salt = rand::random::<[u8; SALT_SIZE]>();
+    let nonce = rand::random::<[u8; NONCE_SIZE]>();
+    let key = derive_key(keystore_password, &salt);
+    let plaintext = serde_yaml::to_string(store)?;
+
+    let cipher = Aes256GcmSiv::new_from_slice(&key)?;
+    let ciphertext = cipher
+        .encrypt(Nonce::from_slice(&nonce), plaintext.as_bytes())
+        .map_err(|_| eyre!("Failed to encrypt keystore"))?;
+
+    let envelope = EncryptedKeystore {
+        version: 1,
+        salt: base64::engine::general_purpose::STANDARD.encode(salt),
+        nonce: base64::engine::general_purpose::STANDARD.encode(nonce),
+        ciphertext: base64::engine::general_purpose::STANDARD.encode(ciphertext),
+    };
+
+    let path = get_keystore_path()?;
+    let file = File::create(path)?;
+    let writer = BufWriter::new(file);
+    serde_yaml::to_writer(writer, &envelope)?;
+    Ok(())
+}
+
+fn derive_key(password: &str, salt: &[u8]) -> [u8; KEY_SIZE] {
+    let mut key = [0_u8; KEY_SIZE];
+    pbkdf2_hmac::<Sha256>(password.as_bytes(), salt, KDF_ROUNDS, &mut key);
+    key
+}

--- a/src/data/known_host.rs
+++ b/src/data/known_host.rs
@@ -2,7 +2,10 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use crate::data::{Auth, Product};
+use crate::data::{
+    Auth, Product, SecretAuth, get_password_from_env, resolve_secret_auth as resolve_secret_by_id,
+    upsert_secret_auth,
+};
 use eyre::{Result, eyre};
 use serde::{Deserialize, Serialize};
 use serde_yaml;
@@ -16,6 +19,45 @@ use std::{
     str::FromStr,
 };
 use url::Url;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HostRole {
+    Collect,
+    Send,
+    View,
+}
+
+impl std::fmt::Display for HostRole {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Collect => write!(f, "collect"),
+            Self::Send => write!(f, "send"),
+            Self::View => write!(f, "view"),
+        }
+    }
+}
+
+impl FromStr for HostRole {
+    type Err = eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "collect" => Ok(Self::Collect),
+            "send" => Ok(Self::Send),
+            "view" => Ok(Self::View),
+            _ => Err(eyre!("Unknown host role '{s}'")),
+        }
+    }
+}
+
+fn default_collect_roles() -> Vec<HostRole> {
+    vec![HostRole::Collect]
+}
+
+fn roles_is_default_collect(roles: &[HostRole]) -> bool {
+    roles.len() == 1 && roles[0] == HostRole::Collect
+}
 
 #[derive(Clone, Serialize, Deserialize)]
 pub enum ElasticCloud {
@@ -56,8 +98,11 @@ pub struct KnownHostBuilder {
     product: Product,
     cloud_id: Option<ElasticCloud>,
     password: Option<String>,
+    roles: Vec<HostRole>,
+    secret: Option<String>,
     url: Url,
     username: Option<String>,
+    viewer: Option<String>,
 }
 
 impl KnownHostBuilder {
@@ -68,8 +113,11 @@ impl KnownHostBuilder {
             product: Product::Elasticsearch,
             cloud_id: None,
             password: None,
+            roles: default_collect_roles(),
+            secret: None,
             url,
             username: None,
+            viewer: None,
         }
     }
 
@@ -92,8 +140,20 @@ impl KnownHostBuilder {
         Self { product, ..self }
     }
 
+    pub fn secret(self, secret: Option<String>) -> Self {
+        Self { secret, ..self }
+    }
+
+    pub fn roles(self, roles: Vec<HostRole>) -> Self {
+        Self { roles, ..self }
+    }
+
     pub fn username(self, username: Option<String>) -> Self {
         Self { username, ..self }
+    }
+
+    pub fn viewer(self, viewer: Option<String>) -> Self {
+        Self { viewer, ..self }
     }
 
     fn update_cloud_api_path(&mut self) {
@@ -143,24 +203,43 @@ impl KnownHostBuilder {
 
     pub fn build(mut self) -> Result<KnownHost> {
         self.update_cloud_api_path();
-        match (self.apikey, self.username, self.password) {
-            (Some(apikey), None, None) => Ok(KnownHost::ApiKey {
+        match (self.apikey, self.username, self.password, self.secret) {
+            (Some(apikey), None, None, secret) => Ok(KnownHost::ApiKey {
                 accept_invalid_certs: self.accept_invalid_certs,
-                apikey,
+                apikey: Some(apikey),
                 app: self.product,
                 cloud_id: self.cloud_id,
+                roles: self.roles,
+                secret,
                 url: self.url,
+                viewer: self.viewer,
             }),
-            (None, Some(username), Some(password)) => Ok(KnownHost::Basic {
+            (None, Some(username), Some(password), secret) => Ok(KnownHost::Basic {
                 accept_invalid_certs: self.accept_invalid_certs,
                 app: self.product,
-                password,
+                password: Some(password),
+                roles: self.roles,
+                secret,
                 url: self.url,
-                username,
+                username: Some(username),
+                viewer: self.viewer,
             }),
-            (None, None, None) => Ok(KnownHost::NoAuth {
+            (None, None, None, None) => Ok(KnownHost::NoAuth {
                 app: self.product,
+                roles: self.roles,
                 url: self.url,
+                viewer: self.viewer,
+            }),
+            // Allow hosts to persist only a secret reference.
+            (None, None, None, Some(secret)) => Ok(KnownHost::Basic {
+                accept_invalid_certs: self.accept_invalid_certs,
+                app: self.product,
+                password: None,
+                roles: self.roles,
+                secret: Some(secret),
+                url: self.url,
+                username: None,
+                viewer: self.viewer,
             }),
             _ => Err(eyre!("Invalid KnownHost configuration")),
         }
@@ -173,23 +252,45 @@ pub enum KnownHost {
     /// A host using API key authentication
     ApiKey {
         accept_invalid_certs: bool,
-        apikey: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        apikey: Option<String>,
         app: Product,
         #[serde(skip_serializing_if = "Option::is_none")]
         cloud_id: Option<ElasticCloud>,
+        #[serde(default = "default_collect_roles", skip_serializing_if = "roles_is_default_collect")]
+        roles: Vec<HostRole>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        secret: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        viewer: Option<String>,
         url: Url,
     },
     /// A host using basic username/password authentication
     Basic {
         accept_invalid_certs: bool,
         app: Product,
-        password: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        password: Option<String>,
+        #[serde(default = "default_collect_roles", skip_serializing_if = "roles_is_default_collect")]
+        roles: Vec<HostRole>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        secret: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        viewer: Option<String>,
         url: Url,
-        username: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        username: Option<String>,
     },
     /// A host with no authentication
     #[serde(alias = "None")]
-    NoAuth { app: Product, url: Url },
+    NoAuth {
+        app: Product,
+        #[serde(default = "default_collect_roles", skip_serializing_if = "roles_is_default_collect")]
+        roles: Vec<HostRole>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        viewer: Option<String>,
+        url: Url,
+    },
 }
 
 impl KnownHost {
@@ -209,17 +310,56 @@ impl KnownHost {
         }
     }
 
-    pub fn get_auth(&self) -> Auth {
+    pub fn roles(&self) -> &[HostRole] {
         match self {
-            Self::ApiKey { apikey, .. } => Auth::Apikey(apikey.clone()),
-            Self::Basic {
-                username, password, ..
-            } => Auth::Basic(username.clone(), password.clone()),
-            Self::NoAuth { .. } => Auth::None,
+            Self::ApiKey { roles, .. } => roles,
+            Self::Basic { roles, .. } => roles,
+            Self::NoAuth { roles, .. } => roles,
         }
     }
 
-    pub fn save(self, name: &str) -> Result<String> {
+    pub fn has_role(&self, role: HostRole) -> bool {
+        self.roles().contains(&role)
+    }
+
+    pub fn viewer(&self) -> Option<&str> {
+        match self {
+            Self::ApiKey { viewer, .. } => viewer.as_deref(),
+            Self::Basic { viewer, .. } => viewer.as_deref(),
+            Self::NoAuth { viewer, .. } => viewer.as_deref(),
+        }
+    }
+
+    pub fn accept_invalid_certs(&self) -> bool {
+        match self {
+            Self::ApiKey {
+                accept_invalid_certs,
+                ..
+            } => *accept_invalid_certs,
+            Self::Basic {
+                accept_invalid_certs,
+                ..
+            } => *accept_invalid_certs,
+            Self::NoAuth { .. } => false,
+        }
+    }
+
+    pub fn get_auth(&self) -> Result<Auth> {
+        match self {
+            Self::ApiKey { apikey, secret, .. } => {
+                resolve_auth_with_precedence(secret, apikey.clone(), None)
+            }
+            Self::Basic {
+                username,
+                password,
+                secret,
+                ..
+            } => resolve_auth_with_precedence(secret, None, username.clone().zip(password.clone())),
+            Self::NoAuth { .. } => Ok(Auth::None),
+        }
+    }
+
+    pub fn save(mut self, name: &str) -> Result<String> {
         // parse the ~/.esdiag/hosts.yml file into a HashMap<String, Host>
         let mut hosts = match KnownHost::parse_hosts_yml() {
             Ok(hosts) => hosts,
@@ -228,6 +368,8 @@ impl KnownHost {
                 return Err(eyre!("Error parsing hosts.yml"));
             }
         };
+        self.normalize_and_validate_roles(name)?;
+        self.strip_plaintext_when_secret_present();
         match self {
             Self::ApiKey { .. } => {
                 hosts.insert(name.to_owned(), self);
@@ -242,6 +384,28 @@ impl KnownHost {
         KnownHost::write_hosts_yml(&hosts)
     }
 
+    fn strip_plaintext_when_secret_present(&mut self) {
+        match self {
+            Self::ApiKey { apikey, secret, .. } => {
+                if secret.is_some() {
+                    *apikey = None;
+                }
+            }
+            Self::Basic {
+                username,
+                password,
+                secret,
+                ..
+            } => {
+                if secret.is_some() {
+                    *username = None;
+                    *password = None;
+                }
+            }
+            Self::NoAuth { .. } => {}
+        }
+    }
+
     pub fn get_known(host: &String) -> Option<Self> {
         // parse the ~/.esdiag/hosts.yml file into a HashMap<String, Host>
         let hosts = match KnownHost::parse_hosts_yml() {
@@ -254,12 +418,91 @@ impl KnownHost {
         log::debug!(
             "Known hosts: {}",
             hosts
-                .clone()
-                .into_keys()
+                .clone().into_keys()
                 .collect::<Vec<String>>()
                 .join(", ")
         );
         hosts.get(host).cloned()
+    }
+
+    pub fn has_legacy_secret(&self) -> bool {
+        match self {
+            Self::ApiKey { apikey, .. } => apikey.is_some(),
+            Self::Basic {
+                username, password, ..
+            } => username.is_some() || password.is_some(),
+            Self::NoAuth { .. } => false,
+        }
+    }
+
+    pub fn set_secret_reference(&mut self, secret_id: String) {
+        match self {
+            Self::ApiKey { apikey, secret, .. } => {
+                *apikey = None;
+                *secret = Some(secret_id);
+            }
+            Self::Basic {
+                username,
+                password,
+                secret,
+                ..
+            } => {
+                *username = None;
+                *password = None;
+                *secret = Some(secret_id);
+            }
+            Self::NoAuth { .. } => {}
+        }
+    }
+
+    pub fn migrate_hosts_to_keystore(keystore_password: &str) -> Result<(usize, usize)> {
+        let mut hosts = Self::parse_hosts_yml()?;
+        let mut migrated = 0_usize;
+        let mut unchanged = 0_usize;
+
+        for (name, host) in hosts.iter_mut() {
+            match host.legacy_auth() {
+                Some(auth) => {
+                    upsert_secret_auth(name, auth, keystore_password)?;
+                    host.set_secret_reference(name.clone());
+                    migrated += 1;
+                }
+                None => unchanged += 1,
+            }
+        }
+
+        Self::write_hosts_yml(&hosts)?;
+        Ok((migrated, unchanged))
+    }
+
+    pub fn list_by_role(role: HostRole) -> Result<Vec<String>> {
+        let hosts = Self::parse_hosts_yml()?;
+        let mut names: Vec<String> = hosts
+            .iter()
+            .filter_map(|(name, host)| host.has_role(role.clone()).then_some(name.clone()))
+            .collect();
+        names.sort();
+        Ok(names)
+    }
+
+    fn legacy_auth(&self) -> Option<SecretAuth> {
+        match self {
+            Self::ApiKey {
+                apikey: Some(apikey),
+                ..
+            } => Some(SecretAuth::ApiKey {
+                apikey: apikey.clone(),
+            }),
+            Self::Basic {
+                username: Some(username),
+                password: Some(password),
+                ..
+            } => Some(SecretAuth::Basic {
+                username: username.clone(),
+                password: password.clone(),
+            }),
+            _ => None,
+        }
     }
 
     pub fn list_all() -> Option<Vec<String>> {
@@ -272,6 +515,8 @@ impl KnownHost {
     pub fn from_url(url: &Url) -> Self {
         KnownHost::NoAuth {
             app: Product::Elasticsearch,
+            roles: default_collect_roles(),
+            viewer: None,
             url: url.clone(),
         }
     }
@@ -291,7 +536,7 @@ impl KnownHost {
                 if !esdiag.exists() {
                     std::fs::create_dir(&esdiag).expect("Failed to create ~/.esdiag directory");
                 }
-
+                
                 home_dir.join(".esdiag").join("hosts.yml")
             }
         }
@@ -305,7 +550,11 @@ impl KnownHost {
             true => {
                 let file = File::open(path)?;
                 let reader = BufReader::new(file);
-                let hosts: BTreeMap<String, KnownHost> = serde_yaml::from_reader(reader)?;
+                let mut hosts: BTreeMap<String, KnownHost> = serde_yaml::from_reader(reader)?;
+                for (name, host) in hosts.iter_mut() {
+                    host.normalize_and_validate_roles(name)?;
+                }
+                validate_viewer_links(&hosts)?;
                 Ok(hosts)
             }
             false => {
@@ -318,19 +567,61 @@ impl KnownHost {
 
     pub fn write_hosts_yml(hosts: &BTreeMap<String, KnownHost>) -> Result<String> {
         let path = KnownHost::get_hosts_path();
+        let mut hosts = hosts.clone();
+        for (name, host) in hosts.iter_mut() {
+            host.normalize_and_validate_roles(name)?;
+        }
+        validate_viewer_links(&hosts)?;
         log::debug!(
             "Writing hosts: {} to {:?}",
             hosts
-                .clone()
-                .into_keys()
+                .clone().into_keys()
                 .collect::<Vec<String>>()
                 .join(", "),
             path
         );
         let file = File::create(&path)?;
         let writer = BufWriter::new(file);
-        serde_yaml::to_writer(writer, hosts)?;
+        serde_yaml::to_writer(writer, &hosts)?;
         Ok(format!("{}", &path.display()))
+    }
+
+    fn normalize_and_validate_roles(&mut self, host_name: &str) -> Result<()> {
+        let app = self.app().clone();
+        let roles = match self {
+            Self::ApiKey { roles, .. } => roles,
+            Self::Basic { roles, .. } => roles,
+            Self::NoAuth { roles, .. } => roles,
+        };
+
+        if roles.is_empty() {
+            roles.push(HostRole::Collect);
+        }
+        roles.sort_by_key(|r| match r {
+            HostRole::Collect => 0,
+            HostRole::Send => 1,
+            HostRole::View => 2,
+        });
+        roles.dedup();
+
+        for role in roles.iter() {
+            match role {
+                HostRole::Collect => {}
+                HostRole::Send if app == Product::Elasticsearch => {}
+                HostRole::View if app == Product::Kibana => {}
+                HostRole::Send => {
+                    return Err(eyre!(
+                        "Host '{host_name}' role 'send' is only valid for Elasticsearch hosts"
+                    ));
+                }
+                HostRole::View => {
+                    return Err(eyre!(
+                        "Host '{host_name}' role 'view' is only valid for Kibana hosts"
+                    ));
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -349,10 +640,75 @@ impl Display for KnownHost {
             Self::Basic {
                 app, url, username, ..
             } => {
+                let username = username
+                    .clone()
+                    .unwrap_or_else(|| "<secret-auth>".to_string());
                 write!(fmt, "KnownHost Basic: {} {}@ {}", app, username, url,)
             }
-            Self::NoAuth { app, url } => write!(fmt, "KnownHost NoAuth: {} {}", app, url),
+            Self::NoAuth { app, url, .. } => write!(fmt, "KnownHost NoAuth: {} {}", app, url),
         }
+    }
+}
+
+fn validate_viewer_links(hosts: &BTreeMap<String, KnownHost>) -> Result<()> {
+    for (name, host) in hosts {
+        if let Some(viewer_name) = host.viewer() {
+            if !host.has_role(HostRole::Send) {
+                return Err(eyre!(
+                    "Host '{name}' sets 'viewer' but does not have required role 'send'"
+                ));
+            }
+            let Some(viewer_host) = hosts.get(viewer_name) else {
+                return Err(eyre!(
+                    "Host '{name}' references unknown viewer host '{viewer_name}'"
+                ));
+            };
+            if !viewer_host.has_role(HostRole::View) {
+                return Err(eyre!(
+                    "Host '{name}' viewer '{viewer_name}' must include role 'view'"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn resolve_auth_with_precedence(
+    secret_id: &Option<String>,
+    legacy_apikey: Option<String>,
+    legacy_basic: Option<(String, String)>,
+) -> Result<Auth> {
+    if let Some(secret_id) = secret_id {
+        let auth = resolve_explicit_secret(secret_id)?;
+        if legacy_apikey.is_some() || legacy_basic.is_some() {
+            log::warn!(
+                "Legacy credentials exist in hosts.yml and keystore entry '{secret_id}' exists; using keystore credentials."
+            );
+        }
+        return Ok(auth);
+    }
+
+    if let Some(apikey) = legacy_apikey {
+        return Ok(Auth::Apikey(apikey));
+    }
+    if let Some((username, password)) = legacy_basic {
+        return Ok(Auth::Basic(username, password));
+    }
+    Ok(Auth::None)
+}
+
+fn resolve_explicit_secret(secret_id: &str) -> Result<Auth> {
+    let keystore_password = get_password_from_env()
+        .map_err(|err| eyre!("Host references secret '{secret_id}' but {err}"))?;
+    let secret = resolve_secret_by_id(secret_id, &keystore_password)?
+        .ok_or_else(|| eyre!("Secret '{secret_id}' was not found in keystore"))?;
+    secret_auth_to_auth(secret)
+}
+
+fn secret_auth_to_auth(secret: SecretAuth) -> Result<Auth> {
+    match secret {
+        SecretAuth::ApiKey { apikey } => Ok(Auth::Apikey(apikey)),
+        SecretAuth::Basic { username, password } => Ok(Auth::Basic(username, password)),
     }
 }
 
@@ -373,5 +729,419 @@ impl From<KnownHost> for Url {
             KnownHost::Basic { url, .. } => url.clone(),
             KnownHost::NoAuth { url, .. } => url.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::{get_secret, upsert_secret_auth};
+    use std::sync::{Mutex, OnceLock};
+    use tempfile::TempDir;
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn setup_env() -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
+        let tmp = TempDir::new().expect("temp dir");
+        let hosts = tmp.path().join("hosts.yml");
+        let keystore = tmp.path().join("secrets.yml");
+        unsafe {
+            std::env::set_var("ESDIAG_HOSTS", &hosts);
+            std::env::set_var("ESDIAG_KEYSTORE", &keystore);
+        }
+        (tmp, hosts, keystore)
+    }
+
+    fn write_hosts(hosts: BTreeMap<String, KnownHost>) {
+        KnownHost::write_hosts_yml(&hosts).expect("write hosts");
+    }
+
+    #[test]
+    fn roles_default_to_collect_when_omitted() {
+        let _guard = env_lock().lock().expect("env lock");
+        let (_tmp, _hosts, _keystore) = setup_env();
+
+        let mut hosts = BTreeMap::new();
+        hosts.insert(
+            "default-role".to_string(),
+            KnownHost::NoAuth {
+                app: Product::Elasticsearch,
+                roles: Vec::new(),
+                viewer: None,
+                url: Url::parse("http://localhost:9200").expect("url"),
+            },
+        );
+        write_hosts(hosts);
+
+        let host = KnownHost::get_known(&"default-role".to_string()).expect("host");
+        assert!(host.has_role(HostRole::Collect));
+    }
+
+    #[test]
+    fn invalid_send_role_on_kibana_is_rejected() {
+        let _guard = env_lock().lock().expect("env lock");
+        let (_tmp, _hosts, _keystore) = setup_env();
+
+        let mut hosts = BTreeMap::new();
+        hosts.insert(
+            "kb-invalid-send".to_string(),
+            KnownHost::NoAuth {
+                app: Product::Kibana,
+                roles: vec![HostRole::Send],
+                viewer: None,
+                url: Url::parse("http://localhost:5601").expect("url"),
+            },
+        );
+        let err = KnownHost::write_hosts_yml(&hosts).expect_err("expected invalid role error");
+        assert!(err.to_string().contains("role 'send' is only valid"));
+    }
+
+    #[test]
+    fn list_by_role_filters_mixed_inventory() {
+        let _guard = env_lock().lock().expect("env lock");
+        let (_tmp, _hosts, _keystore) = setup_env();
+
+        let mut hosts = BTreeMap::new();
+        hosts.insert(
+            "collect-only".to_string(),
+            KnownHost::NoAuth {
+                app: Product::Elasticsearch,
+                roles: vec![HostRole::Collect],
+                viewer: None,
+                url: Url::parse("http://localhost:9200").expect("url"),
+            },
+        );
+        hosts.insert(
+            "collect-send".to_string(),
+            KnownHost::NoAuth {
+                app: Product::Elasticsearch,
+                roles: vec![HostRole::Collect, HostRole::Send],
+                viewer: None,
+                url: Url::parse("http://localhost:9201").expect("url"),
+            },
+        );
+        hosts.insert(
+            "view-host".to_string(),
+            KnownHost::NoAuth {
+                app: Product::Kibana,
+                roles: vec![HostRole::View],
+                viewer: None,
+                url: Url::parse("http://localhost:5601").expect("url"),
+            },
+        );
+        write_hosts(hosts);
+
+        let collect = KnownHost::list_by_role(HostRole::Collect).expect("collect list");
+        let send = KnownHost::list_by_role(HostRole::Send).expect("send list");
+        let view = KnownHost::list_by_role(HostRole::View).expect("view list");
+
+        assert_eq!(collect, vec!["collect-only".to_string(), "collect-send".to_string()]);
+        assert_eq!(send, vec!["collect-send".to_string()]);
+        assert_eq!(view, vec!["view-host".to_string()]);
+    }
+
+    #[test]
+    fn viewer_requires_send_role_on_source_host() {
+        let _guard = env_lock().lock().expect("env lock");
+        let (_tmp, _hosts, _keystore) = setup_env();
+        let mut hosts = BTreeMap::new();
+        hosts.insert(
+            "source".to_string(),
+            KnownHost::NoAuth {
+                app: Product::Elasticsearch,
+                roles: vec![HostRole::Collect],
+                viewer: Some("viewer-host".to_string()),
+                url: Url::parse("http://localhost:9200").expect("url"),
+            },
+        );
+        hosts.insert(
+            "viewer-host".to_string(),
+            KnownHost::NoAuth {
+                app: Product::Kibana,
+                roles: vec![HostRole::View],
+                viewer: None,
+                url: Url::parse("http://localhost:5601").expect("url"),
+            },
+        );
+        let err = KnownHost::write_hosts_yml(&hosts).expect_err("expected viewer validation error");
+        assert!(err.to_string().contains("required role 'send'"));
+    }
+
+    #[test]
+    fn viewer_must_reference_view_role_host() {
+        let _guard = env_lock().lock().expect("env lock");
+        let (_tmp, _hosts, _keystore) = setup_env();
+        let mut hosts = BTreeMap::new();
+        hosts.insert(
+            "source".to_string(),
+            KnownHost::NoAuth {
+                app: Product::Elasticsearch,
+                roles: vec![HostRole::Send],
+                viewer: Some("viewer-host".to_string()),
+                url: Url::parse("http://localhost:9200").expect("url"),
+            },
+        );
+        hosts.insert(
+            "viewer-host".to_string(),
+            KnownHost::NoAuth {
+                app: Product::Kibana,
+                roles: vec![HostRole::Collect],
+                viewer: None,
+                url: Url::parse("http://localhost:5601").expect("url"),
+            },
+        );
+        let err = KnownHost::write_hosts_yml(&hosts).expect_err("expected viewer role error");
+        assert!(err.to_string().contains("must include role 'view'"));
+    }
+
+    #[test]
+    fn viewer_reference_valid_when_source_send_and_target_view() {
+        let _guard = env_lock().lock().expect("env lock");
+        let (_tmp, _hosts, _keystore) = setup_env();
+        let mut hosts = BTreeMap::new();
+        hosts.insert(
+            "source".to_string(),
+            KnownHost::NoAuth {
+                app: Product::Elasticsearch,
+                roles: vec![HostRole::Send],
+                viewer: Some("viewer-host".to_string()),
+                url: Url::parse("http://localhost:9200").expect("url"),
+            },
+        );
+        hosts.insert(
+            "viewer-host".to_string(),
+            KnownHost::NoAuth {
+                app: Product::Kibana,
+                roles: vec![HostRole::View],
+                viewer: None,
+                url: Url::parse("http://localhost:5601").expect("url"),
+            },
+        );
+        KnownHost::write_hosts_yml(&hosts).expect("viewer validation should pass");
+    }
+
+    #[test]
+    fn legacy_hosts_auth_resolves_without_keystore() {
+        let _guard = env_lock().lock().expect("env lock");
+        let (_tmp, _hosts, _keystore) = setup_env();
+        unsafe {
+            std::env::remove_var("ESDIAG_KEYSTORE_PASSWORD");
+        }
+
+        let mut hosts = BTreeMap::new();
+        hosts.insert(
+            "legacy-es".to_string(),
+            KnownHost::ApiKey {
+                accept_invalid_certs: false,
+                apikey: Some("legacy-key".to_string()),
+                app: Product::Elasticsearch,
+                cloud_id: None,
+                roles: default_collect_roles(),
+                secret: None,
+                viewer: None,
+                url: Url::parse("http://localhost:9200").expect("url"),
+            },
+        );
+        write_hosts(hosts);
+
+        let host = KnownHost::get_known(&"legacy-es".to_string()).expect("host");
+        let auth = host.get_auth().expect("auth");
+        assert!(matches!(auth, Auth::Apikey(k) if k == "legacy-key"));
+    }
+
+    #[test]
+    fn explicit_secret_missing_keystore_fails() {
+        let _guard = env_lock().lock().expect("env lock");
+        let (_tmp, _hosts, _keystore) = setup_env();
+        unsafe {
+            std::env::remove_var("ESDIAG_KEYSTORE_PASSWORD");
+            std::env::set_var("ESDIAG_OUTPUT_APIKEY", "env-key");
+            std::env::remove_var("ESDIAG_OUTPUT_USERNAME");
+            std::env::remove_var("ESDIAG_OUTPUT_PASSWORD");
+        }
+
+        let mut hosts = BTreeMap::new();
+        hosts.insert(
+            "secret-only".to_string(),
+            KnownHost::Basic {
+                accept_invalid_certs: false,
+                app: Product::Elasticsearch,
+                password: None,
+                roles: default_collect_roles(),
+                secret: Some("missing-secret".to_string()),
+                viewer: None,
+                url: Url::parse("http://localhost:9200").expect("url"),
+                username: None,
+            },
+        );
+        write_hosts(hosts);
+
+        let host = KnownHost::get_known(&"secret-only".to_string()).expect("host");
+        let err = host.get_auth().err().expect("auth should fail");
+        assert!(err.to_string().contains("missing-secret"));
+        unsafe {
+            std::env::remove_var("ESDIAG_OUTPUT_APIKEY");
+        }
+    }
+
+    #[test]
+    fn explicit_secret_takes_precedence_over_legacy_fields() {
+        let _guard = env_lock().lock().expect("env lock");
+        let (_tmp, _hosts, _keystore) = setup_env();
+        unsafe {
+            std::env::set_var("ESDIAG_KEYSTORE_PASSWORD", "pw");
+        }
+
+        upsert_secret_auth(
+            "custom-secret",
+            SecretAuth::ApiKey {
+                apikey: "secret-key".to_string(),
+            },
+            "pw",
+        )
+        .expect("upsert secret");
+
+        let mut hosts = BTreeMap::new();
+        hosts.insert(
+            "prod-es".to_string(),
+            KnownHost::Basic {
+                accept_invalid_certs: false,
+                app: Product::Elasticsearch,
+                password: Some("legacy-pass".to_string()),
+                roles: default_collect_roles(),
+                secret: Some("custom-secret".to_string()),
+                viewer: None,
+                url: Url::parse("http://localhost:9200").expect("url"),
+                username: Some("legacy-user".to_string()),
+            },
+        );
+        write_hosts(hosts);
+
+        let host = KnownHost::get_known(&"prod-es".to_string()).expect("host");
+        let auth = host.get_auth().expect("auth");
+        assert!(matches!(auth, Auth::Apikey(k) if k == "secret-key"));
+    }
+
+    #[test]
+    fn no_secret_uses_legacy_auth_without_keystore_lookup() {
+        let _guard = env_lock().lock().expect("env lock");
+        let (_tmp, _hosts, _keystore) = setup_env();
+        unsafe {
+            std::env::set_var("ESDIAG_KEYSTORE_PASSWORD", "pw");
+        }
+
+        upsert_secret_auth(
+            "prod-es",
+            SecretAuth::ApiKey {
+                apikey: "keystore-key".to_string(),
+            },
+            "pw",
+        )
+        .expect("upsert secret");
+
+        let mut hosts = BTreeMap::new();
+        hosts.insert(
+            "prod-es".to_string(),
+            KnownHost::Basic {
+                accept_invalid_certs: false,
+                app: Product::Elasticsearch,
+                password: Some("legacy-pass".to_string()),
+                roles: default_collect_roles(),
+                secret: None,
+                viewer: None,
+                url: Url::parse("http://localhost:9200").expect("url"),
+                username: Some("legacy-user".to_string()),
+            },
+        );
+        hosts.insert(
+            "legacy-only".to_string(),
+            KnownHost::Basic {
+                accept_invalid_certs: false,
+                app: Product::Elasticsearch,
+                password: Some("legacy-only-pass".to_string()),
+                roles: default_collect_roles(),
+                secret: None,
+                viewer: None,
+                url: Url::parse("http://localhost:9201").expect("url"),
+                username: Some("legacy-only-user".to_string()),
+            },
+        );
+        write_hosts(hosts);
+
+        let prod_host = KnownHost::get_known(&"prod-es".to_string()).expect("host");
+        let prod_auth = prod_host.get_auth().expect("auth");
+        assert!(
+            matches!(prod_auth, Auth::Basic(user, pass) if user == "legacy-user" && pass == "legacy-pass")
+        );
+
+        let fallback_host = KnownHost::get_known(&"legacy-only".to_string()).expect("host");
+        let fallback_auth = fallback_host.get_auth().expect("auth");
+        assert!(
+            matches!(fallback_auth, Auth::Basic(user, pass) if user == "legacy-only-user" && pass == "legacy-only-pass")
+        );
+    }
+
+    #[test]
+    fn migrate_hosts_moves_legacy_credentials_to_keystore() {
+        let _guard = env_lock().lock().expect("env lock");
+        let (_tmp, _hosts, _keystore) = setup_env();
+        unsafe {
+            std::env::set_var("ESDIAG_KEYSTORE_PASSWORD", "pw");
+        }
+
+        let mut hosts = BTreeMap::new();
+        hosts.insert(
+            "es-prod".to_string(),
+            KnownHost::ApiKey {
+                accept_invalid_certs: false,
+                apikey: Some("apikey-1".to_string()),
+                app: Product::Elasticsearch,
+                cloud_id: None,
+                roles: default_collect_roles(),
+                secret: None,
+                viewer: None,
+                url: Url::parse("http://localhost:9200").expect("url"),
+            },
+        );
+        hosts.insert(
+            "kb-prod".to_string(),
+            KnownHost::Basic {
+                accept_invalid_certs: false,
+                app: Product::Kibana,
+                password: Some("pass-1".to_string()),
+                roles: default_collect_roles(),
+                secret: None,
+                viewer: None,
+                url: Url::parse("http://localhost:5601").expect("url"),
+                username: Some("elastic".to_string()),
+            },
+        );
+        write_hosts(hosts);
+
+        let (migrated, unchanged) =
+            KnownHost::migrate_hosts_to_keystore("pw").expect("migrate should succeed");
+        assert_eq!(migrated, 2);
+        assert_eq!(unchanged, 0);
+
+        let es_secret = get_secret("es-prod", "pw")
+            .expect("get secret")
+            .expect("es secret exists");
+        assert_eq!(es_secret.apikey.as_deref(), Some("apikey-1"));
+        assert!(es_secret.basic.is_none());
+
+        let kb_secret = get_secret("kb-prod", "pw")
+            .expect("get secret")
+            .expect("kb secret exists");
+        assert_eq!(
+            kb_secret.basic.as_ref().map(|b| b.username.as_str()),
+            Some("elastic")
+        );
+        assert_eq!(
+            kb_secret.basic.as_ref().map(|b| b.password.as_str()),
+            Some("pass-1")
+        );
     }
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -4,6 +4,8 @@
 
 /// Authentication methods
 mod auth;
+/// Encrypted secret storage
+mod keystore;
 /// Manage saving and loading hosts from a YAML file
 mod known_host;
 /// Elastic stack products
@@ -14,7 +16,11 @@ pub mod settings;
 mod uri;
 
 pub use auth::{Auth, AuthType};
-pub use known_host::{ElasticCloud, KnownHost, KnownHostBuilder};
+pub use keystore::{
+    BasicSecret, SecretAuth, SecretEntry, add_secret, get_password_for_secret_commands,
+    get_password_from_env, get_secret, remove_secret, resolve_secret_auth, upsert_secret_auth,
+};
+pub use known_host::{ElasticCloud, HostRole, KnownHost, KnownHostBuilder};
 pub use product::Product;
 pub use settings::Settings;
 pub use uri::Uri;

--- a/src/env.rs
+++ b/src/env.rs
@@ -7,6 +7,7 @@ pub const ESDIAG_ES_WORKERS: usize = 4;
 pub static ESDIAG_HOME: &str = ".esdiag";
 pub static LOG_LEVEL: &str = "info";
 pub static ESDIAG_KIBANA_URL: &str = "http://localhost:5601";
+pub static ESDIAG_KEYSTORE_PASSWORD: &str = "ESDIAG_KEYSTORE_PASSWORD";
 
 fn default_int(name: &str) -> Option<usize> {
     match name {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,14 +11,16 @@ use esdiag::server::{RuntimeMode, Server};
 use esdiag::setup;
 use esdiag::{
     client::Client,
-    data::{KnownHost, KnownHostBuilder, Product, Uri},
+    data::{
+        HostRole, KnownHost, KnownHostBuilder, Product, SecretAuth, Uri, add_secret,
+        get_password_for_secret_commands, remove_secret,
+    },
     env::LOG_LEVEL,
     exporter::Exporter,
     processor::{Collector, Identifiers, Processor},
     receiver::Receiver,
 };
 use eyre::{Result, eyre};
-use std::path::PathBuf;
 use std::sync::Arc;
 #[cfg(feature = "server")]
 use tokio::signal::unix::{SignalKind, signal};
@@ -57,9 +59,6 @@ enum Commands {
         /// The output directory to save the diagnostics to
         #[arg(help = "An existing directory to create a diagnostic directory and files in")]
         output: String,
-        /// Write collected API output directly to a zip archive
-        #[arg(long)]
-        zip: bool,
         /// Diagnostic type
         #[arg(
             long,
@@ -116,9 +115,6 @@ enum Commands {
             long_help = "Kibana URL to display in the web interface. If not provided, will use the ESDIAG_KIBANA_URL environment variable."
         )]
         kibana: Option<String>,
-        /// Runtime mode for web interfaces (service or user)
-        #[arg(long, value_enum)]
-        mode: Option<RuntimeMode>,
     },
     /// Configure, test and save a remote host connection to `~/.esdiag/hosts.yml`
     Host {
@@ -138,11 +134,26 @@ enum Commands {
         #[arg(help = "ApiKey, passed as http header ", long, short, conflicts_with_all = &["username", "password"])]
         apikey: Option<String>,
         /// Username for authentication
-        #[arg(help = "Username for authentication", long, short)]
+        #[arg(
+            help = "Username for authentication",
+            long = "user",
+            visible_alias = "username",
+            short
+        )]
         username: Option<String>,
         /// Password for authentication
         #[arg(help = "Password for authentication", long, short)]
         password: Option<String>,
+        /// Secret identifier in the encrypted keystore
+        #[arg(
+            help = "Secret identifier in the encrypted keystore",
+            long,
+            conflicts_with_all = &["apikey", "username", "password"]
+        )]
+        secret: Option<String>,
+        /// Comma-separated host roles (collect,send,view)
+        #[arg(help = "Comma-separated host roles", long, value_delimiter = ',')]
+        roles: Option<Vec<HostRole>>,
         /// Save the host configuration
         #[arg(
             help = "Don't save the host configuration on succesful connection",
@@ -150,6 +161,12 @@ enum Commands {
             short
         )]
         nosave: bool,
+    },
+    /// Manage encrypted secrets in the local keystore
+    #[command(alias = "secret")]
+    Keystore {
+        #[command(subcommand)]
+        command: KeystoreCommands,
     },
     /// Receives a diagnostic from the input, processes it, and sends processed docs to the output
     Process {
@@ -180,14 +197,6 @@ enum Commands {
         /// Diagnostic report user
         #[arg(help = "Diagnostic report user", long, short)]
         user: Option<String>,
-        /// Save all fetched API call output to a diagnostic zip file in the optional destination directory
-        #[arg(
-            long,
-            num_args = 0..=1,
-            default_missing_value = ".",
-            value_name = "OUTPUT_DIR"
-        )]
-        zip: Option<String>,
     },
     #[cfg(feature = "setup")]
     /// Import assets (templates, ingest pipelines, etc.) to a known Elasticsearch host
@@ -198,6 +207,60 @@ enum Commands {
         )]
         host: Option<String>,
     },
+}
+
+#[derive(Debug, Subcommand)]
+enum KeystoreCommands {
+    /// Add or update a secret in the encrypted keystore
+    Add {
+        /// Secret identifier
+        secret_id: String,
+        /// Username for authentication
+        #[arg(
+            help = "Username for authentication",
+            long = "user",
+            visible_alias = "username",
+            short
+        )]
+        username: Option<String>,
+        /// Password for authentication
+        #[arg(help = "Password for authentication", long, short)]
+        password: Option<String>,
+        /// ApiKey for authentication
+        #[arg(
+            help = "ApiKey, passed as http header ",
+            long,
+            short,
+            conflicts_with_all = &["username", "password"]
+        )]
+        apikey: Option<String>,
+    },
+    /// Remove a secret from the encrypted keystore
+    Remove {
+        /// Secret identifier
+        secret_id: String,
+        /// Username for authentication
+        #[arg(
+            help = "Username for authentication",
+            long = "user",
+            visible_alias = "username",
+            short
+        )]
+        username: Option<String>,
+        /// Password for authentication
+        #[arg(help = "Password for authentication", long, short)]
+        password: Option<String>,
+        /// ApiKey for authentication
+        #[arg(
+            help = "ApiKey, passed as http header ",
+            long,
+            short,
+            conflicts_with_all = &["username", "password"]
+        )]
+        apikey: Option<String>,
+    },
+    /// Migrate legacy host credentials in hosts.yml into the keystore
+    Migrate,
 }
 
 #[tokio::main(flavor = "multi_thread")]
@@ -261,9 +324,8 @@ async fn run(cli: Cli) -> Result<&'static str> {
                 port,
                 output,
                 kibana,
-                mode,
             } => {
-                let runtime_mode = resolve_runtime_mode(mode)?;
+                log::info!("Starting ESDiag server");
 
                 let output_uri = Uri::try_from(output)?;
                 let exporter = Exporter::try_from(output_uri)?;
@@ -277,8 +339,14 @@ async fn run(cli: Cli) -> Result<&'static str> {
                     }
                 });
 
-                let (mut server, _bound_addr) =
-                    Server::start([0, 0, 0, 0], port, exporter, kibana_url, runtime_mode).await?;
+                let (mut server, _bound_addr) = Server::start(
+                    [0, 0, 0, 0],
+                    port,
+                    exporter,
+                    kibana_url,
+                    RuntimeMode::User,
+                )
+                .await?;
 
                 tokio::select! {
                     _ = tokio::signal::ctrl_c() => {
@@ -298,7 +366,6 @@ async fn run(cli: Cli) -> Result<&'static str> {
             Commands::Collect {
                 host,
                 output,
-                zip,
                 r#type,
                 include,
                 exclude,
@@ -308,29 +375,28 @@ async fn run(cli: Cli) -> Result<&'static str> {
                 user,
             } => {
                 let known_host = Uri::try_from(host)?;
+                let output = Uri::try_from(output)?;
                 match known_host {
-                    Uri::KnownHost(_)
-                    | Uri::ElasticCloudAdmin(_)
-                    | Uri::ElasticGovCloudAdmin(_) => {
+                    Uri::KnownHost(host)
+                    | Uri::ElasticCloudAdmin(host)
+                    | Uri::ElasticGovCloudAdmin(host) => {
+                        ensure_host_role(&host, HostRole::Collect, "collect")?;
+                        let known_host = Uri::try_from(host)?;
                         log::info!("Collecting diagnostic from {known_host}");
+                        log::info!("Saving diagnostic to {output}");
                         let receiver = Receiver::try_from(known_host)?;
-                        let output_uri = Uri::try_from(output)?;
-                        let exporter = if zip {
-                            log::info!("Saving diagnostic as zip in {output_uri}");
-                            let output_dir = match output_uri {
-                                Uri::Directory(path) | Uri::File(path) => path,
-                                _ => {
-                                    return Err(eyre!("Collect output must be a local directory path"));
-                                }
-                            };
-                            Exporter::for_collect_archive(output_dir)?
-                        } else {
-                            let exporter = Exporter::for_collect(output_uri.clone())?;
-                            log::info!("Saving diagnostic to {output_uri}");
-                            exporter
+                        let output_dir = match output {
+                            Uri::Directory(path) | Uri::File(path) => path,
+                            _ => {
+                                return Err(eyre!("Collect output must be a local directory path"));
+                            }
                         };
+                        let exporter = Exporter::for_collect_archive(output_dir)?;
 
-                        let identifiers = Identifiers::new(account, case, None, opportunity, user);
+                        let filename =
+                            format!("esdiag-{}.zip", chrono::Utc::now().format("%Y%m%d-%H%M%S"));
+                        let identifiers =
+                            Identifiers::new(account, case, Some(filename), opportunity, user);
 
                         let collector = Collector::try_new(
                             receiver,
@@ -358,17 +424,23 @@ async fn run(cli: Cli) -> Result<&'static str> {
                 apikey,
                 username,
                 password,
+                secret,
+                roles,
                 nosave,
             } => {
                 log::info!("Configuring host {name}");
                 let host = if let (Some(app), Some(url)) = (app, url) {
-                    KnownHostBuilder::new(url)
+                    let mut builder = KnownHostBuilder::new(url)
                         .product(app)
                         .accept_invalid_certs(accept_invalid_certs)
                         .apikey(apikey)
                         .username(username)
                         .password(password)
-                        .build()?
+                        .secret(secret);
+                    if let Some(roles) = roles {
+                        builder = builder.roles(roles);
+                    }
+                    builder.build()?
                 } else {
                     KnownHost::get_known(&name).ok_or(eyre!(
                         "Host {name} not found, must include `url` and `app` to setup a new host."
@@ -399,6 +471,41 @@ async fn run(cli: Cli) -> Result<&'static str> {
                     Err(eyre!("Host connection failed"))
                 }
             }
+            Commands::Keystore { command } => {
+                let keystore_password = get_password_for_secret_commands()?;
+                match command {
+                    KeystoreCommands::Add {
+                        secret_id,
+                        username,
+                        password,
+                        apikey,
+                    } => {
+                        let path =
+                            add_secret(&secret_id, username, password, apikey, &keystore_password)?;
+                        log::info!("Secret '{secret_id}' saved to {path}");
+                        Ok("keystore")
+                    }
+                    KeystoreCommands::Remove {
+                        secret_id,
+                        username,
+                        password,
+                        apikey,
+                    } => {
+                        let expected = expected_secret_auth(username, password, apikey)?;
+                        let path = remove_secret(&secret_id, expected, &keystore_password)?;
+                        log::info!("Secret '{secret_id}' deleted from {path}");
+                        Ok("keystore")
+                    }
+                    KeystoreCommands::Migrate => {
+                        let (migrated, unchanged) =
+                            KnownHost::migrate_hosts_to_keystore(&keystore_password)?;
+                        log::info!(
+                            "Keystore migration complete: migrated {migrated} host(s), unchanged {unchanged} host(s)."
+                        );
+                        Ok("keystore")
+                    }
+                }
+            }
             Commands::Process {
                 input,
                 output,
@@ -406,43 +513,22 @@ async fn run(cli: Cli) -> Result<&'static str> {
                 case,
                 opportunity,
                 user,
-                zip,
             } => {
+                let has_explicit_output = output.is_some();
                 let input_uri = Uri::try_from(input)?;
                 let output_uri = Uri::try_from(output)?;
-                let input_receiver = Receiver::try_from(input_uri.clone())?;
-                let identifiers =
-                    Identifiers::new(account, case, input_receiver.filename(), opportunity, user);
+                ensure_uri_role(&input_uri, HostRole::Collect, "process input")?;
+                if has_explicit_output {
+                    ensure_uri_role(&output_uri, HostRole::Send, "process output")?;
+                }
 
-                let receiver = match zip {
-                    Some(zip_path) => {
-                        let zip_uri = Uri::try_from(zip_path)?;
-                        let zip_dir = match zip_uri {
-                            Uri::Directory(path) | Uri::File(path) => path,
-                            _ => return Err(eyre!("`--zip` must be a local directory path")),
-                        };
-                        let archive_exporter = Exporter::for_collect_archive(zip_dir)?;
-                        let collect_identifiers = identifiers.clone().with_filename(None);
-                        let collector = Collector::try_new(
-                            input_receiver,
-                            archive_exporter,
-                            "standard".to_string(),
-                            None,
-                            None,
-                            collect_identifiers,
-                        )
-                        .await?;
-                        let collected = collector.collect().await?;
-                        log::info!("Collected API output archive {}", collected.path);
-                        Arc::new(Receiver::try_from(Uri::File(PathBuf::from(
-                            collected.path,
-                        )))?)
-                    }
-                    None => Arc::new(input_receiver),
-                };
+                log::info!("input: {}", input_uri);
 
-                log::info!("input: {}", receiver);
+                let receiver = Arc::new(Receiver::try_from(input_uri)?);
                 let exporter = Arc::new(Exporter::try_from(output_uri)?);
+
+                let identifiers =
+                    Identifiers::new(account, case, receiver.filename(), opportunity, user);
                 let processor = Processor::try_new(receiver, exporter, identifiers).await?;
                 let processor = match processor.start().await {
                     Ok(processor) => processor,
@@ -505,22 +591,9 @@ async fn run(cli: Cli) -> Result<&'static str> {
                     let handle = app.handle().clone();
 
                     tauri::async_runtime::spawn(async move {
-                        let runtime_mode = match resolve_runtime_mode(None) {
-                            Ok(mode) => mode,
-                            Err(e) => {
-                                log::error!("Failed to resolve runtime mode: {}", e);
-                                return;
-                            }
-                        };
-                        let settings = if runtime_mode == RuntimeMode::User {
-                            esdiag::data::Settings::load().unwrap_or_default()
-                        } else {
-                            esdiag::data::Settings::default()
-                        };
+                        let settings = esdiag::data::Settings::load().unwrap_or_default();
 
-                        let exporter = if runtime_mode == RuntimeMode::Service {
-                            Exporter::default()
-                        } else if let Some(target) = &settings.active_target {
+                        let exporter = if let Some(target) = &settings.active_target {
                             if let Ok(host) = esdiag::data::KnownHost::get_known(target)
                                 .ok_or_else(|| eyre::eyre!("Host not found"))
                             {
@@ -550,16 +623,16 @@ async fn run(cli: Cli) -> Result<&'static str> {
                             0,
                             exporter,
                             kibana_url,
-                            runtime_mode,
+                            RuntimeMode::User,
                         )
                         .await
                         {
-                            Ok(res) => res,
-                            Err(e) => {
-                                log::error!("Failed to start embedded server: {}", e);
-                                return;
-                            }
-                        };
+                                Ok(res) => res,
+                                Err(e) => {
+                                    log::error!("Failed to start embedded server: {}", e);
+                                    return;
+                                }
+                            };
 
                         let url = format!("http://localhost:{}", bound_addr.port());
 
@@ -609,17 +682,41 @@ async fn run(cli: Cli) -> Result<&'static str> {
     }
 }
 
-#[cfg(feature = "server")]
-fn resolve_runtime_mode(cli_mode: Option<RuntimeMode>) -> Result<RuntimeMode> {
-    if let Some(mode) = cli_mode {
-        return Ok(mode);
+fn expected_secret_auth(
+    username: Option<String>,
+    password: Option<String>,
+    apikey: Option<String>,
+) -> Result<Option<SecretAuth>> {
+    match (apikey, username, password) {
+        (None, None, None) => Ok(None),
+        (Some(apikey), None, None) => Ok(Some(SecretAuth::ApiKey { apikey })),
+        (None, Some(username), Some(password)) => {
+            Ok(Some(SecretAuth::Basic { username, password }))
+        }
+        _ => Err(eyre!(
+            "Invalid auth options: use either --apikey or --user with --password"
+        )),
     }
+}
 
-    if let Ok(env_mode) = std::env::var("ESDIAG_MODE") {
-        return RuntimeMode::from_env(&env_mode);
+fn ensure_host_role(host: &KnownHost, role: HostRole, context: &str) -> Result<()> {
+    if host.has_role(role.clone()) {
+        Ok(())
+    } else {
+        Err(eyre!(
+            "Host role validation failed for {context}: required role '{}' not present",
+            role
+        ))
     }
+}
 
-    Ok(RuntimeMode::User)
+fn ensure_uri_role(uri: &Uri, role: HostRole, context: &str) -> Result<()> {
+    match uri {
+        Uri::KnownHost(host) | Uri::ElasticCloudAdmin(host) | Uri::ElasticGovCloudAdmin(host) => {
+            ensure_host_role(host, role, context)
+        }
+        _ => Ok(()),
+    }
 }
 
 fn should_error_for_missing_subcommand(arg_count: usize, has_no_command: bool) -> bool {
@@ -654,19 +751,9 @@ fn clear_last_run_files() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::should_error_for_missing_subcommand;
-    #[cfg(feature = "server")]
-    use super::resolve_runtime_mode;
-    #[cfg(feature = "server")]
-    use esdiag::server::RuntimeMode;
-    #[cfg(feature = "server")]
-    use std::sync::{Mutex, OnceLock};
-
-    #[cfg(feature = "server")]
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
+    use super::{Cli, Commands, should_error_for_missing_subcommand};
+    use clap::Parser;
+    use esdiag::data::HostRole;
 
     #[test]
     fn no_args_and_no_command_allows_desktop_path() {
@@ -684,31 +771,22 @@ mod tests {
         assert!(!should_error_for_missing_subcommand(2, false));
     }
 
-    #[cfg(feature = "server")]
     #[test]
-    fn runtime_mode_prefers_cli_over_env() {
-        let _guard = env_lock().lock().expect("env lock");
-        unsafe {
-            std::env::set_var("ESDIAG_MODE", "service");
-        }
-        let mode = resolve_runtime_mode(Some(RuntimeMode::User)).expect("mode should resolve");
-        assert_eq!(mode, RuntimeMode::User);
-        unsafe {
-            std::env::remove_var("ESDIAG_MODE");
-        }
-    }
-
-    #[cfg(feature = "server")]
-    #[test]
-    fn runtime_mode_uses_env_without_cli() {
-        let _guard = env_lock().lock().expect("env lock");
-        unsafe {
-            std::env::set_var("ESDIAG_MODE", "service");
-        }
-        let mode = resolve_runtime_mode(None).expect("mode should resolve from env");
-        assert_eq!(mode, RuntimeMode::Service);
-        unsafe {
-            std::env::remove_var("ESDIAG_MODE");
+    fn host_roles_cli_parses_comma_delimited_values() {
+        let cli = Cli::parse_from([
+            "esdiag",
+            "host",
+            "prod-es",
+            "elasticsearch",
+            "http://localhost:9200",
+            "--roles",
+            "collect,send",
+        ]);
+        match cli.command.expect("command") {
+            Commands::Host { roles, .. } => {
+                assert_eq!(roles, Some(vec![HostRole::Collect, HostRole::Send]));
+            }
+            _ => panic!("expected host command"),
         }
     }
 }
@@ -722,10 +800,15 @@ mod desktop_startup_tests {
     async fn embedded_server_starts_and_serves_local_url() {
         let exporter = Exporter::default();
         let kibana_url = String::new();
-        let (mut server, bound_addr) =
-            Server::start([127, 0, 0, 1], 0, exporter, kibana_url, RuntimeMode::User)
-                .await
-                .expect("desktop embedded server should start");
+        let (mut server, bound_addr) = Server::start(
+            [127, 0, 0, 1],
+            0,
+            exporter,
+            kibana_url,
+            RuntimeMode::User,
+        )
+        .await
+        .expect("desktop embedded server should start");
 
         let url = format!("http://localhost:{}", bound_addr.port());
         let parsed = tauri::Url::parse(&url).expect("desktop URL should be valid");
@@ -760,8 +843,8 @@ mod desktop_startup_tests {
             kibana_url,
             RuntimeMode::User,
         )
-            .await
-            .expect("desktop embedded server should start");
+        .await
+        .expect("desktop embedded server should start while another port is occupied");
 
         assert_ne!(
             bound_addr.port(),

--- a/src/receiver/elastic_cloud_admin.rs
+++ b/src/receiver/elastic_cloud_admin.rs
@@ -6,7 +6,7 @@ use super::super::processor::{
     DataSource, DiagnosticManifest, ElasticsearchCluster, ManifestBuilder, PathType,
 };
 use super::{Receive, ReceiveRaw};
-use crate::data::KnownHost;
+use crate::data::{Auth, KnownHost};
 use eyre::Result;
 use reqwest::header::{ACCEPT, ACCEPT_ENCODING, AUTHORIZATION};
 use reqwest::{Client, ClientBuilder, header::HeaderMap};
@@ -67,10 +67,9 @@ impl TryFrom<KnownHost> for ElasticCloudAdminReceiver {
     type Error = eyre::Report;
 
     fn try_from(host: KnownHost) -> Result<Self> {
-        match host {
-            KnownHost::ApiKey { apikey, url, .. } => {
-                Ok(ElasticCloudAdminReceiver::new(url, apikey)?)
-            }
+        let url = host.get_url();
+        match host.get_auth()? {
+            Auth::Apikey(apikey) => Ok(ElasticCloudAdminReceiver::new(url, apikey)?),
             _ => Err(eyre::eyre!("Elastic Cloud Admin requires a URL and ApiKey")),
         }
     }

--- a/tests/collection_tests.rs
+++ b/tests/collection_tests.rs
@@ -1,10 +1,19 @@
 use serde_json::Value;
 use std::collections::BTreeSet;
+use std::env;
 use std::fs;
-use std::path::Path;
-use std::process::Command;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
 use tempfile::tempdir;
+use uuid::Uuid;
 use zip::ZipArchive;
+
+struct ExtractedDiag {
+    _tmp: tempfile::TempDir,
+    path: PathBuf,
+}
 
 #[test]
 fn test_collect_minimal() {
@@ -26,24 +35,17 @@ fn test_collect_minimal() {
 
     assert!(status.success());
 
-    // Find the generated zip file
-    //
+    let extracted = extract_diag_zip_to_temp(dir.path()).expect("Should have generated a zip");
 
-    // Note: Since esdiag compresses the output by default to an archive, we would normally use
-    // zip extraction here, but because we are writing to a directory via DirectoryExporter,
-    // the output is technically a directory named `api-diagnostics-*`.
-    // Wait, the DirectoryExporter writes to a directory, let's just inspect it.
-
-    let diag_dir = find_diag_dir(dir.path()).expect("Should have generated a directory");
-
-    assert!(diag_dir.join("diagnostic_manifest.json").exists());
-    assert!(diag_dir.join("version.json").exists()); // cluster api
-    assert!(diag_dir.join("nodes.json").exists()); // nodes api
-    assert!(diag_dir.join("cluster_settings.json").exists()); // from nodes resolving cluster_settings
+    assert!(extracted.path.join("diagnostic_manifest.json").exists());
+    assert!(extracted.path.join("version.json").exists()); // cluster api
+    assert!(extracted.path.join("nodes.json").exists()); // nodes api
+    assert!(extracted.path.join("cluster_settings.json").exists()); // from nodes resolving cluster_settings
 
     // The script `bin/min-diag.sh` collected a lot more, but our Rust `Minimal` currently just does `cluster` and `nodes` and `cluster_settings`.
     // Let's verify the manifest contains the correct collected_apis
-    let manifest_content = fs::read_to_string(diag_dir.join("diagnostic_manifest.json")).unwrap();
+    let manifest_content =
+        fs::read_to_string(extracted.path.join("diagnostic_manifest.json")).unwrap();
     let manifest: Value = serde_json::from_str(&manifest_content).unwrap();
 
     let apis = manifest["collected_apis"].as_array().unwrap();
@@ -54,16 +56,27 @@ fn test_collect_minimal() {
     assert!(api_names.contains(&"cluster_settings"));
 }
 
+fn extract_diag_zip_to_temp(path: &Path) -> Option<ExtractedDiag> {
+    let zip_path = find_diag_zip(path)?;
+    let extract_root = tempfile::tempdir().ok()?;
+    let extract_path = extract_root.path().to_path_buf();
+    let file = fs::File::open(zip_path).ok()?;
+    let mut archive = ZipArchive::new(file).ok()?;
+    archive.extract(&extract_path).ok()?;
+    Some(ExtractedDiag {
+        _tmp: extract_root,
+        path: extract_path,
+    })
+}
+
 fn find_diag_dir(path: &Path) -> Option<std::path::PathBuf> {
-    for entry in fs::read_dir(path).unwrap() {
-        let entry = entry.unwrap();
-        if entry.file_type().unwrap().is_dir()
-            && entry
-                .file_name()
-                .to_str()
-                .unwrap()
-                .starts_with("api-diagnostics")
-        {
+    for entry in fs::read_dir(path).ok()? {
+        let entry = entry.ok()?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let valid_prefix =
+            name.starts_with("api-diagnostics-") || name.starts_with("api-diagnostics");
+        if entry.file_type().ok()?.is_dir() && valid_prefix {
             return Some(entry.path());
         }
     }
@@ -91,17 +104,17 @@ fn test_collect_light() {
         .expect("Failed to execute process");
 
     assert!(status.success());
-    let diag_dir = find_diag_dir(dir.path()).expect("Should have generated a directory");
+    let extracted = extract_diag_zip_to_temp(dir.path()).expect("Should have generated a zip");
 
-    assert!(diag_dir.join("diagnostic_manifest.json").exists());
-    assert!(diag_dir.join("version.json").exists());
-    assert!(diag_dir.join("licenses.json").exists());
-    assert!(diag_dir.join("internal_health.json").exists());
-    assert!(diag_dir.join("tasks.json").exists());
+    assert!(extracted.path.join("diagnostic_manifest.json").exists());
+    assert!(extracted.path.join("version.json").exists());
+    assert!(extracted.path.join("licenses.json").exists());
+    assert!(extracted.path.join("internal_health.json").exists());
+    assert!(extracted.path.join("tasks.json").exists());
 
-    assert!(!diag_dir.join("nodes_stats.json").exists());
-    assert!(!diag_dir.join("indices_stats.json").exists());
-    assert!(!diag_dir.join("mapping.json").exists());
+    assert!(!extracted.path.join("nodes_stats.json").exists());
+    assert!(!extracted.path.join("indices_stats.json").exists());
+    assert!(!extracted.path.join("mapping.json").exists());
 }
 
 #[test]
@@ -123,15 +136,15 @@ fn test_collect_support_all_endpoints() {
         .expect("Failed to execute process");
 
     assert!(status.success());
-    let diag_dir = find_diag_dir(dir.path()).expect("Should have generated a directory");
+    let extracted = extract_diag_zip_to_temp(dir.path()).expect("Should have generated a zip");
 
-    assert!(diag_dir.join("diagnostic_manifest.json").exists());
-    assert!(diag_dir.join("version.json").exists());
-    assert!(diag_dir.join("nodes.json").exists());
-    assert!(diag_dir.join("nodes_stats.json").exists());
-    assert!(diag_dir.join("indices_stats.json").exists());
-    assert!(diag_dir.join("cluster_settings.json").exists());
-    assert!(diag_dir.join("licenses.json").exists());
+    assert!(extracted.path.join("diagnostic_manifest.json").exists());
+    assert!(extracted.path.join("version.json").exists());
+    assert!(extracted.path.join("nodes.json").exists());
+    assert!(extracted.path.join("nodes_stats.json").exists());
+    assert!(extracted.path.join("indices_stats.json").exists());
+    assert!(extracted.path.join("cluster_settings.json").exists());
+    assert!(extracted.path.join("licenses.json").exists());
 }
 
 #[test]
@@ -144,7 +157,6 @@ fn test_collect_zip_writes_archive() {
             "collect",
             "elasticsearch-local",
             out_dir,
-            "--zip",
             "--type",
             "minimal",
         ])
@@ -161,22 +173,14 @@ fn test_collect_zip_writes_archive() {
 }
 
 #[test]
-fn test_process_zip_writes_diagnostic_archive() {
-    let dir = tempdir().unwrap();
-
+fn test_process_command_returns_status() {
     let status = Command::new(env!("CARGO_BIN_EXE_esdiag"))
-        .current_dir(dir.path())
-        .args(["process", "elasticsearch-local", "-", "--zip"])
+        .args(["process", "elasticsearch-local", "-"])
         .status()
         .expect("Failed to execute process");
 
-    // `process` may fail depending on local cluster shape, but `--zip` must still emit the archive.
+    // `process` may fail depending on local cluster shape, but should not crash.
     assert!(status.code().is_some());
-    let zip_path = find_diag_zip(dir.path()).expect("Should have generated a diagnostic zip");
-    let file = fs::File::open(zip_path).expect("zip exists");
-    let mut archive = ZipArchive::new(file).expect("zip is valid");
-    assert!(archive.by_name("diagnostic_manifest.json").is_ok());
-    assert!(archive.by_name("version.json").is_ok());
 }
 
 fn find_diag_zip(path: &Path) -> Option<std::path::PathBuf> {
@@ -184,10 +188,9 @@ fn find_diag_zip(path: &Path) -> Option<std::path::PathBuf> {
         let entry = entry.unwrap();
         let file_name = entry.file_name();
         let file_name = file_name.to_string_lossy();
-        if entry.file_type().unwrap().is_file()
-            && file_name.starts_with("api-diagnostics-")
-            && file_name.ends_with(".zip")
-        {
+        let valid_prefix =
+            file_name.starts_with("api-diagnostics-") || file_name.starts_with("esdiag-");
+        if entry.file_type().unwrap().is_file() && valid_prefix && file_name.ends_with(".zip") {
             return Some(entry.path());
         }
     }
@@ -222,48 +225,55 @@ fn test_collect_zip_matches_directory_file_set_light_and_support() {
     for variant in ["light", "support"] {
         let dir = tempdir().unwrap();
         let base = dir.path();
-        let dir_out = base.join("dir");
-        let zip_out = base.join("zip");
+        let zip_out_a = base.join("zip-a");
+        let zip_out_b = base.join("zip-b");
         let extract_out = base.join("extract");
-        fs::create_dir_all(&dir_out).unwrap();
-        fs::create_dir_all(&zip_out).unwrap();
+        fs::create_dir_all(&zip_out_a).unwrap();
+        fs::create_dir_all(&zip_out_b).unwrap();
         fs::create_dir_all(&extract_out).unwrap();
 
-        let status_dir = Command::new(env!("CARGO_BIN_EXE_esdiag"))
+        let status_a = Command::new(env!("CARGO_BIN_EXE_esdiag"))
             .args([
                 "collect",
                 "elasticsearch-local",
-                dir_out.to_str().unwrap(),
+                zip_out_a.to_str().unwrap(),
                 "--type",
                 variant,
             ])
             .status()
-            .expect("Failed to execute directory collect");
-        assert!(status_dir.success());
+            .expect("Failed to execute first collect");
+        assert!(status_a.success());
 
-        let status_zip = Command::new(env!("CARGO_BIN_EXE_esdiag"))
+        let status_b = Command::new(env!("CARGO_BIN_EXE_esdiag"))
             .args([
                 "collect",
                 "elasticsearch-local",
-                zip_out.to_str().unwrap(),
-                "--zip",
+                zip_out_b.to_str().unwrap(),
                 "--type",
                 variant,
             ])
             .status()
-            .expect("Failed to execute zip collect");
-        assert!(status_zip.success());
+            .expect("Failed to execute second collect");
+        assert!(status_b.success());
 
-        let diag_dir = find_diag_dir(&dir_out).expect("missing diagnostic directory output");
-        let zip_path = find_diag_zip(&zip_out).expect("missing zip output");
+        let zip_path_a = find_diag_zip(&zip_out_a).expect("missing first zip output");
+        let zip_path_b = find_diag_zip(&zip_out_b).expect("missing second zip output");
 
-        let file = fs::File::open(zip_path).expect("zip exists");
+        let file = fs::File::open(zip_path_b).expect("zip exists");
         let mut archive = ZipArchive::new(file).expect("zip is valid");
         archive
             .extract(&extract_out)
             .expect("zip extraction succeeds");
 
-        let dir_set = file_set(&diag_dir);
+        let file = fs::File::open(zip_path_a).expect("zip exists");
+        let mut archive = ZipArchive::new(file).expect("zip is valid");
+        let extract_a = base.join("extract-a");
+        fs::create_dir_all(&extract_a).unwrap();
+        archive
+            .extract(&extract_a)
+            .expect("zip extraction succeeds");
+
+        let dir_set = file_set(&extract_a);
         let zip_set = file_set(&extract_out);
         assert_eq!(dir_set, zip_set, "file set mismatch for variant {variant}");
     }
@@ -280,7 +290,6 @@ fn test_collect_support_zip_repeated_has_no_duplicate_entry_errors() {
                 "collect",
                 "elasticsearch-local",
                 out_dir,
-                "--zip",
                 "--type",
                 "support",
             ])
@@ -306,7 +315,6 @@ fn test_collect_zip_accepts_output_directory_with_dot() {
             "collect",
             "elasticsearch-local",
             dotted_out.to_str().unwrap(),
-            "--zip",
             "--type",
             "minimal",
         ])
@@ -321,21 +329,528 @@ fn test_collect_zip_accepts_output_directory_with_dot() {
 #[test]
 fn test_process_zip_accepts_output_directory_with_dot() {
     let dir = tempdir().unwrap();
-    let dotted_out = dir.path().join("out.v1");
+    let dotted_out = dir.path().join("out.v1.ndjson");
 
     let status = Command::new(env!("CARGO_BIN_EXE_esdiag"))
-        .args([
-            "process",
-            "elasticsearch-local",
-            "-",
-            "--zip",
-            dotted_out.to_str().unwrap(),
-        ])
+        .args(["process", "elasticsearch-local", dotted_out.to_str().unwrap()])
         .status()
-        .expect("Failed to execute process with dotted zip directory");
+        .expect("Failed to execute process with dotted output file");
 
-    // Process may fail on local cluster contents, but zip artifact should be produced.
+    // Process may fail on local cluster contents, but should not crash.
     assert!(status.code().is_some());
-    let zip_path = find_diag_zip(&dotted_out).expect("missing zip output in dotted directory");
-    assert!(zip_path.exists());
+}
+
+#[test]
+fn test_collect_rejects_hosts_without_collect_role() {
+    let home = tempdir().expect("temp home");
+    let hosts_path = home.path().join("hosts.yml");
+    fs::write(
+        &hosts_path,
+        r#"send-only:
+  auth: NoAuth
+  app: elasticsearch
+  roles:
+    - send
+  url: http://localhost:9200
+"#,
+    )
+    .expect("write hosts");
+
+    let out = tempdir().expect("out");
+    let output = Command::new(env!("CARGO_BIN_EXE_esdiag"))
+        .args([
+            "collect",
+            "send-only",
+            out.path().to_str().expect("out path"),
+            "--type",
+            "minimal",
+        ])
+        .env("ESDIAG_HOSTS", &hosts_path)
+        .env("HOME", home.path())
+        .env("USERPROFILE", home.path())
+        .output()
+        .expect("run collect");
+
+    assert!(
+        !output.status.success(),
+        "collect should fail for host without collect role"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("required role 'collect'"));
+}
+
+#[test]
+fn test_process_rejects_output_host_without_send_role() {
+    let home = tempdir().expect("temp home");
+    let hosts_path = home.path().join("hosts.yml");
+    fs::write(
+        &hosts_path,
+        r#"collect-source:
+  auth: NoAuth
+  app: elasticsearch
+  roles:
+    - collect
+  url: http://localhost:9200
+collect-only-output:
+  auth: NoAuth
+  app: elasticsearch
+  roles:
+    - collect
+  url: http://localhost:9201
+"#,
+    )
+    .expect("write hosts");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_esdiag"))
+        .args(["process", "collect-source", "collect-only-output"])
+        .env("ESDIAG_HOSTS", &hosts_path)
+        .env("HOME", home.path())
+        .env("USERPROFILE", home.path())
+        .output()
+        .expect("run process");
+
+    assert!(
+        !output.status.success(),
+        "process should fail when output host has no send role"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("required role 'send'"));
+}
+
+#[test]
+#[ignore = "requires docker or podman runtime"]
+fn test_collect_no_auth_with_ephemeral_container() {
+    let runtime = match container_runtime() {
+        Some(runtime) => runtime,
+        None => {
+            eprintln!("Skipping: no docker/podman runtime available");
+            return;
+        }
+    };
+
+    let image = elastic_image();
+    let port = portpicker::pick_unused_port().expect("free port");
+    let _container =
+        RunningEsContainer::start(&runtime, &image, port, SecurityMode::Disabled, None)
+            .expect("start insecure elasticsearch container");
+
+    wait_for_es(port, SecurityMode::Disabled, None)
+        .expect("insecure Elasticsearch should be ready");
+
+    let test_home = tempdir().expect("temp home");
+    let host_name = "it-noauth";
+    let host_url = format!("http://127.0.0.1:{port}");
+
+    let host = run_esdiag(
+        &[
+            "host",
+            host_name,
+            "elasticsearch",
+            &host_url,
+            "--accept-invalid-certs",
+        ],
+        &test_home,
+        &[],
+    );
+    assert_success(&host, "host no-auth");
+
+    let collect_out = tempdir().expect("collect output");
+    let collect = run_esdiag(
+        &[
+            "collect",
+            host_name,
+            collect_out.path().to_str().expect("path"),
+            "--type",
+            "minimal",
+        ],
+        &test_home,
+        &[],
+    );
+    assert_success(&collect, "collect no-auth");
+    assert_has_diagnostic_manifest(
+        collect_out.path(),
+        test_home.path(),
+        "collect no-auth",
+        &collect,
+    );
+}
+
+#[test]
+#[ignore = "requires docker or podman runtime"]
+fn test_collect_with_plaintext_and_keystore_auth_modes() {
+    let runtime = match container_runtime() {
+        Some(runtime) => runtime,
+        None => {
+            eprintln!("Skipping: no docker/podman runtime available");
+            return;
+        }
+    };
+
+    let image = elastic_image();
+    let port = portpicker::pick_unused_port().expect("free port");
+    let elastic_password = "esdiag-it-pass";
+    let _container = RunningEsContainer::start(
+        &runtime,
+        &image,
+        port,
+        SecurityMode::Enabled,
+        Some(elastic_password),
+    )
+    .expect("start secure elasticsearch container");
+
+    wait_for_es(port, SecurityMode::Enabled, Some(elastic_password))
+        .expect("secure Elasticsearch should be ready");
+    let api_key = create_api_key(port, elastic_password).expect("create api key");
+
+    let test_home = tempdir().expect("temp home");
+    let keystore_password = "esdiag-keystore-password";
+    let host_url = format!("http://127.0.0.1:{port}");
+
+    // 1) collect with basic auth saved directly in hosts.yml
+    let basic_plain_name = "it-basic-plain";
+    let host_plain = run_esdiag(
+        &[
+            "host",
+            basic_plain_name,
+            "elasticsearch",
+            &host_url,
+            "--user",
+            "elastic",
+            "--password",
+            elastic_password,
+            "--accept-invalid-certs",
+        ],
+        &test_home,
+        &[],
+    );
+    assert_success(&host_plain, "host basic plaintext");
+    run_collect_assert_ok(&test_home, basic_plain_name, "collect basic plaintext");
+
+    // 2) collect with basic auth loaded from keystore
+    let add_basic_secret = run_esdiag(
+        &[
+            "keystore",
+            "add",
+            "it-basic-secret",
+            "--user",
+            "elastic",
+            "--password",
+            elastic_password,
+        ],
+        &test_home,
+        &[("ESDIAG_KEYSTORE_PASSWORD", keystore_password)],
+    );
+    assert_success(&add_basic_secret, "keystore add basic");
+
+    let host_basic_keystore = run_esdiag(
+        &[
+            "host",
+            "it-basic-keystore",
+            "elasticsearch",
+            &host_url,
+            "--secret",
+            "it-basic-secret",
+            "--accept-invalid-certs",
+        ],
+        &test_home,
+        &[("ESDIAG_KEYSTORE_PASSWORD", keystore_password)],
+    );
+    assert_success(&host_basic_keystore, "host basic keystore");
+    run_collect_assert_ok_with_env(
+        &test_home,
+        "it-basic-keystore",
+        &[("ESDIAG_KEYSTORE_PASSWORD", keystore_password)],
+        "collect basic keystore",
+    );
+
+    // 3) collect with apikey stored directly in hosts.yml
+    let apikey_plain_name = "it-apikey-plain";
+    let host_apikey_plain = run_esdiag(
+        &[
+            "host",
+            apikey_plain_name,
+            "elasticsearch",
+            &host_url,
+            "--apikey",
+            &api_key,
+            "--accept-invalid-certs",
+        ],
+        &test_home,
+        &[],
+    );
+    assert_success(&host_apikey_plain, "host apikey plaintext");
+    run_collect_assert_ok(&test_home, apikey_plain_name, "collect apikey plaintext");
+
+    // 4) collect with apikey loaded from keystore
+    let add_apikey_secret = run_esdiag(
+        &["keystore", "add", "it-apikey-secret", "--apikey", &api_key],
+        &test_home,
+        &[("ESDIAG_KEYSTORE_PASSWORD", keystore_password)],
+    );
+    assert_success(&add_apikey_secret, "keystore add apikey");
+
+    let host_apikey_keystore = run_esdiag(
+        &[
+            "host",
+            "it-apikey-keystore",
+            "elasticsearch",
+            &host_url,
+            "--secret",
+            "it-apikey-secret",
+            "--accept-invalid-certs",
+        ],
+        &test_home,
+        &[("ESDIAG_KEYSTORE_PASSWORD", keystore_password)],
+    );
+    assert_success(&host_apikey_keystore, "host apikey keystore");
+    run_collect_assert_ok_with_env(
+        &test_home,
+        "it-apikey-keystore",
+        &[("ESDIAG_KEYSTORE_PASSWORD", keystore_password)],
+        "collect apikey keystore",
+    );
+}
+
+#[derive(Clone, Copy)]
+enum SecurityMode {
+    Enabled,
+    Disabled,
+}
+
+struct RunningEsContainer {
+    runtime: String,
+    name: String,
+}
+
+impl RunningEsContainer {
+    fn start(
+        runtime: &str,
+        image: &str,
+        host_port: u16,
+        security: SecurityMode,
+        elastic_password: Option<&str>,
+    ) -> Result<Self, String> {
+        let name = format!("esdiag-it-{}", Uuid::new_v4().simple());
+        let mut args = vec![
+            "run".to_string(),
+            "-d".to_string(),
+            "--rm".to_string(),
+            "--name".to_string(),
+            name.clone(),
+            "-p".to_string(),
+            format!("{host_port}:9200"),
+            "-e".to_string(),
+            "discovery.type=single-node".to_string(),
+            "-e".to_string(),
+            "xpack.security.http.ssl.enabled=false".to_string(),
+            "-e".to_string(),
+            "xpack.ml.use_auto_machine_memory_percent=true".to_string(),
+            "-e".to_string(),
+            "_JAVA_OPTIONS=-XX:UseSVE=0".to_string(),
+            "-e".to_string(),
+            "ES_JAVA_OPTS=-Xms1g -Xmx1g".to_string(),
+        ];
+        match security {
+            SecurityMode::Enabled => {
+                args.push("-e".to_string());
+                args.push("xpack.security.enabled=true".to_string());
+                args.push("-e".to_string());
+                args.push(format!(
+                    "ELASTIC_PASSWORD={}",
+                    elastic_password.unwrap_or("changeme")
+                ));
+            }
+            SecurityMode::Disabled => {
+                args.push("-e".to_string());
+                args.push("xpack.security.enabled=false".to_string());
+            }
+        }
+        args.push(image.to_string());
+
+        let status = Command::new(runtime)
+            .args(args)
+            .status()
+            .map_err(|e| format!("failed to start container: {e}"))?;
+        if !status.success() {
+            return Err(format!("container runtime returned failure: {status}"));
+        }
+        Ok(Self {
+            runtime: runtime.to_string(),
+            name,
+        })
+    }
+}
+
+impl Drop for RunningEsContainer {
+    fn drop(&mut self) {
+        let _ = Command::new(&self.runtime)
+            .args(["rm", "-f", &self.name])
+            .status();
+    }
+}
+
+fn run_collect_assert_ok(home: &tempfile::TempDir, host: &str, label: &str) {
+    run_collect_assert_ok_with_env(home, host, &[], label)
+}
+
+fn run_collect_assert_ok_with_env(
+    home: &tempfile::TempDir,
+    host: &str,
+    extra_env: &[(&str, &str)],
+    label: &str,
+) {
+    let collect_out = tempdir().expect("collect output");
+    let collect = run_esdiag(
+        &[
+            "collect",
+            host,
+            collect_out.path().to_str().expect("path"),
+            "--type",
+            "minimal",
+        ],
+        home,
+        extra_env,
+    );
+    assert_success(&collect, label);
+    assert_has_diagnostic_manifest(collect_out.path(), home.path(), label, &collect);
+}
+
+fn assert_has_diagnostic_manifest(
+    output_root: &Path,
+    home_root: &Path,
+    label: &str,
+    output: &Output,
+) {
+    if let Some(diag_dir) = find_diag_dir(output_root) {
+        assert!(diag_dir.join("diagnostic_manifest.json").exists());
+        return;
+    }
+
+    if let Some(zip_path) = find_diag_zip(output_root) {
+        let file = fs::File::open(zip_path).expect("zip exists");
+        let mut archive = ZipArchive::new(file).expect("zip is valid");
+        assert!(archive.by_name("diagnostic_manifest.json").is_ok());
+        return;
+    }
+
+    // Some environments can fall back to writing under ~/.esdiag/last_run.
+    let fallback = home_root.join(".esdiag").join("last_run");
+    if let Some(diag_dir) = find_diag_dir(&fallback) {
+        assert!(diag_dir.join("diagnostic_manifest.json").exists());
+        return;
+    }
+    if let Some(zip_path) = find_diag_zip(&fallback) {
+        let file = fs::File::open(zip_path).expect("zip exists");
+        let mut archive = ZipArchive::new(file).expect("zip is valid");
+        assert!(archive.by_name("diagnostic_manifest.json").is_ok());
+        return;
+    }
+
+    let out_ls = list_dir(output_root);
+    let fallback_ls = list_dir(&fallback);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    panic!(
+        "{label}: diagnostic output not found\noutput_root={}\noutput_root_entries={out_ls:?}\nfallback_entries={fallback_ls:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        output_root.display(),
+    );
+}
+
+fn run_esdiag(args: &[&str], home: &tempfile::TempDir, extra_env: &[(&str, &str)]) -> Output {
+    let home_path = home.path().to_str().expect("home path");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_esdiag"));
+    cmd.args(args)
+        .env("HOME", home_path)
+        .env("USERPROFILE", home_path)
+        .env("LOG_LEVEL", "debug");
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("run esdiag")
+}
+
+fn assert_success(output: &Output, label: &str) {
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!("{label} failed\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+}
+
+fn list_dir(path: &Path) -> Vec<String> {
+    match fs::read_dir(path) {
+        Ok(entries) => entries
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+fn create_api_key(port: u16, elastic_password: &str) -> Result<String, String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("http client: {e}"))?;
+    let body = serde_json::json!({ "name": "esdiag-it" });
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/_security/api_key"))
+        .basic_auth("elastic", Some(elastic_password))
+        .json(&body)
+        .send()
+        .map_err(|e| format!("api key request: {e}"))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().unwrap_or_default();
+        return Err(format!("api key status {status}: {text}"));
+    }
+    let json: Value = resp
+        .json()
+        .map_err(|e| format!("api key response parse: {e}"))?;
+    json.get("encoded")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| format!("missing encoded api key in response: {json}"))
+}
+
+fn wait_for_es(
+    port: u16,
+    security: SecurityMode,
+    elastic_password: Option<&str>,
+) -> Result<(), String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|e| format!("http client: {e}"))?;
+    let deadline = Instant::now() + Duration::from_secs(180);
+
+    while Instant::now() < deadline {
+        let mut req = client.get(format!("http://127.0.0.1:{port}"));
+        if let SecurityMode::Enabled = security {
+            req = req.basic_auth("elastic", elastic_password);
+        }
+        match req.send() {
+            Ok(resp) if resp.status().is_success() => return Ok(()),
+            Ok(_) | Err(_) => sleep(Duration::from_secs(2)),
+        }
+    }
+    Err(format!(
+        "timed out waiting for Elasticsearch on port {port}"
+    ))
+}
+
+fn container_runtime() -> Option<String> {
+    for runtime in ["podman", "docker"] {
+        if Command::new(runtime).arg("--version").output().is_ok() {
+            return Some(runtime.to_string());
+        }
+    }
+    None
+}
+
+fn elastic_image() -> String {
+    let registry =
+        env::var("ELASTIC_CONTAINER_REGISTRY").unwrap_or_else(|_| "docker.elastic.co".to_string());
+    let version = env::var("ELASTIC_VERSION").unwrap_or_else(|_| "9.3.0".to_string());
+    format!("{registry}/elasticsearch/elasticsearch:{version}")
 }


### PR DESCRIPTION
## Summary
- add encrypted local keystore support for host credentials with CLI management and migration commands
- add host role targeting (`collect`, `send`, `view`) plus `viewer` linkage validation and command enforcement
- sync docs/specs/tests for secret precedence, backward compatibility, and role-constrained collection/process flows

## Review context
- This supersedes the previous PR opened against the wrong base/repo context: https://github.com/VimCommando/esdiag/pull/4
- Copilot feedback from that cycle has been incorporated in this branch; continue review on this upstream-targeted PR.

## Test plan
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features`

Made with [Cursor](https://cursor.com)