### PR TITLE
Optimize snapshot indices handling with RawValue

### DIFF
--- a/src/processor/elasticsearch/snapshots/data.rs
+++ b/src/processor/elasticsearch/snapshots/data.rs
@@ -6,7 +6,7 @@ use super::super::super::diagnostic::data_source::StreamingDataSource;
 use super::super::DataSource;
 use eyre::{Result, eyre};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Value, value::RawValue};
 use std::collections::HashMap;
 use tokio::sync::mpsc::Sender;
 
@@ -32,8 +32,8 @@ pub struct Snapshot {
     pub snapshot: String,
     pub repository: Option<String>,
     pub state: Option<String>,
-    pub indices: Option<Vec<String>>,
-    pub data_streams: Option<Vec<String>>,
+    pub indices: Option<Box<RawValue>>,
+    pub data_streams: Option<Box<RawValue>>,
     pub start_time: Option<String>,
     pub start_time_in_millis: Option<u64>,
     pub end_time: Option<String>,

--- a/src/processor/elasticsearch/snapshots/processor.rs
+++ b/src/processor/elasticsearch/snapshots/processor.rs
@@ -9,7 +9,7 @@ use crate::exporter::Exporter;
 use eyre::Report;
 use futures::stream::{BoxStream, StreamExt};
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{Value, value::RawValue};
 use serde_with::skip_serializing_none;
 use tokio::sync::mpsc;
 
@@ -135,8 +135,8 @@ struct SnapshotDocument {
     name: String,
     repository: Option<String>,
     state: Option<String>,
-    indices: Option<Vec<String>>,
-    data_streams: Option<Vec<String>>,
+    indices: Option<Box<RawValue>>,
+    data_streams: Option<Box<RawValue>>,
     date: Option<String>,
     start_time: Option<String>,
     start_time_in_millis: Option<u64>,
@@ -166,6 +166,7 @@ impl From<Snapshot> for SnapshotDocument {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::value::RawValue;
     use serde_json::json;
 
     #[test]
@@ -174,8 +175,13 @@ mod tests {
             snapshot: "daily-2026.03.01".to_string(),
             repository: Some("repo-a".to_string()),
             state: Some("SUCCESS".to_string()),
-            indices: Some(vec!["logs-1".to_string()]),
-            data_streams: Some(vec!["logs-app".to_string()]),
+            indices: Some(
+                RawValue::from_string("[\"logs-1\"]".to_string()).expect("raw indices array"),
+            ),
+            data_streams: Some(
+                RawValue::from_string("[\"logs-app\"]".to_string())
+                    .expect("raw data_streams array"),
+            ),
             start_time: Some("2026-03-01T01:00:00.000Z".to_string()),
             start_time_in_millis: Some(1709254800000),
             end_time: Some("2026-03-01T01:10:00.000Z".to_string()),


### PR DESCRIPTION
## Summary
- Reduce memory pressure during snapshot processing by avoiding `Vec<String>` materialization for large `snapshot.indices` and `snapshot.data_streams` arrays.
- Store these fields as `Box<RawValue>` through deserialization and export to preserve payloads while preventing per-element allocation overhead.
- Update snapshot serialization test fixtures to use raw JSON array values.

## Test plan
- [x] Build release binary in this worktree.
- [x] Run: `/usr/bin/time -l target-debug/release/esdiag process /Users/reno/Accounts/adhoc/diag3.zip /tmp/esdiag-debug-run-final`
- [x] Verify output doc count is unchanged.
- [x] Verify `maximum resident set size` improves versus prior main baseline.


Made with [Cursor](https://cursor.com)