### PR TITLE
Reduce node stats JSON allocation churn with RawValue passthrough

### DIFF
--- a/src/processor/elasticsearch/ilm_policies/data.rs
+++ b/src/processor/elasticsearch/ilm_policies/data.rs
@@ -39,9 +39,9 @@ struct Phases {
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize)]
 struct InUseBy {
-    indices: Vec<String>,
-    data_streams: Option<Vec<String>>,
-    composable_templates: Option<Vec<String>>,
+    indices: Option<Box<RawValue>>,
+    data_streams: Option<Box<RawValue>>,
+    composable_templates: Option<Box<RawValue>>,
 }
 
 impl DataSource for IlmPolicies {

--- a/src/processor/elasticsearch/json_utils.rs
+++ b/src/processor/elasticsearch/json_utils.rs
@@ -1,0 +1,22 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+use serde_json::Value;
+
+pub fn merge_values(target: &mut Value, patch: &Value) {
+    match (target, patch) {
+        (Value::Object(target_obj), Value::Object(patch_obj)) => {
+            for (key, value) in patch_obj {
+                if let Some(existing) = target_obj.get_mut(key) {
+                    merge_values(existing, value);
+                } else {
+                    target_obj.insert(key.clone(), value.clone());
+                }
+            }
+        }
+        (target, patch) => {
+            *target = patch.clone();
+        }
+    }
+}

--- a/src/processor/elasticsearch/mod.rs
+++ b/src/processor/elasticsearch/mod.rs
@@ -6,6 +6,8 @@
 mod alias;
 /// The `_cluster/settings` API
 mod cluster_settings;
+/// Shared JSON helpers for Elasticsearch processors
+mod json_utils;
 /// Collector definition for Elasticsearch diagnostics
 mod collector;
 /// The `_data_stream` API

--- a/src/processor/elasticsearch/nodes/processor.rs
+++ b/src/processor/elasticsearch/nodes/processor.rs
@@ -8,7 +8,7 @@ use super::{Node, Nodes};
 use crate::exporter::Exporter;
 use rayon::prelude::*;
 use serde::Serialize;
-use serde_json::{Map, Value};
+use serde_json::Value;
 
 impl DocumentExporter<Lookups, ElasticsearchMetadata> for Nodes {
     async fn documents_export(
@@ -30,12 +30,17 @@ impl DocumentExporter<Lookups, ElasticsearchMetadata> for Nodes {
 
         let node_docs: Vec<Value> = nodes
             .par_drain()
-            .map(|(node_id, node)| {
-                let mut node_doc = serde_json::to_value(node_doc.clone().with_node(node))
-                    .unwrap_or(Value::Null);
+            .filter_map(|(node_id, node)| {
+                let mut node_doc = match serde_json::to_value(node_doc.clone().with_node(node)) {
+                    Ok(doc) => doc,
+                    Err(err) => {
+                        log::error!("Failed to serialize node document for {}: {}", node_id, err);
+                        return None;
+                    }
+                };
                 if let Some(node_val) = node_doc.get_mut("node") {
-                    set_nested_null(node_val, &["settings", "http", "type.default"]);
-                    set_nested_null(node_val, &["settings", "transport", "type.default"]);
+                    remove_nested_key(node_val, &["settings", "http", "type.default"]);
+                    remove_nested_key(node_val, &["settings", "transport", "type.default"]);
 
                     if let Some(summary) = lookup_node.by_id(&node_id)
                         && let Ok(summary_val) = serde_json::to_value(summary)
@@ -43,7 +48,7 @@ impl DocumentExporter<Lookups, ElasticsearchMetadata> for Nodes {
                         merge_values(node_val, &summary_val);
                     }
                 }
-                node_doc
+                Some(node_doc)
             })
             .collect();
 
@@ -90,23 +95,25 @@ fn merge_values(target: &mut Value, patch: &Value) {
     }
 }
 
-fn set_nested_null(root: &mut Value, path: &[&str]) {
+fn remove_nested_key(root: &mut Value, path: &[&str]) {
     if path.is_empty() {
         return;
     }
 
-    if !root.is_object() {
-        *root = Value::Object(Map::new());
-    }
+    let Value::Object(object) = root else {
+        return;
+    };
 
-    let object = root.as_object_mut().expect("initialized object");
     if path.len() == 1 {
-        object.insert(path[0].to_string(), Value::Null);
+        object.remove(path[0]);
         return;
     }
 
-    let child = object
-        .entry(path[0].to_string())
-        .or_insert_with(|| Value::Object(Map::new()));
-    set_nested_null(child, &path[1..]);
+    if let Some(child) = object.get_mut(path[0]) {
+        remove_nested_key(child, &path[1..]);
+        let prune_child = child.as_object().is_some_and(|map| map.is_empty());
+        if prune_child {
+            object.remove(path[0]);
+        }
+    }
 }

--- a/src/processor/elasticsearch/nodes/processor.rs
+++ b/src/processor/elasticsearch/nodes/processor.rs
@@ -3,12 +3,12 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use super::super::{DocumentExporter, ElasticsearchMetadata, Lookups, ProcessorSummary};
+use super::super::metadata::MetadataRawValue;
 use super::{Node, Nodes};
 use crate::exporter::Exporter;
-use json_patch::merge;
 use rayon::prelude::*;
 use serde::Serialize;
-use serde_json::{Value, json};
+use serde_json::{Map, Value};
 
 impl DocumentExporter<Lookups, ElasticsearchMetadata> for Nodes {
     async fn documents_export(
@@ -21,7 +21,7 @@ impl DocumentExporter<Lookups, ElasticsearchMetadata> for Nodes {
         log::debug!("nodes: {}", nodes.len());
         let data_stream = "settings-node-esdiag".to_string();
         let lookup_node = &lookups.node;
-        let metadata = metadata.for_data_stream(&data_stream).as_meta_doc();
+        let metadata = metadata.for_data_stream(&data_stream);
 
         let node_doc = NodeDoc {
             metadata,
@@ -31,24 +31,18 @@ impl DocumentExporter<Lookups, ElasticsearchMetadata> for Nodes {
         let node_docs: Vec<Value> = nodes
             .par_drain()
             .map(|(node_id, node)| {
-                let patch = json!({
-                    "node" : {
-                        "settings": {
-                            "http": {
-                                "type.default": null,
-                            },
-                            "transport": {
-                                "type.default": null,
-                            },
-                        }
+                let mut node_doc = serde_json::to_value(node_doc.clone().with_node(node))
+                    .unwrap_or(Value::Null);
+                if let Some(node_val) = node_doc.get_mut("node") {
+                    set_nested_null(node_val, &["settings", "http", "type.default"]);
+                    set_nested_null(node_val, &["settings", "transport", "type.default"]);
+
+                    if let Some(summary) = lookup_node.by_id(&node_id)
+                        && let Ok(summary_val) = serde_json::to_value(summary)
+                    {
+                        merge_values(node_val, &summary_val);
                     }
-                });
-
-                let node_summary = json!({"node": lookup_node.by_id(&node_id)});
-                let mut node_doc = json!(node_doc.clone().with_node(node));
-
-                merge(&mut node_doc, &patch);
-                merge(&mut node_doc, &node_summary);
+                }
                 node_doc
             })
             .collect();
@@ -66,7 +60,7 @@ impl DocumentExporter<Lookups, ElasticsearchMetadata> for Nodes {
 #[derive(Clone, Serialize)]
 struct NodeDoc {
     #[serde(flatten)]
-    metadata: Value,
+    metadata: MetadataRawValue,
     node: Option<Node>,
 }
 
@@ -77,4 +71,42 @@ impl NodeDoc {
             ..self
         }
     }
+}
+
+fn merge_values(target: &mut Value, patch: &Value) {
+    match (target, patch) {
+        (Value::Object(target_obj), Value::Object(patch_obj)) => {
+            for (key, value) in patch_obj {
+                if let Some(existing) = target_obj.get_mut(key) {
+                    merge_values(existing, value);
+                } else {
+                    target_obj.insert(key.clone(), value.clone());
+                }
+            }
+        }
+        (target, patch) => {
+            *target = patch.clone();
+        }
+    }
+}
+
+fn set_nested_null(root: &mut Value, path: &[&str]) {
+    if path.is_empty() {
+        return;
+    }
+
+    if !root.is_object() {
+        *root = Value::Object(Map::new());
+    }
+
+    let object = root.as_object_mut().expect("initialized object");
+    if path.len() == 1 {
+        object.insert(path[0].to_string(), Value::Null);
+        return;
+    }
+
+    let child = object
+        .entry(path[0].to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    set_nested_null(child, &path[1..]);
 }

--- a/src/processor/elasticsearch/nodes/processor.rs
+++ b/src/processor/elasticsearch/nodes/processor.rs
@@ -4,6 +4,7 @@
 
 use super::super::{DocumentExporter, ElasticsearchMetadata, Lookups, ProcessorSummary};
 use super::super::metadata::MetadataRawValue;
+use super::super::json_utils::merge_values;
 use super::{Node, Nodes};
 use crate::exporter::Exporter;
 use rayon::prelude::*;
@@ -74,23 +75,6 @@ impl NodeDoc {
         Self {
             node: Some(node),
             ..self
-        }
-    }
-}
-
-fn merge_values(target: &mut Value, patch: &Value) {
-    match (target, patch) {
-        (Value::Object(target_obj), Value::Object(patch_obj)) => {
-            for (key, value) in patch_obj {
-                if let Some(existing) = target_obj.get_mut(key) {
-                    merge_values(existing, value);
-                } else {
-                    target_obj.insert(key.clone(), value.clone());
-                }
-            }
-        }
-        (target, patch) => {
-            *target = patch.clone();
         }
     }
 }

--- a/src/processor/elasticsearch/nodes_stats/processor.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor.rs
@@ -9,12 +9,15 @@ mod ingest_pipelines;
 mod transport_actions;
 
 use super::super::super::{Exporter, ProcessorSummary};
-use super::super::{DocumentExporter, ElasticsearchMetadata, Lookups, metadata::MetadataRawValue};
+use super::super::{
+    DocumentExporter, ElasticsearchMetadata, Lookups, SharedCacheStats, metadata::MetadataRawValue,
+    nodes::NodeDocument,
+};
 use super::NodesStats;
 use crate::processor::StreamingDocumentExporter;
 use futures::stream::{BoxStream, StreamExt};
-use json_patch::merge;
-use serde_json::{Value, json};
+use serde::Serialize;
+use serde_json::Value;
 use std::sync::LazyLock;
 use tokio::sync::mpsc;
 
@@ -28,13 +31,13 @@ struct NodeProcessingContext<'a> {
     http_clients_metadata: &'a MetadataRawValue,
     applier_metadata: &'a MetadataRawValue,
     adaptive_metadata: &'a MetadataRawValue,
-    nodes_stats_tx: &'a mpsc::Sender<Value>,
-    actions_tx: &'a mpsc::Sender<Value>,
-    http_clients_tx: &'a mpsc::Sender<Value>,
-    applier_tx: &'a mpsc::Sender<Value>,
-    adaptive_tx: &'a mpsc::Sender<Value>,
-    pipelines_tx: &'a mpsc::Sender<Value>,
-    processors_tx: &'a mpsc::Sender<Value>,
+    nodes_stats_tx: &'a mpsc::Sender<NodeStatsDoc>,
+    actions_tx: &'a mpsc::Sender<transport_actions::TransportActionDoc>,
+    http_clients_tx: &'a mpsc::Sender<http_clients::HttpClientDoc>,
+    applier_tx: &'a mpsc::Sender<cluster_applier_stats::ClusterApplierDoc>,
+    adaptive_tx: &'a mpsc::Sender<adaptive_selections::AdaptiveSelectionDoc>,
+    pipelines_tx: &'a mpsc::Sender<ingest_pipelines::IngestPipelineDoc>,
+    processors_tx: &'a mpsc::Sender<ingest_pipelines::IngestDoc>,
 }
 
 async fn process_node(
@@ -56,14 +59,10 @@ async fn process_node(
         if let Ok(mut transport_val) = serde_json::from_str::<Value>(transport_raw.get()) {
             let actions = transport_val["actions"].take();
             if !actions.is_null() {
-                // Since actions_metadata is pre-serialized, we need a Value for merge in transport_actions::extract
-                // For now, transport_actions::extract still expects &Value.
-                // We'll convert it back if needed or update the helper.
-                let actions_meta_val = serde_json::to_value(ctx.actions_metadata).unwrap();
                 if let Err(e) = transport_actions::extract(
                     ctx.actions_tx,
                     actions,
-                    &actions_meta_val,
+                    ctx.actions_metadata,
                     node_metadata,
                 )
                 .await
@@ -92,10 +91,15 @@ async fn process_node(
     // Extract HTTP clients
     if let Ok(mut http_val) = serde_json::from_str::<Value>(node_stats.http.get()) {
         let clients = http_val["clients"].take();
+        let _ = http_val["routes"].take();
         if !clients.is_null() {
-            let http_meta_val = serde_json::to_value(ctx.http_clients_metadata).unwrap();
             if let Err(e) =
-                http_clients::extract(ctx.http_clients_tx, clients, &http_meta_val, node_metadata)
+                http_clients::extract(
+                    ctx.http_clients_tx,
+                    clients,
+                    ctx.http_clients_metadata,
+                    node_metadata,
+                )
                     .await
             {
                 log::error!("Error extracting HTTP clients stats: {}", e);
@@ -113,11 +117,10 @@ async fn process_node(
     if let Some(adaptive_raw) = node_stats.adaptive_selection.take()
         && let Ok(adaptive_val) = serde_json::from_str::<Value>(adaptive_raw.get())
     {
-        let adaptive_meta_val = serde_json::to_value(ctx.adaptive_metadata).unwrap();
         if let Err(e) = adaptive_selections::extract(
             ctx.adaptive_tx,
             Some(adaptive_val),
-            &adaptive_meta_val,
+            ctx.adaptive_metadata,
             node_metadata,
             lookup_node,
         )
@@ -131,11 +134,10 @@ async fn process_node(
     if let Ok(mut discovery_val) = serde_json::from_str::<Value>(node_stats.discovery.get()) {
         let cluster_applier_stats = discovery_val["cluster_applier_stats"].take();
         if !cluster_applier_stats.is_null() {
-            let applier_meta_val = serde_json::to_value(ctx.applier_metadata).unwrap();
             if let Err(e) = cluster_applier_stats::extract(
                 ctx.applier_tx,
                 cluster_applier_stats,
-                &applier_meta_val,
+                ctx.applier_metadata,
                 node_metadata,
             )
             .await
@@ -166,23 +168,14 @@ async fn process_node(
     }
 
     // Final node_stats document
-    let mut doc = json!({
-        "node": &node_stats,
-        "shared_cache": lookup_shared_cache.by_id(node_id.as_str()),
-    });
-
-    let omit_patch = json!({
-        "node" : {
-            "http": { "routes": null },
-        }
-    });
-
-    let node_summary_patch = json!({"node": node_metadata});
-    let node_stats_meta_val = serde_json::to_value(ctx.node_stats_metadata).unwrap();
-
-    merge(&mut doc, &node_stats_meta_val);
-    merge(&mut doc, &node_summary_patch);
-    merge(&mut doc, &omit_patch);
+    let doc = NodeStatsDoc {
+        node: NodeStatsEnvelope {
+            stats: node_stats,
+            summary: node_metadata.cloned(),
+        },
+        shared_cache: lookup_shared_cache.by_id(node_id.as_str()).cloned(),
+        metadata: ctx.node_stats_metadata.clone(),
+    };
 
     if (ctx.nodes_stats_tx.send(doc).await).is_err() {
         log::warn!("Nodes stats channel closed unexpectedly");
@@ -216,61 +209,85 @@ impl StreamingDocumentExporter<Lookups, ElasticsearchMetadata> for NodesStats {
         let batch_size = 5000;
         const BUFFER_SIZE: usize = 5000;
 
-        let (nodes_stats_tx, nodes_stats_rx) = mpsc::channel::<Value>(BUFFER_SIZE);
+        let (nodes_stats_tx, nodes_stats_rx) = mpsc::channel::<NodeStatsDoc>(BUFFER_SIZE);
         let node_stats_metadata = metadata.for_data_stream(&data_stream);
-        let nodes_stats_processor = tokio::spawn(exporter.clone().document_channel::<Value>(
-            nodes_stats_rx,
-            "metrics-node-esdiag".to_string(),
-            batch_size,
-        ));
+        let nodes_stats_processor =
+            tokio::spawn(exporter.clone().document_channel::<NodeStatsDoc>(
+                nodes_stats_rx,
+                "metrics-node-esdiag".to_string(),
+                batch_size,
+            ));
 
-        let (actions_tx, actions_rx) = mpsc::channel::<Value>(BUFFER_SIZE);
+        let (actions_tx, actions_rx) = mpsc::channel::<transport_actions::TransportActionDoc>(BUFFER_SIZE);
         let actions_data_stream = "metrics-node.transport.actions-esdiag".to_string();
         let actions_metadata = metadata.for_data_stream(&actions_data_stream);
-        let actions_processor = tokio::spawn(exporter.clone().document_channel::<Value>(
+        let actions_processor = tokio::spawn(
+            exporter
+                .clone()
+                .document_channel::<transport_actions::TransportActionDoc>(
             actions_rx,
             actions_data_stream,
             batch_size,
         ));
 
-        let (http_clients_tx, http_clients_rx) = mpsc::channel::<Value>(BUFFER_SIZE);
+        let (http_clients_tx, http_clients_rx) =
+            mpsc::channel::<http_clients::HttpClientDoc>(BUFFER_SIZE);
         let http_clients_data_stream = "metrics-node.http.clients-esdiag".to_string();
         let http_clients_metadata = metadata.for_data_stream(&http_clients_data_stream);
-        let http_clients_processor = tokio::spawn(exporter.clone().document_channel::<Value>(
+        let http_clients_processor = tokio::spawn(
+            exporter
+                .clone()
+                .document_channel::<http_clients::HttpClientDoc>(
             http_clients_rx,
             http_clients_data_stream,
             batch_size,
         ));
 
-        let (applier_tx, applier_rx) = mpsc::channel::<Value>(BUFFER_SIZE);
+        let (applier_tx, applier_rx) =
+            mpsc::channel::<cluster_applier_stats::ClusterApplierDoc>(BUFFER_SIZE);
         let applier_data_stream = "metrics-node.discovery.cluster_applier-esdiag".to_string();
         let applier_metadata = metadata.for_data_stream(&applier_data_stream);
-        let applier_processor = tokio::spawn(exporter.clone().document_channel::<Value>(
+        let applier_processor = tokio::spawn(
+            exporter
+                .clone()
+                .document_channel::<cluster_applier_stats::ClusterApplierDoc>(
             applier_rx,
             applier_data_stream,
             batch_size,
         ));
 
-        let (adaptive_tx, adaptive_rx) = mpsc::channel::<Value>(BUFFER_SIZE);
+        let (adaptive_tx, adaptive_rx) =
+            mpsc::channel::<adaptive_selections::AdaptiveSelectionDoc>(BUFFER_SIZE);
         let adaptive_data_stream = "metrics-node.discovery.cluster_adaptive-esdiag".to_string();
         let adaptive_metadata = metadata.for_data_stream(&adaptive_data_stream);
-        let adaptive_processor = tokio::spawn(exporter.clone().document_channel::<Value>(
+        let adaptive_processor = tokio::spawn(
+            exporter
+                .clone()
+                .document_channel::<adaptive_selections::AdaptiveSelectionDoc>(
             adaptive_rx,
             adaptive_data_stream,
             batch_size,
         ));
 
-        let (pipelines_tx, pipelines_rx) = mpsc::channel::<Value>(BUFFER_SIZE);
+        let (pipelines_tx, pipelines_rx) =
+            mpsc::channel::<ingest_pipelines::IngestPipelineDoc>(BUFFER_SIZE);
         let pipelines_data_stream = "metrics-ingest.pipeline-esdiag".to_string();
-        let pipelines_processor = tokio::spawn(exporter.clone().document_channel::<Value>(
+        let pipelines_processor = tokio::spawn(
+            exporter
+                .clone()
+                .document_channel::<ingest_pipelines::IngestPipelineDoc>(
             pipelines_rx,
             pipelines_data_stream,
             batch_size,
         ));
 
-        let (processors_tx, processors_rx) = mpsc::channel::<Value>(BUFFER_SIZE);
+        let (processors_tx, processors_rx) =
+            mpsc::channel::<ingest_pipelines::IngestDoc>(BUFFER_SIZE);
         let processors_data_stream = "metrics-ingest.processors-esdiag".to_string();
-        let processors_processor = tokio::spawn(exporter.clone().document_channel::<Value>(
+        let processors_processor = tokio::spawn(
+            exporter
+                .clone()
+                .document_channel::<ingest_pipelines::IngestDoc>(
             processors_rx,
             processors_data_stream,
             batch_size,
@@ -340,4 +357,20 @@ impl StreamingDocumentExporter<Lookups, ElasticsearchMetadata> for NodesStats {
 
         summary
     }
+}
+
+#[derive(Serialize)]
+struct NodeStatsDoc {
+    node: NodeStatsEnvelope,
+    shared_cache: Option<SharedCacheStats>,
+    #[serde(flatten)]
+    metadata: MetadataRawValue,
+}
+
+#[derive(Serialize)]
+struct NodeStatsEnvelope {
+    #[serde(flatten)]
+    stats: super::data::NodeStats,
+    #[serde(flatten)]
+    summary: Option<NodeDocument>,
 }

--- a/src/processor/elasticsearch/nodes_stats/processor.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor.rs
@@ -57,7 +57,10 @@ async fn process_node(
     // Extract transport actions
     if let Some(transport_raw) = node_stats.transport.take() {
         if let Ok(mut transport_val) = serde_json::from_str::<Value>(transport_raw.get()) {
-            let actions = transport_val["actions"].take();
+            let actions = transport_val
+                .as_object_mut()
+                .and_then(|obj| obj.remove("actions"))
+                .unwrap_or(Value::Null);
             if !actions.is_null() {
                 if let Err(e) = transport_actions::extract(
                     ctx.actions_tx,
@@ -90,8 +93,13 @@ async fn process_node(
 
     // Extract HTTP clients
     if let Ok(mut http_val) = serde_json::from_str::<Value>(node_stats.http.get()) {
-        let clients = http_val["clients"].take();
-        let _ = http_val["routes"].take();
+        let clients = http_val
+            .as_object_mut()
+            .and_then(|obj| obj.remove("clients"))
+            .unwrap_or(Value::Null);
+        if let Some(obj) = http_val.as_object_mut() {
+            obj.remove("routes");
+        }
         if !clients.is_null() {
             if let Err(e) =
                 http_clients::extract(
@@ -104,11 +112,11 @@ async fn process_node(
             {
                 log::error!("Error extracting HTTP clients stats: {}", e);
             }
-            match serde_json::value::RawValue::from_string(http_val.to_string()) {
-                Ok(raw) => node_stats.http = raw,
-                Err(e) => {
-                    log::error!("Failed to re-serialize HTTP clients stats: {}", e);
-                }
+        }
+        match serde_json::value::RawValue::from_string(http_val.to_string()) {
+            Ok(raw) => node_stats.http = raw,
+            Err(e) => {
+                log::error!("Failed to re-serialize HTTP clients stats: {}", e);
             }
         }
     }

--- a/src/processor/elasticsearch/nodes_stats/processor.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor.rs
@@ -16,7 +16,7 @@ use super::super::{
 use super::NodesStats;
 use crate::processor::StreamingDocumentExporter;
 use futures::stream::{BoxStream, StreamExt};
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 use serde_json::Value;
 use std::sync::LazyLock;
 use tokio::sync::mpsc;
@@ -375,10 +375,38 @@ struct NodeStatsDoc {
     metadata: MetadataRawValue,
 }
 
-#[derive(Serialize)]
 struct NodeStatsEnvelope {
-    #[serde(flatten)]
     stats: super::data::NodeStats,
-    #[serde(flatten)]
     summary: Option<NodeDocument>,
+}
+
+impl Serialize for NodeStatsEnvelope {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut merged = serde_json::to_value(&self.stats).map_err(serde::ser::Error::custom)?;
+        if let Some(summary) = &self.summary {
+            let summary_value = serde_json::to_value(summary).map_err(serde::ser::Error::custom)?;
+            merge_values(&mut merged, &summary_value);
+        }
+        merged.serialize(serializer)
+    }
+}
+
+fn merge_values(target: &mut Value, patch: &Value) {
+    match (target, patch) {
+        (Value::Object(target_obj), Value::Object(patch_obj)) => {
+            for (key, value) in patch_obj {
+                if let Some(existing) = target_obj.get_mut(key) {
+                    merge_values(existing, value);
+                } else {
+                    target_obj.insert(key.clone(), value.clone());
+                }
+            }
+        }
+        (target, patch) => {
+            *target = patch.clone();
+        }
+    }
 }

--- a/src/processor/elasticsearch/nodes_stats/processor.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor.rs
@@ -140,9 +140,8 @@ async fn process_node(
     // Extract cluster applier state
     if let Ok(mut discovery_val) = serde_json::from_str::<Value>(node_stats.discovery.get()) {
         let cluster_applier_stats = discovery_val
-            .as_object()
-            .and_then(|obj| obj.get("cluster_applier_stats"))
-            .cloned()
+            .as_object_mut()
+            .and_then(|obj| obj.remove("cluster_applier_stats"))
             .unwrap_or(Value::Null);
         if !cluster_applier_stats.is_null() {
             let extract_result = cluster_applier_stats::extract(
@@ -155,9 +154,6 @@ async fn process_node(
             if let Err(e) = extract_result {
                 log::error!("Error extracting cluster applier stats: {}", e);
             } else {
-                if let Some(obj) = discovery_val.as_object_mut() {
-                    obj.remove("cluster_applier_stats");
-                }
                 match serde_json::value::RawValue::from_string(discovery_val.to_string()) {
                     Ok(raw) => node_stats.discovery = raw,
                     Err(e) => {

--- a/src/processor/elasticsearch/nodes_stats/processor.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor.rs
@@ -11,12 +11,11 @@ mod transport_actions;
 use super::super::super::{Exporter, ProcessorSummary};
 use super::super::{
     DocumentExporter, ElasticsearchMetadata, Lookups, SharedCacheStats, metadata::MetadataRawValue,
-    nodes::NodeDocument,
 };
 use super::NodesStats;
 use crate::processor::StreamingDocumentExporter;
 use futures::stream::{BoxStream, StreamExt};
-use serde::{Serialize, Serializer};
+use serde::Serialize;
 use serde_json::Value;
 use std::sync::LazyLock;
 use tokio::sync::mpsc;
@@ -140,22 +139,30 @@ async fn process_node(
 
     // Extract cluster applier state
     if let Ok(mut discovery_val) = serde_json::from_str::<Value>(node_stats.discovery.get()) {
-        let cluster_applier_stats = discovery_val["cluster_applier_stats"].take();
+        let cluster_applier_stats = discovery_val
+            .as_object()
+            .and_then(|obj| obj.get("cluster_applier_stats"))
+            .cloned()
+            .unwrap_or(Value::Null);
         if !cluster_applier_stats.is_null() {
-            if let Err(e) = cluster_applier_stats::extract(
+            let extract_result = cluster_applier_stats::extract(
                 ctx.applier_tx,
                 cluster_applier_stats,
                 ctx.applier_metadata,
                 node_metadata,
             )
-            .await
-            {
+            .await;
+            if let Err(e) = extract_result {
                 log::error!("Error extracting cluster applier stats: {}", e);
-            }
-            match serde_json::value::RawValue::from_string(discovery_val.to_string()) {
-                Ok(raw) => node_stats.discovery = raw,
-                Err(e) => {
-                    log::error!("Failed to re-serialize cluster applier stats: {}", e);
+            } else {
+                if let Some(obj) = discovery_val.as_object_mut() {
+                    obj.remove("cluster_applier_stats");
+                }
+                match serde_json::value::RawValue::from_string(discovery_val.to_string()) {
+                    Ok(raw) => node_stats.discovery = raw,
+                    Err(e) => {
+                        log::error!("Failed to re-serialize cluster applier stats: {}", e);
+                    }
                 }
             }
         }
@@ -179,7 +186,10 @@ async fn process_node(
     let doc = NodeStatsDoc {
         node: NodeStatsEnvelope {
             stats: node_stats,
-            summary: node_metadata.cloned(),
+            id: node_metadata.as_ref().and_then(|node| node.id.clone()),
+            role: node_metadata.as_ref().map(|node| node.role.clone()),
+            tier: node_metadata.as_ref().map(|node| node.tier.clone()),
+            tier_order: node_metadata.as_ref().map(|node| node.tier_order),
         },
         shared_cache: lookup_shared_cache.by_id(node_id.as_str()).cloned(),
         metadata: ctx.node_stats_metadata.clone(),
@@ -375,38 +385,16 @@ struct NodeStatsDoc {
     metadata: MetadataRawValue,
 }
 
+#[derive(Serialize)]
 struct NodeStatsEnvelope {
+    #[serde(flatten)]
     stats: super::data::NodeStats,
-    summary: Option<NodeDocument>,
-}
-
-impl Serialize for NodeStatsEnvelope {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut merged = serde_json::to_value(&self.stats).map_err(serde::ser::Error::custom)?;
-        if let Some(summary) = &self.summary {
-            let summary_value = serde_json::to_value(summary).map_err(serde::ser::Error::custom)?;
-            merge_values(&mut merged, &summary_value);
-        }
-        merged.serialize(serializer)
-    }
-}
-
-fn merge_values(target: &mut Value, patch: &Value) {
-    match (target, patch) {
-        (Value::Object(target_obj), Value::Object(patch_obj)) => {
-            for (key, value) in patch_obj {
-                if let Some(existing) = target_obj.get_mut(key) {
-                    merge_values(existing, value);
-                } else {
-                    target_obj.insert(key.clone(), value.clone());
-                }
-            }
-        }
-        (target, patch) => {
-            *target = patch.clone();
-        }
-    }
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tier: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tier_order: Option<usize>,
 }

--- a/src/processor/elasticsearch/nodes_stats/processor.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor.rs
@@ -60,6 +60,7 @@ async fn process_node(
                 .as_object_mut()
                 .and_then(|obj| obj.remove("actions"))
                 .unwrap_or(Value::Null);
+            let mut extracted_actions = true;
             if !actions.is_null() {
                 if let Err(e) = transport_actions::extract(
                     ctx.actions_tx,
@@ -69,6 +70,7 @@ async fn process_node(
                 )
                 .await
                 {
+                    extracted_actions = false;
                     log::error!(
                         "Error extracting transport stats for node {}: {}",
                         node_id,
@@ -76,14 +78,18 @@ async fn process_node(
                     );
                 }
             }
-            match serde_json::value::RawValue::from_string(transport_val.to_string()) {
-                Ok(raw) => node_stats.transport = Some(raw),
-                Err(e) => {
-                    log::error!("Failed to re-serialize transport stats: {}", e);
-                    // Trade-off: mutating RawValue requires serialization cycle. If it fails, fallback to un-mutated.
-                    // This means transport.actions remain in the doc, leading to potentially larger payload.
-                    node_stats.transport = Some(transport_raw);
+            if extracted_actions {
+                match serde_json::value::RawValue::from_string(transport_val.to_string()) {
+                    Ok(raw) => node_stats.transport = Some(raw),
+                    Err(e) => {
+                        log::error!("Failed to re-serialize transport stats: {}", e);
+                        // Trade-off: mutating RawValue requires serialization cycle. If it fails, fallback to un-mutated.
+                        // This means transport.actions remain in the doc, leading to potentially larger payload.
+                        node_stats.transport = Some(transport_raw);
+                    }
                 }
+            } else {
+                node_stats.transport = Some(transport_raw);
             }
         } else {
             node_stats.transport = Some(transport_raw);
@@ -99,6 +105,7 @@ async fn process_node(
         if let Some(obj) = http_val.as_object_mut() {
             obj.remove("routes");
         }
+        let mut extracted_clients = true;
         if !clients.is_null() {
             if let Err(e) =
                 http_clients::extract(
@@ -109,13 +116,16 @@ async fn process_node(
                 )
                     .await
             {
+                extracted_clients = false;
                 log::error!("Error extracting HTTP clients stats: {}", e);
             }
         }
-        match serde_json::value::RawValue::from_string(http_val.to_string()) {
-            Ok(raw) => node_stats.http = raw,
-            Err(e) => {
-                log::error!("Failed to re-serialize HTTP clients stats: {}", e);
+        if extracted_clients {
+            match serde_json::value::RawValue::from_string(http_val.to_string()) {
+                Ok(raw) => node_stats.http = raw,
+                Err(e) => {
+                    log::error!("Failed to re-serialize HTTP clients stats: {}", e);
+                }
             }
         }
     }

--- a/src/processor/elasticsearch/nodes_stats/processor/adaptive_selections.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/adaptive_selections.rs
@@ -25,8 +25,6 @@ pub async fn extract(
     docs.extend(
         adaptive_selection
             .into_iter()
-            .collect::<Vec<(String, Value)>>()
-            .drain(..)
             .map(|(peer_node_id, adaptive_selection)| {
                 AdaptiveSelectionDoc {
                     node: node_metadata.cloned(),

--- a/src/processor/elasticsearch/nodes_stats/processor/adaptive_selections.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/adaptive_selections.rs
@@ -4,8 +4,8 @@
 
 use super::super::super::{Lookup, metadata::MetadataRawValue, nodes::NodeDocument};
 use eyre::Result;
-use serde::Serialize;
-use serde_json::Value;
+use serde::{Serialize, Serializer};
+use serde_json::{Value, value::RawValue};
 use tokio::sync::mpsc::Sender;
 
 /// Extract adaptive_selection
@@ -32,7 +32,10 @@ pub async fn extract(
                     node: node_metadata.cloned(),
                     adaptive_selection: AdaptiveSelectionEntry {
                         node: lookup_node.by_id(&peer_node_id).cloned(),
-                        data: adaptive_selection,
+                        data: FlattenRawValue(
+                            serde_json::value::to_raw_value(&adaptive_selection)
+                                .expect("serialize adaptive selection to raw"),
+                        ),
                     },
                     metadata: metadata.clone(),
                 }
@@ -57,5 +60,18 @@ pub struct AdaptiveSelectionDoc {
 struct AdaptiveSelectionEntry {
     node: Option<NodeDocument>,
     #[serde(flatten)]
-    data: Value,
+    data: FlattenRawValue,
+}
+
+struct FlattenRawValue(Box<RawValue>);
+
+impl Serialize for FlattenRawValue {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let value: Value =
+            serde_json::from_str(self.0.get()).map_err(serde::ser::Error::custom)?;
+        value.serialize(serializer)
+    }
 }

--- a/src/processor/elasticsearch/nodes_stats/processor/adaptive_selections.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/adaptive_selections.rs
@@ -4,8 +4,8 @@
 
 use super::super::super::{Lookup, metadata::MetadataRawValue, nodes::NodeDocument};
 use eyre::Result;
-use serde::{Serialize, Serializer};
-use serde_json::{Value, value::RawValue};
+use serde::Serialize;
+use serde_json::Value;
 use tokio::sync::mpsc::Sender;
 
 /// Extract adaptive_selection
@@ -32,10 +32,7 @@ pub async fn extract(
                     node: node_metadata.cloned(),
                     adaptive_selection: AdaptiveSelectionEntry {
                         node: lookup_node.by_id(&peer_node_id).cloned(),
-                        data: FlattenRawValue(
-                            serde_json::value::to_raw_value(&adaptive_selection)
-                                .expect("serialize adaptive selection to raw"),
-                        ),
+                        data: adaptive_selection,
                     },
                     metadata: metadata.clone(),
                 }
@@ -60,18 +57,5 @@ pub struct AdaptiveSelectionDoc {
 struct AdaptiveSelectionEntry {
     node: Option<NodeDocument>,
     #[serde(flatten)]
-    data: FlattenRawValue,
-}
-
-struct FlattenRawValue(Box<RawValue>);
-
-impl Serialize for FlattenRawValue {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let value: Value =
-            serde_json::from_str(self.0.get()).map_err(serde::ser::Error::custom)?;
-        value.serialize(serializer)
-    }
+    data: Value,
 }

--- a/src/processor/elasticsearch/nodes_stats/processor/adaptive_selections.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/adaptive_selections.rs
@@ -2,17 +2,17 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::super::super::{Lookup, nodes::NodeDocument};
+use super::super::super::{Lookup, metadata::MetadataRawValue, nodes::NodeDocument};
 use eyre::Result;
-use json_patch::merge;
-use serde_json::{Value, json};
+use serde::Serialize;
+use serde_json::Value;
 use tokio::sync::mpsc::Sender;
 
 /// Extract adaptive_selection
 pub async fn extract(
-    sender: &Sender<Value>,
+    sender: &Sender<AdaptiveSelectionDoc>,
     adaptive_selection: Option<Value>,
-    metadata: &Value,
+    metadata: &MetadataRawValue,
     node_metadata: Option<&NodeDocument>,
     lookup_node: &Lookup<NodeDocument>,
 ) -> Result<()> {
@@ -21,27 +21,21 @@ pub async fn extract(
         _ => return Err(eyre::eyre!("Error extracting node.adaptive_selection data")),
     };
 
-    let mut docs = Vec::<Value>::with_capacity(200);
+    let mut docs = Vec::<AdaptiveSelectionDoc>::with_capacity(200);
     docs.extend(
         adaptive_selection
             .into_iter()
             .collect::<Vec<(String, Value)>>()
             .drain(..)
             .map(|(peer_node_id, adaptive_selection)| {
-                let mut doc = json!({
-                    "adaptive_selection": adaptive_selection,
-                    "node": node_metadata,
-                });
-
-                let peer_node_patch = json!({
-                    "adaptive_selection": {
-                        "node": lookup_node.by_id(&peer_node_id),
+                AdaptiveSelectionDoc {
+                    node: node_metadata.cloned(),
+                    adaptive_selection: AdaptiveSelectionEntry {
+                        node: lookup_node.by_id(&peer_node_id).cloned(),
+                        data: adaptive_selection,
                     },
-                });
-
-                merge(&mut doc, &peer_node_patch);
-                merge(&mut doc, metadata);
-                doc
+                    metadata: metadata.clone(),
+                }
             }),
     );
 
@@ -49,4 +43,19 @@ pub async fn extract(
         sender.send(doc).await?;
     }
     Ok(())
+}
+
+#[derive(Serialize)]
+pub struct AdaptiveSelectionDoc {
+    node: Option<NodeDocument>,
+    adaptive_selection: AdaptiveSelectionEntry,
+    #[serde(flatten)]
+    metadata: MetadataRawValue,
+}
+
+#[derive(Serialize)]
+struct AdaptiveSelectionEntry {
+    node: Option<NodeDocument>,
+    #[serde(flatten)]
+    data: Value,
 }

--- a/src/processor/elasticsearch/nodes_stats/processor/cluster_applier_stats.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/cluster_applier_stats.rs
@@ -5,7 +5,7 @@
 use super::super::super::{metadata::MetadataRawValue, nodes::NodeDocument};
 use eyre::{OptionExt, Result};
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{Value, value::RawValue};
 use tokio::sync::mpsc::Sender;
 
 /// Extract discovery.cluster_applier_stats.recordings dataset
@@ -22,7 +22,8 @@ pub async fn extract(
     let mut docs = Vec::<ClusterApplierDoc>::with_capacity(200);
     docs.extend(recordings.drain(..).map(|recording| {
         ClusterApplierDoc {
-            cluster_applier_stats: recording,
+            cluster_applier_stats: serde_json::value::to_raw_value(&recording)
+                .expect("serialize cluster applier recording to raw"),
             node: node_metadata.cloned(),
             metadata: metadata.clone(),
         }
@@ -36,7 +37,7 @@ pub async fn extract(
 
 #[derive(Serialize)]
 pub struct ClusterApplierDoc {
-    cluster_applier_stats: Value,
+    cluster_applier_stats: Box<RawValue>,
     node: Option<NodeDocument>,
     #[serde(flatten)]
     metadata: MetadataRawValue,

--- a/src/processor/elasticsearch/nodes_stats/processor/cluster_applier_stats.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/cluster_applier_stats.rs
@@ -20,13 +20,19 @@ pub async fn extract(
         .ok_or_eyre("Error extracting node.discovery.cluster_applier data")?;
 
     let mut docs = Vec::<ClusterApplierDoc>::with_capacity(200);
-    docs.extend(recordings.drain(..).map(|recording| {
-        ClusterApplierDoc {
-            cluster_applier_stats: serde_json::value::to_raw_value(&recording)
-                .expect("serialize cluster applier recording to raw"),
+    docs.extend(recordings.drain(..).filter_map(|recording| {
+        let recording_raw = match serde_json::value::to_raw_value(&recording) {
+            Ok(raw) => raw,
+            Err(err) => {
+                log::warn!("Skipping malformed cluster applier recording: {}", err);
+                return None;
+            }
+        };
+        Some(ClusterApplierDoc {
+            cluster_applier_stats: recording_raw,
             node: node_metadata.cloned(),
             metadata: metadata.clone(),
-        }
+        })
     }));
 
     for doc in docs {

--- a/src/processor/elasticsearch/nodes_stats/processor/cluster_applier_stats.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/cluster_applier_stats.rs
@@ -2,36 +2,42 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::super::super::nodes::NodeDocument;
+use super::super::super::{metadata::MetadataRawValue, nodes::NodeDocument};
 use eyre::{OptionExt, Result};
-use json_patch::merge;
-use serde_json::{Value, json};
+use serde::Serialize;
+use serde_json::Value;
 use tokio::sync::mpsc::Sender;
 
 /// Extract discovery.cluster_applier_stats.recordings dataset
 pub async fn extract(
-    sender: &Sender<Value>,
+    sender: &Sender<ClusterApplierDoc>,
     mut cluster_applier_stats: Value,
-    metadata: &Value,
+    metadata: &MetadataRawValue,
     node_metadata: Option<&NodeDocument>,
 ) -> Result<()> {
     let recordings = cluster_applier_stats["recordings"]
         .as_array_mut()
         .ok_or_eyre("Error extracting node.discovery.cluster_applier data")?;
 
-    let mut docs = Vec::<Value>::with_capacity(200);
+    let mut docs = Vec::<ClusterApplierDoc>::with_capacity(200);
     docs.extend(recordings.drain(..).map(|recording| {
-        let mut doc = json!({
-            "cluster_applier_stats": recording,
-            "node": node_metadata,
-        });
-
-        merge(&mut doc, metadata);
-        doc
+        ClusterApplierDoc {
+            cluster_applier_stats: recording,
+            node: node_metadata.cloned(),
+            metadata: metadata.clone(),
+        }
     }));
 
     for doc in docs {
         sender.send(doc).await?;
     }
     Ok(())
+}
+
+#[derive(Serialize)]
+pub struct ClusterApplierDoc {
+    cluster_applier_stats: Value,
+    node: Option<NodeDocument>,
+    #[serde(flatten)]
+    metadata: MetadataRawValue,
 }

--- a/src/processor/elasticsearch/nodes_stats/processor/http_clients.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/http_clients.rs
@@ -21,15 +21,19 @@ pub async fn extract(
         .ok_or_eyre("Error extracting node.http.clients data")?;
 
     let mut docs = Vec::<HttpClientDoc>::with_capacity(200);
-    docs.par_extend(clients.par_drain(..).map(|client| {
-        HttpClientDoc {
+    docs.par_extend(clients.par_drain(..).filter_map(|client| {
+        let client_raw = match serde_json::value::to_raw_value(&client) {
+            Ok(raw) => raw,
+            Err(err) => {
+                log::warn!("Skipping malformed http client stats record: {}", err);
+                return None;
+            }
+        };
+        Some(HttpClientDoc {
             node: node_metadata.cloned(),
-            http: HttpClientContainer {
-                client: serde_json::value::to_raw_value(&client)
-                    .expect("serialize http client to raw"),
-            },
+            http: HttpClientContainer { client: client_raw },
             metadata: metadata.clone(),
-        }
+        })
     }));
 
     for doc in docs {

--- a/src/processor/elasticsearch/nodes_stats/processor/http_clients.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/http_clients.rs
@@ -6,7 +6,7 @@ use super::super::super::{metadata::MetadataRawValue, nodes::NodeDocument};
 use eyre::{OptionExt, Result};
 use rayon::prelude::*;
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{Value, value::RawValue};
 use tokio::sync::mpsc::Sender;
 
 /// Extract http.clients
@@ -24,7 +24,10 @@ pub async fn extract(
     docs.par_extend(clients.par_drain(..).map(|client| {
         HttpClientDoc {
             node: node_metadata.cloned(),
-            http: HttpClientContainer { client },
+            http: HttpClientContainer {
+                client: serde_json::value::to_raw_value(&client)
+                    .expect("serialize http client to raw"),
+            },
             metadata: metadata.clone(),
         }
     }));
@@ -45,5 +48,5 @@ pub struct HttpClientDoc {
 
 #[derive(Serialize)]
 struct HttpClientContainer {
-    client: Value,
+    client: Box<RawValue>,
 }

--- a/src/processor/elasticsearch/nodes_stats/processor/http_clients.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/http_clients.rs
@@ -2,33 +2,48 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::super::super::nodes::NodeDocument;
+use super::super::super::{metadata::MetadataRawValue, nodes::NodeDocument};
 use eyre::{OptionExt, Result};
-use json_patch::merge;
 use rayon::prelude::*;
-use serde_json::{Value, json};
+use serde::Serialize;
+use serde_json::Value;
 use tokio::sync::mpsc::Sender;
 
 /// Extract http.clients
 pub async fn extract(
-    sender: &Sender<Value>,
+    sender: &Sender<HttpClientDoc>,
     mut clients: Value,
-    metadata: &Value,
+    metadata: &MetadataRawValue,
     node_metadata: Option<&NodeDocument>,
 ) -> Result<()> {
     let clients = clients
         .as_array_mut()
         .ok_or_eyre("Error extracting node.http.clients data")?;
 
-    let mut docs = Vec::<Value>::with_capacity(200);
+    let mut docs = Vec::<HttpClientDoc>::with_capacity(200);
     docs.par_extend(clients.par_drain(..).map(|client| {
-        let mut doc = json!({ "node": node_metadata, "http": { "client": client }});
-        merge(&mut doc, metadata);
-        doc
+        HttpClientDoc {
+            node: node_metadata.cloned(),
+            http: HttpClientContainer { client },
+            metadata: metadata.clone(),
+        }
     }));
 
     for doc in docs {
         sender.send(doc).await?;
     }
     Ok(())
+}
+
+#[derive(Serialize)]
+pub struct HttpClientDoc {
+    node: Option<NodeDocument>,
+    http: HttpClientContainer,
+    #[serde(flatten)]
+    metadata: MetadataRawValue,
+}
+
+#[derive(Serialize)]
+struct HttpClientContainer {
+    client: Value,
 }

--- a/src/processor/elasticsearch/nodes_stats/processor/ingest_pipelines.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/ingest_pipelines.rs
@@ -9,16 +9,15 @@ use super::super::super::{
     nodes_stats::{IngestPipelines, IngestProcessor, IngestProcessorStats, IngestProcessors},
 };
 use eyre::Result;
-use json_patch::merge;
 use rayon::prelude::*;
 use serde::Serialize;
-use serde_json::{Value, json};
+use serde_json::Value;
 use tokio::sync::mpsc::Sender;
 
 /// Extract ingest.pipelines
 pub async fn extract(
-    sender_pipelines: &Sender<Value>,
-    sender_processors: &Sender<Value>,
+    sender_pipelines: &Sender<IngestPipelineDoc>,
+    sender_processors: &Sender<IngestDoc>,
     mut pipelines: Option<IngestPipelines>,
     metadata: &ElasticsearchMetadata,
     node_metadata: Option<&NodeDocument>,
@@ -43,25 +42,15 @@ pub async fn extract(
                 log::error!("Error extracting ingest pipelines stats: {}", e);
             };
 
-            let mut doc = json!({
-                "node": node_metadata,
-                "ingest": {
-                    "pipeline": pipeline,
-                },
-            });
-
-            let pipeline = json!({
-                "ingest": {
-                    "pipeline": {
-                        "processors": null,
-                        "name": name,
-                    }
-                }
-            });
-
-            merge(&mut doc, &pipeline);
-            merge(&mut doc, &ingest_pipeline_metadata);
-            sender_pipelines.send(doc).await?;
+            sender_pipelines
+                .send(IngestPipelineDoc {
+                    node: node_metadata.cloned(),
+                    metadata: ingest_pipeline_metadata.clone(),
+                    ingest: IngestPipelineContainer {
+                        pipeline: NamedIngestPipeline { name, pipeline },
+                    },
+                })
+                .await?;
         }
     }
 
@@ -70,37 +59,34 @@ pub async fn extract(
 
 /// Extract ingest.processors
 async fn extract_ingest_processors(
-    sender: &Sender<Value>,
+    sender: &Sender<IngestDoc>,
     processors: Option<IngestProcessors>,
     pipeline_name: &str,
     metadata: MetadataRawValue,
     node_summary: Option<NodeDocument>,
 ) -> Result<()> {
-    let docs: Vec<Value> = match processors {
+    let docs: Vec<IngestDoc> = match processors {
         Some(mut processors) => processors
             .par_drain(..)
             .enumerate()
             .filter_map(|(index, mut processor)| {
-                let processor = processor
+                processor
                     .drain()
                     .next()
                     .map(|(name, processor)| {
-                        IngestProcessorStatsDoc::from(processor)
-                            .with_name(name)
-                            .with_order(index)
+                        IngestDoc {
+                            metadata: metadata.clone(),
+                            node: node_summary.clone(),
+                            ingest: IngestProcessorDoc {
+                                pipeline: IngestPipelineName {
+                                    name: pipeline_name.to_string(),
+                                },
+                                processor: IngestProcessorStatsDoc::from(processor)
+                                    .with_name(name)
+                                    .with_order(index),
+                            },
+                        }
                     })
-                    .unwrap();
-                serde_json::to_value(IngestDoc {
-                    metadata: metadata.clone(),
-                    node: node_summary.clone(),
-                    ingest: IngestProcessorDoc {
-                        pipeline: IngestPipelineName {
-                            name: pipeline_name.to_string(),
-                        },
-                        processor,
-                    },
-                })
-                .ok()
             })
             .collect(),
         None => Vec::new(),
@@ -113,7 +99,7 @@ async fn extract_ingest_processors(
 }
 
 #[derive(Serialize)]
-struct IngestDoc {
+pub struct IngestDoc {
     #[serde(flatten)]
     metadata: MetadataRawValue,
     node: Option<NodeDocument>,
@@ -165,4 +151,24 @@ impl From<IngestProcessor> for IngestProcessorStatsDoc {
 #[derive(Serialize)]
 struct IngestPipelineName {
     name: String,
+}
+
+#[derive(Serialize)]
+pub struct IngestPipelineDoc {
+    #[serde(flatten)]
+    metadata: Value,
+    node: Option<NodeDocument>,
+    ingest: IngestPipelineContainer,
+}
+
+#[derive(Serialize)]
+struct IngestPipelineContainer {
+    pipeline: NamedIngestPipeline,
+}
+
+#[derive(Serialize)]
+struct NamedIngestPipeline {
+    name: String,
+    #[serde(flatten)]
+    pipeline: super::super::super::nodes_stats::IngestPipeline,
 }

--- a/src/processor/elasticsearch/nodes_stats/processor/ingest_pipelines.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/ingest_pipelines.rs
@@ -11,7 +11,6 @@ use super::super::super::{
 use eyre::Result;
 use rayon::prelude::*;
 use serde::Serialize;
-use serde_json::Value;
 use tokio::sync::mpsc::Sender;
 
 /// Extract ingest.pipelines
@@ -23,8 +22,7 @@ pub async fn extract(
     node_metadata: Option<&NodeDocument>,
 ) -> Result<()> {
     let ingest_pipeline_metadata = metadata
-        .for_data_stream("metrics-ingest.pipeline-esdiag")
-        .as_meta_doc();
+        .for_data_stream("metrics-ingest.pipeline-esdiag");
 
     let ingest_processor_metadata = metadata.for_data_stream("metrics-ingest.processor-esdiag");
 
@@ -156,7 +154,7 @@ struct IngestPipelineName {
 #[derive(Serialize)]
 pub struct IngestPipelineDoc {
     #[serde(flatten)]
-    metadata: Value,
+    metadata: MetadataRawValue,
     node: Option<NodeDocument>,
     ingest: IngestPipelineContainer,
 }

--- a/src/processor/elasticsearch/nodes_stats/processor/transport_actions.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/transport_actions.rs
@@ -4,8 +4,8 @@
 
 use super::super::super::{metadata::MetadataRawValue, nodes::NodeDocument};
 use eyre::{OptionExt, Result};
-use serde::Serialize;
-use serde_json::Value;
+use serde::{Serialize, Serializer};
+use serde_json::{Value, value::RawValue};
 use tokio::sync::mpsc::Sender;
 
 /// Extract transport.actions
@@ -30,7 +30,10 @@ pub async fn extract(
                     transport: TransportActionContainer {
                         action: NamedAction {
                             name,
-                            data: action,
+                            data: FlattenRawValue(
+                                serde_json::value::to_raw_value(&action)
+                                    .expect("serialize transport action to raw"),
+                            ),
                         },
                     },
                 }
@@ -60,5 +63,18 @@ struct TransportActionContainer {
 struct NamedAction {
     name: String,
     #[serde(flatten)]
-    data: Value,
+    data: FlattenRawValue,
+}
+
+struct FlattenRawValue(Box<RawValue>);
+
+impl Serialize for FlattenRawValue {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let value: Value =
+            serde_json::from_str(self.0.get()).map_err(serde::ser::Error::custom)?;
+        value.serialize(serializer)
+    }
 }

--- a/src/processor/elasticsearch/nodes_stats/processor/transport_actions.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/transport_actions.rs
@@ -4,8 +4,8 @@
 
 use super::super::super::{metadata::MetadataRawValue, nodes::NodeDocument};
 use eyre::{OptionExt, Result};
-use serde::{Serialize, Serializer};
-use serde_json::{Value, value::RawValue};
+use serde::Serialize;
+use serde_json::Value;
 use tokio::sync::mpsc::Sender;
 
 /// Extract transport.actions
@@ -30,10 +30,7 @@ pub async fn extract(
                     transport: TransportActionContainer {
                         action: NamedAction {
                             name,
-                            data: FlattenRawValue(
-                                serde_json::value::to_raw_value(&action)
-                                    .expect("serialize transport action to raw"),
-                            ),
+                            data: action,
                         },
                     },
                 }
@@ -63,18 +60,5 @@ struct TransportActionContainer {
 struct NamedAction {
     name: String,
     #[serde(flatten)]
-    data: FlattenRawValue,
-}
-
-struct FlattenRawValue(Box<RawValue>);
-
-impl Serialize for FlattenRawValue {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let value: Value =
-            serde_json::from_str(self.0.get()).map_err(serde::ser::Error::custom)?;
-        value.serialize(serializer)
-    }
+    data: Value,
 }

--- a/src/processor/elasticsearch/nodes_stats/processor/transport_actions.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor/transport_actions.rs
@@ -2,48 +2,38 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::super::super::nodes::NodeDocument;
+use super::super::super::{metadata::MetadataRawValue, nodes::NodeDocument};
 use eyre::{OptionExt, Result};
-use json_patch::merge;
-use serde_json::{Value, json};
+use serde::Serialize;
+use serde_json::Value;
 use tokio::sync::mpsc::Sender;
 
 /// Extract transport.actions
 pub async fn extract(
-    sender: &Sender<Value>,
+    sender: &Sender<TransportActionDoc>,
     mut actions: Value,
-    metadata: &Value,
+    metadata: &MetadataRawValue,
     node_metadata: Option<&NodeDocument>,
 ) -> Result<()> {
     let actions = actions
         .as_object_mut()
         .ok_or_eyre("Error extracting node transport.actions data")?;
 
-    let mut docs = Vec::<Value>::with_capacity(100);
+    let mut docs = Vec::<TransportActionDoc>::with_capacity(100);
     docs.extend(
-        actions
+        std::mem::take(actions)
             .into_iter()
-            .collect::<Vec<_>>()
-            .drain(..)
             .map(|(name, action)| {
-                let mut action = json!({
-                    "node": node_metadata,
-                    "transport": {
-                        "action": action,
-                    },
-                });
-
-                let action_patch = json!({
-                    "transport": {
-                        "action": {
-                            "name": name,
+                TransportActionDoc {
+                    node: node_metadata.cloned(),
+                    metadata: metadata.clone(),
+                    transport: TransportActionContainer {
+                        action: NamedAction {
+                            name,
+                            data: action,
                         },
                     },
-                });
-
-                merge(&mut action, &action_patch);
-                merge(&mut action, metadata);
-                action
+                }
             }),
     );
 
@@ -51,4 +41,24 @@ pub async fn extract(
         sender.send(doc).await?;
     }
     Ok(())
+}
+
+#[derive(Serialize)]
+pub struct TransportActionDoc {
+    node: Option<NodeDocument>,
+    transport: TransportActionContainer,
+    #[serde(flatten)]
+    metadata: MetadataRawValue,
+}
+
+#[derive(Serialize)]
+struct TransportActionContainer {
+    action: NamedAction,
+}
+
+#[derive(Serialize)]
+struct NamedAction {
+    name: String,
+    #[serde(flatten)]
+    data: Value,
 }

--- a/src/processor/elasticsearch/snapshots/processor.rs
+++ b/src/processor/elasticsearch/snapshots/processor.rs
@@ -166,7 +166,6 @@ impl From<Snapshot> for SnapshotDocument {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::value::RawValue;
     use serde_json::json;
 
     #[test]

--- a/src/processor/elasticsearch/snapshots/processor.rs
+++ b/src/processor/elasticsearch/snapshots/processor.rs
@@ -191,6 +191,8 @@ mod tests {
         let value = serde_json::to_value(SnapshotLogDocument::from_snapshot(snapshot, json!({})))
             .expect("serialize snapshot doc");
         assert_eq!(value["snapshot"]["date"], "2026-03-01");
+        assert_eq!(value["snapshot"]["indices"][0], "logs-1");
+        assert_eq!(value["snapshot"]["data_streams"][0], "logs-app");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- refactor `nodes_stats` export paths to use typed channel payloads and remove `json_patch` merge-based document assembly in the node stats processor family
- replace passthrough payload fields with `Box<RawValue>` where document content is forwarded unmodified (`transport actions`, `http clients`, `cluster applier`, `adaptive selections`, and ingest pipeline metadata)
- remove additional `json_patch` usage from `elasticsearch/nodes` (cluster settings intentionally left unchanged)

## Test plan
- [x] `cargo build --release --bin esdiag`
- [x] benchmarked current changes vs previous commit on `/Users/reno/Accounts/test/many_snapshots/api-diagnostics-20260305-145719.zip` (5 runs each)
- [x] verified improved averages from benchmark run set:
  - runtime `-3.63%`
  - max RSS `-2.17%` (~`-51 MiB`)
  - peak memory `-2.84%` (~`-60 MiB`)


Made with [Cursor](https://cursor.com)