### PR TITLE
feat: add Logstash API collection support

### DIFF
--- a/assets/logstash/sources.yml
+++ b/assets/logstash/sources.yml
@@ -1,0 +1,44 @@
+# The new settings format:
+# At the top level the label descring the query that will also be used as the
+#   file name for its output.
+#   Below the query label are the following attributes:
+#     * extension - the file extension to be used for output. Optional, defaults to .json.
+#     * subdir - some api's are now grouped in a subdirectory of the output directory to lessen clutter. Optional, defaults to root dir.
+#     * retry - whether if a query fails it will be retried for the configured number of attempts. Optional, defaults to false.
+#     * versions - one or more attributes of the format "version rule: "query string". Each set of version/query key pairs
+#       should evaluate to exactly one that is appropriate for the version of the server being queried. Therefor rules should
+#       be structured in such a way that only a valid query can be executed against a given version. Required.
+#   NPM mode is the only one used: https://github.com/vdurmont/semver4j
+#   NPM Versioning rules are documented here: https://github.com/npm/node-semver
+#
+#   Note to those adding entries: within each group, cat API's, json API's, and commercial, they are in alphabetical order.
+#   Please adhere to this convention when submitting pull requests.
+
+logstash_health_report:
+  versions:
+    ">= 8.16.0": "/_health_report"
+
+logstash_node:
+  versions:
+    "> 5.0.0": "/_node"
+
+logstash_nodes_hot_threads:
+  versions:
+    "> 5.0.0": "/_node/hot_threads?threads=10000"
+
+logstash_nodes_hot_threads_human:
+  extension: .txt
+  versions:
+    "> 5.0.0": "/_node/hot_threads?human&threads=10000"
+
+logstash_node_stats:
+  versions:
+    "> 5.0.0": "/_node/stats"
+
+logstash_plugins:
+  versions:
+    "> 5.0.0": "/_node/plugins"
+
+logstash_version:
+  versions:
+    "> 5.0.0": "/"

--- a/openspec/changes/collect-logstash/.openspec.yaml
+++ b/openspec/changes/collect-logstash/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-09

--- a/openspec/changes/collect-logstash/design.md
+++ b/openspec/changes/collect-logstash/design.md
@@ -27,12 +27,12 @@ There is also a naming mismatch between existing typed Logstash data sources and
 - **Alternative considered**: Refactor immediately to a single generic collector for all products.
 - **Why not now**: That would enlarge the change substantially and couple Logstash parity to a broader collector architecture rewrite.
 
-### 2. Make the source registry product-scoped
+### 2. Make the source registry product-scoped and receiver-owned at runtime
 
-- **Decision**: Extend the global source registry to embed and expose both Elasticsearch and Logstash `sources.yml` files under separate product keys.
-- **Rationale**: `get_source(product, name, aliases)` already has the right lookup shape; the missing piece is loading Logstash definitions and allowing Logstash `DataSource` implementations to declare `product() -> "logstash"`.
-- **Alternative considered**: Keep a separate Logstash-only registry.
-- **Why not now**: A second registry would duplicate the configuration-loading and semver/path-resolution logic that already exists.
+- **Decision**: Extend the global source registry to embed and expose both Elasticsearch and Logstash `sources.yml` files under separate product keys, but resolve those product keys from the active receiver or collect command context rather than from `DataSource` types.
+- **Rationale**: Each `collect` or `process` execution operates on exactly one product, so the receiver already has the right boundary for selecting the correct source registry. Keeping `DataSource` product-agnostic avoids leaking transport or manifest context into every data model type.
+- **Alternative considered**: Keep product selection on `DataSource` implementations via a static method such as `product()`.
+- **Why not now**: That makes source lookup an intrinsic property of the data type even though the real runtime boundary is the receiver/command execution context, and it becomes awkward for fixed bundle files like `manifest.json`.
 
 ### 3. Normalize Logstash APIs to canonical source keys
 
@@ -48,14 +48,21 @@ There is also a naming mismatch between existing typed Logstash data sources and
 - **Alternative considered**: Add typed collection handlers for every Logstash source already represented by a `DataSource`.
 - **Why not now**: It provides little value over raw collection, and it increases duplicate-fetch risk for sources that only need to be stored.
 
-### 5. Preserve current lighter profiles until Logstash tags exist
+### 5. Use dedicated Logstash transport types
+
+- **Decision**: Add dedicated `LogstashClient` and `LogstashReceiver` implementations for Logstash known hosts instead of routing Logstash traffic through the Elasticsearch client and receiver.
+- **Rationale**: Logstash only needs a light reqwest-based HTTP wrapper like Kibana, and using dedicated transport types keeps product detection, root-response validation, and request semantics explicit at the client/receiver boundary.
+- **Alternative considered**: Continue treating Logstash as compatible with the Elasticsearch client and receiver stack.
+- **Why not now**: The Elasticsearch transport has product-specific assumptions that are not part of the Logstash contract, and sharing that path obscures bugs in future Logstash-specific behavior.
+
+### 6. Preserve current lighter profiles until Logstash tags exist
 
 - **Decision**: Keep `minimal` mapped to the node baseline, and keep `standard`/`light` mapped to the current bounded Logstash subset until `assets/logstash/sources.yml` grows tags or other metadata for lighter profiles.
 - **Rationale**: The user request is specifically about full support collection from `sources.yml`. The file currently defines full coverage, not differentiated light-profile metadata.
 - **Alternative considered**: Make `light` or `standard` dynamically include all Logstash sources immediately.
 - **Why not now**: That would silently change the performance profile of non-support runs without any source metadata justifying the change.
 
-### 6. Add ignored external-service compatibility coverage
+### 7. Add ignored external-service compatibility coverage
 
 - **Decision**: Add ignored integration tests that target externally managed Logstash `6.8.x`, `7.17.x`, `8.19.x`, and `9.x` instances.
 - **Rationale**: The main behavioral risk in this change is version-sensitive endpoint resolution from `assets/logstash/sources.yml`. Ignored tests let the repository encode the supported compatibility matrix without making CI depend on always-available external services.

--- a/openspec/changes/collect-logstash/design.md
+++ b/openspec/changes/collect-logstash/design.md
@@ -29,40 +29,47 @@ There is also a naming mismatch between existing typed Logstash data sources and
 
 ### 2. Make the source registry product-scoped and receiver-owned at runtime
 
-- **Decision**: Extend the global source registry to embed and expose both Elasticsearch and Logstash `sources.yml` files under separate product keys, but resolve those product keys from the active receiver or collect command context rather than from `DataSource` types.
-- **Rationale**: Each `collect` or `process` execution operates on exactly one product, so the receiver already has the right boundary for selecting the correct source registry. Keeping `DataSource` product-agnostic avoids leaking transport or manifest context into every data model type.
+- **Decision**: Extend the global source registry to embed and expose both Elasticsearch and Logstash `sources.yml` files under separate product keys, but resolve those product keys from the active receiver or collect command context rather than from `DataSource` types. Represent that runtime selection with a shared source context passed into `DataSource` path-resolution methods.
+- **Rationale**: Each `collect` or `process` execution operates on exactly one product, so the receiver already has the right boundary for selecting the correct source registry. Keeping `DataSource` product-agnostic avoids leaking transport or manifest context into every data model type while still giving call sites explicit source-path APIs.
 - **Alternative considered**: Keep product selection on `DataSource` implementations via a static method such as `product()`.
 - **Why not now**: That makes source lookup an intrinsic property of the data type even though the real runtime boundary is the receiver/command execution context, and it becomes awkward for fixed bundle files like `manifest.json`.
 
-### 3. Normalize Logstash APIs to canonical source keys
+### 3. Separate bundle metadata files from API data sources
+
+- **Decision**: Stop treating bundle metadata files such as `manifest.json` and `diagnostic_manifest.json` as `DataSource` implementations, and read them explicitly through receiver bundle-file helpers.
+- **Rationale**: Those files are archive/directory artifacts, not `sources.yml`-defined APIs. Removing them from `DataSource` keeps API path resolution limited to real source entries and removes special-case checks from archive/directory receivers.
+- **Alternative considered**: Keep manifest files inside `DataSource` with special-case filename handling.
+- **Why not now**: That mixes bundle metadata with API sources and weakens the boundary introduced by receiver-owned source resolution.
+
+### 4. Normalize Logstash APIs to canonical source keys
 
 - **Decision**: Resolve Logstash collections internally using the canonical `assets/logstash/sources.yml` keys (`logstash_node`, `logstash_node_stats`, etc.), while accepting existing short aliases (`node`, `node_stats`, `plugins`, `version`, `hot_threads`) for backward compatibility.
 - **Rationale**: The YAML keys must remain the source of truth for support collection and manifest reporting, but alias support prevents breaking existing include/exclude usage and avoids renaming every Logstash data source immediately.
 - **Alternative considered**: Rename all Logstash data sources and CLI-facing identifiers to canonical keys in one step.
 - **Why not now**: That would create unnecessary processor churn and increase migration risk.
 
-### 4. Split execution into typed and raw Logstash endpoints
+### 5. Split execution into typed and raw Logstash endpoints
 
 - **Decision**: Keep explicit typed handlers for `logstash_node` and `logstash_node_stats`, and collect the remaining Logstash sources as raw files resolved from YAML.
 - **Rationale**: These two endpoints already map directly to established Logstash processing logic, while `logstash_version`, `logstash_plugins`, and the hot-threads variants only need archive-compatible file output for parity. Raw collection avoids creating extra enums or save branches for every new source.
 - **Alternative considered**: Add typed collection handlers for every Logstash source already represented by a `DataSource`.
 - **Why not now**: It provides little value over raw collection, and it increases duplicate-fetch risk for sources that only need to be stored.
 
-### 5. Use dedicated Logstash transport types
+### 6. Use dedicated Logstash transport types
 
 - **Decision**: Add dedicated `LogstashClient` and `LogstashReceiver` implementations for Logstash known hosts instead of routing Logstash traffic through the Elasticsearch client and receiver.
 - **Rationale**: Logstash only needs a light reqwest-based HTTP wrapper like Kibana, and using dedicated transport types keeps product detection, root-response validation, and request semantics explicit at the client/receiver boundary.
 - **Alternative considered**: Continue treating Logstash as compatible with the Elasticsearch client and receiver stack.
 - **Why not now**: The Elasticsearch transport has product-specific assumptions that are not part of the Logstash contract, and sharing that path obscures bugs in future Logstash-specific behavior.
 
-### 6. Preserve current lighter profiles until Logstash tags exist
+### 7. Preserve current lighter profiles until Logstash tags exist
 
 - **Decision**: Keep `minimal` mapped to the node baseline, and keep `standard`/`light` mapped to the current bounded Logstash subset until `assets/logstash/sources.yml` grows tags or other metadata for lighter profiles.
 - **Rationale**: The user request is specifically about full support collection from `sources.yml`. The file currently defines full coverage, not differentiated light-profile metadata.
 - **Alternative considered**: Make `light` or `standard` dynamically include all Logstash sources immediately.
 - **Why not now**: That would silently change the performance profile of non-support runs without any source metadata justifying the change.
 
-### 7. Add ignored external-service compatibility coverage
+### 8. Add ignored external-service compatibility coverage
 
 - **Decision**: Add ignored integration tests that target externally managed Logstash `6.8.x`, `7.17.x`, `8.19.x`, and `9.x` instances.
 - **Rationale**: The main behavioral risk in this change is version-sensitive endpoint resolution from `assets/logstash/sources.yml`. Ignored tests let the repository encode the supported compatibility matrix without making CI depend on always-available external services.

--- a/openspec/changes/collect-logstash/design.md
+++ b/openspec/changes/collect-logstash/design.md
@@ -1,0 +1,80 @@
+## Context
+
+`esdiag collect` currently has a product-aware processing pipeline for Logstash, but its collection pipeline is still Elasticsearch-only. The shared source registry embeds `assets/elasticsearch/sources.yml` and the Logstash API resolver still hardcodes only `node` and `node_stats`, even though `assets/logstash/sources.yml` defines the full support surface (`logstash_health_report`, `logstash_node`, `logstash_nodes_hot_threads`, `logstash_nodes_hot_threads_human`, `logstash_node_stats`, `logstash_plugins`, `logstash_version`).
+
+There is also a naming mismatch between existing typed Logstash data sources and the YAML file: the code uses short identifiers such as `node`, `node_stats`, `plugins`, and `version`, while the YAML uses canonical `logstash_*` keys. The design needs to add full Logstash collection support without breaking existing processor-side parsing or forcing a broad rename across the codebase.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a Logstash collection path that can execute `minimal`, `standard`, `support`, and `light` diagnostic types.
+- Load Logstash source definitions from `assets/logstash/sources.yml` and use them for URL/file resolution, validation, and support-profile expansion.
+- Support canonical Logstash source keys while preserving compatibility with existing short identifiers used by typed data sources.
+- Collect typed Logstash APIs through dedicated handlers where they already exist, and use generic raw collection for the remaining Logstash endpoints.
+- Emit a diagnostic manifest for Logstash collections that records the resolved API list.
+
+**Non-Goals:**
+- Changing the Logstash processing/export behavior for already supported files after collection completes.
+- Reworking Elasticsearch collection into a fully generic multi-product collector in this change.
+- Defining new `tags` semantics for Logstash `light` collection before the source file actually carries those tags.
+
+## Decisions
+
+### 1. Add a dedicated `LogstashCollector`
+
+- **Decision**: Introduce a Logstash-specific collector and dispatch to it from the top-level collector factory instead of trying to fully genericize the existing Elasticsearch collector first.
+- **Rationale**: The current collector already mixes product-specific manifest bootstrap, API enums, and typed/raw save dispatch. A parallel Logstash collector is the lowest-risk path to ship parity quickly while still reusing the same retry, archive, and raw-fetch patterns.
+- **Alternative considered**: Refactor immediately to a single generic collector for all products.
+- **Why not now**: That would enlarge the change substantially and couple Logstash parity to a broader collector architecture rewrite.
+
+### 2. Make the source registry product-scoped
+
+- **Decision**: Extend the global source registry to embed and expose both Elasticsearch and Logstash `sources.yml` files under separate product keys.
+- **Rationale**: `get_source(product, name, aliases)` already has the right lookup shape; the missing piece is loading Logstash definitions and allowing Logstash `DataSource` implementations to declare `product() -> "logstash"`.
+- **Alternative considered**: Keep a separate Logstash-only registry.
+- **Why not now**: A second registry would duplicate the configuration-loading and semver/path-resolution logic that already exists.
+
+### 3. Normalize Logstash APIs to canonical source keys
+
+- **Decision**: Resolve Logstash collections internally using the canonical `assets/logstash/sources.yml` keys (`logstash_node`, `logstash_node_stats`, etc.), while accepting existing short aliases (`node`, `node_stats`, `plugins`, `version`, `hot_threads`) for backward compatibility.
+- **Rationale**: The YAML keys must remain the source of truth for support collection and manifest reporting, but alias support prevents breaking existing include/exclude usage and avoids renaming every Logstash data source immediately.
+- **Alternative considered**: Rename all Logstash data sources and CLI-facing identifiers to canonical keys in one step.
+- **Why not now**: That would create unnecessary processor churn and increase migration risk.
+
+### 4. Split execution into typed and raw Logstash endpoints
+
+- **Decision**: Keep explicit typed handlers for `logstash_node` and `logstash_node_stats`, and collect the remaining Logstash sources as raw files resolved from YAML.
+- **Rationale**: These two endpoints already map directly to established Logstash processing logic, while `logstash_version`, `logstash_plugins`, and the hot-threads variants only need archive-compatible file output for parity. Raw collection avoids creating extra enums or save branches for every new source.
+- **Alternative considered**: Add typed collection handlers for every Logstash source already represented by a `DataSource`.
+- **Why not now**: It provides little value over raw collection, and it increases duplicate-fetch risk for sources that only need to be stored.
+
+### 5. Preserve current lighter profiles until Logstash tags exist
+
+- **Decision**: Keep `minimal` mapped to the node baseline, and keep `standard`/`light` mapped to the current bounded Logstash subset until `assets/logstash/sources.yml` grows tags or other metadata for lighter profiles.
+- **Rationale**: The user request is specifically about full support collection from `sources.yml`. The file currently defines full coverage, not differentiated light-profile metadata.
+- **Alternative considered**: Make `light` or `standard` dynamically include all Logstash sources immediately.
+- **Why not now**: That would silently change the performance profile of non-support runs without any source metadata justifying the change.
+
+### 6. Add ignored external-service compatibility coverage
+
+- **Decision**: Add ignored integration tests that target externally managed Logstash `6.8.x`, `7.17.x`, `8.19.x`, and `9.x` instances.
+- **Rationale**: The main behavioral risk in this change is version-sensitive endpoint resolution from `assets/logstash/sources.yml`. Ignored tests let the repository encode the supported compatibility matrix without making CI depend on always-available external services.
+- **Alternative considered**: Limit verification to unit tests around semver resolution and local mocks.
+- **Why not now**: Unit tests are necessary but do not prove that real Logstash versions expose the expected endpoints or response shapes across the full target matrix.
+
+## Risks / Trade-offs
+
+- **[Risk] Alias normalization creates duplicate planning paths** → **Mitigation**: Normalize requested Logstash identifiers to canonical source keys before deduplication, dependency resolution, and manifest generation.
+- **[Risk] Product dispatch remains partially duplicated between Elasticsearch and Logstash** → **Mitigation**: Reuse the same raw-save, retry, and manifest patterns so a future generic refactor can collapse the two collectors cleanly.
+- **[Risk] Logstash `light` remains only partially source-driven** → **Mitigation**: Scope this change to support parity now and document that lighter profiles can become tag-driven once the Logstash source file adds the required metadata.
+- **[Risk] Some Logstash endpoints may not be available on older versions** → **Mitigation**: Continue using semver-based source resolution and skip unsupported endpoints the same way Elasticsearch raw collection already does.
+- **[Risk] External compatibility tests may be unavailable in normal CI** → **Mitigation**: Mark them ignored, document the required service configuration, and keep core logic covered by unit tests.
+
+## Migration Plan
+
+- No user-facing migration is required for existing short Logstash include/exclude identifiers.
+- New support collections will record canonical Logstash source keys in the manifest and save additional files defined by `assets/logstash/sources.yml`.
+
+## Open Questions
+
+- Whether `logstash_plugins` and `logstash_version` should remain raw-only during collection long-term, or later gain explicit typed save branches for symmetry with processing.

--- a/openspec/changes/collect-logstash/proposal.md
+++ b/openspec/changes/collect-logstash/proposal.md
@@ -5,9 +5,11 @@ PR260 brought full support-diagnostic API collection to Elasticsearch by treatin
 ## What Changes
 
 - Load `assets/logstash/sources.yml` into the shared source configuration so Logstash endpoints can be resolved dynamically by version, file path, and output extension.
+- Move `sources.yml` product selection into the active receiver or collect command context so each execution resolves files and URLs from exactly one product registry.
 - Expand Logstash API selection so `support` includes every top-level Logstash source, while `light` and `standard` continue to resolve a bounded subset appropriate for lighter-weight runs.
 - Add generic raw Logstash collection for endpoints that do not have typed processors, including `logstash_health_report`, `logstash_nodes_hot_threads`, `logstash_nodes_hot_threads_human`, `logstash_plugins`, and `logstash_version`.
 - Preserve existing typed Logstash processing for `logstash_node` and `logstash_node_stats`, avoiding duplicate fetches when a typed processor already covers a selected source.
+- Add dedicated Logstash client and receiver implementations instead of routing Logstash traffic through the Elasticsearch transport.
 - Record the resolved Logstash API list in the diagnostic manifest and keep include/exclude validation aligned with the keys defined in `assets/logstash/sources.yml`.
 
 ## Capabilities
@@ -22,6 +24,6 @@ PR260 brought full support-diagnostic API collection to Elasticsearch by treatin
 
 ## Impact
 
-- **Core processing logic**: Affects `src/processor/api.rs`, Logstash diagnostic orchestration, and generic receiver/export flow for raw endpoints.
+- **Core processing logic**: Affects `src/processor/api.rs`, Logstash diagnostic orchestration, client/receiver dispatch, and generic receiver/export flow for raw endpoints.
 - **Assets/configuration**: Introduces first-class use of `assets/logstash/sources.yml` at runtime.
 - **Diagnostic output**: Support collections will contain additional Logstash `.json` and `.txt` outputs, increasing parity with legacy support diagnostics.

--- a/openspec/changes/collect-logstash/proposal.md
+++ b/openspec/changes/collect-logstash/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+PR260 brought full support-diagnostic API collection to Elasticsearch by treating `sources.yml` as the source of truth for what a support run should fetch. Logstash collection still only resolves a small hardcoded subset, so `esdiag collect logstash --type support` does not yet match the legacy diagnostic output described by `assets/logstash/sources.yml`.
+
+## What Changes
+
+- Load `assets/logstash/sources.yml` into the shared source configuration so Logstash endpoints can be resolved dynamically by version, file path, and output extension.
+- Expand Logstash API selection so `support` includes every top-level Logstash source, while `light` and `standard` continue to resolve a bounded subset appropriate for lighter-weight runs.
+- Add generic raw Logstash collection for endpoints that do not have typed processors, including `logstash_health_report`, `logstash_nodes_hot_threads`, `logstash_nodes_hot_threads_human`, `logstash_plugins`, and `logstash_version`.
+- Preserve existing typed Logstash processing for `logstash_node` and `logstash_node_stats`, avoiding duplicate fetches when a typed processor already covers a selected source.
+- Record the resolved Logstash API list in the diagnostic manifest and keep include/exclude validation aligned with the keys defined in `assets/logstash/sources.yml`.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `api-selection`: Update Logstash diagnostic type resolution and include/exclude validation to use the Logstash `sources.yml` keys instead of a hardcoded enum subset.
+- `support-diagnostics-parity`: Extend full support-diagnostic parity to Logstash by fetching and storing all selected Logstash endpoints, using raw collection where no typed processor exists.
+- `version-dependent-sources`: Extend dynamic source loading and path/URL resolution to support product-specific Logstash source definitions in addition to Elasticsearch.
+
+## Impact
+
+- **Core processing logic**: Affects `src/processor/api.rs`, Logstash diagnostic orchestration, and generic receiver/export flow for raw endpoints.
+- **Assets/configuration**: Introduces first-class use of `assets/logstash/sources.yml` at runtime.
+- **Diagnostic output**: Support collections will contain additional Logstash `.json` and `.txt` outputs, increasing parity with legacy support diagnostics.

--- a/openspec/changes/collect-logstash/proposal.md
+++ b/openspec/changes/collect-logstash/proposal.md
@@ -5,11 +5,12 @@ PR260 brought full support-diagnostic API collection to Elasticsearch by treatin
 ## What Changes
 
 - Load `assets/logstash/sources.yml` into the shared source configuration so Logstash endpoints can be resolved dynamically by version, file path, and output extension.
-- Move `sources.yml` product selection into the active receiver or collect command context so each execution resolves files and URLs from exactly one product registry.
+- Move `sources.yml` product selection into the active receiver or collect command context so each execution resolves files and URLs from exactly one product registry via a shared source context.
 - Expand Logstash API selection so `support` includes every top-level Logstash source, while `light` and `standard` continue to resolve a bounded subset appropriate for lighter-weight runs.
 - Add generic raw Logstash collection for endpoints that do not have typed processors, including `logstash_health_report`, `logstash_nodes_hot_threads`, `logstash_nodes_hot_threads_human`, `logstash_plugins`, and `logstash_version`.
 - Preserve existing typed Logstash processing for `logstash_node` and `logstash_node_stats`, avoiding duplicate fetches when a typed processor already covers a selected source.
 - Add dedicated Logstash client and receiver implementations instead of routing Logstash traffic through the Elasticsearch transport.
+- Split bundle metadata files like `manifest.json` and `diagnostic_manifest.json` away from `DataSource` so only `sources.yml`-backed APIs participate in source resolution.
 - Record the resolved Logstash API list in the diagnostic manifest and keep include/exclude validation aligned with the keys defined in `assets/logstash/sources.yml`.
 
 ## Capabilities
@@ -24,6 +25,6 @@ PR260 brought full support-diagnostic API collection to Elasticsearch by treatin
 
 ## Impact
 
-- **Core processing logic**: Affects `src/processor/api.rs`, Logstash diagnostic orchestration, client/receiver dispatch, and generic receiver/export flow for raw endpoints.
+- **Core processing logic**: Affects `src/processor/api.rs`, Logstash diagnostic orchestration, client/receiver dispatch, generic receiver/export flow for raw endpoints, and explicit bundle-file manifest loading.
 - **Assets/configuration**: Introduces first-class use of `assets/logstash/sources.yml` at runtime.
 - **Diagnostic output**: Support collections will contain additional Logstash `.json` and `.txt` outputs, increasing parity with legacy support diagnostics.

--- a/openspec/changes/collect-logstash/specs/api-selection/spec.md
+++ b/openspec/changes/collect-logstash/specs/api-selection/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Logstash Support Diagnostic Type Expansion
+The system SHALL resolve the Logstash `support` diagnostic type from the top-level keys defined in `assets/logstash/sources.yml` instead of a hardcoded API subset.
+
+#### Scenario: Support type includes every configured Logstash source
+- **GIVEN** `assets/logstash/sources.yml` defines the canonical Logstash sources
+- **WHEN** the user runs `esdiag collect logstash --type support`
+- **THEN** the resolver includes every top-level Logstash source key in the requested collection set before dependency resolution and exclusions are applied
+
+### Requirement: Logstash Lighter Profile Stability
+The system SHALL preserve bounded Logstash `minimal`, `standard`, and `light` profiles until `assets/logstash/sources.yml` provides metadata that defines lighter-weight subsets.
+
+#### Scenario: Minimal Logstash collection stays narrow
+- **GIVEN** the user runs `esdiag collect logstash --type minimal`
+- **WHEN** the resolver builds the Logstash API plan
+- **THEN** it includes only the required baseline Logstash node source and any required dependencies
+
+#### Scenario: Standard and light keep the current bounded subset
+- **GIVEN** the user runs `esdiag collect logstash --type standard` or `esdiag collect logstash --type light`
+- **WHEN** the resolver builds the Logstash API plan
+- **THEN** it includes the existing bounded Logstash subset rather than expanding to every key in `assets/logstash/sources.yml`
+
+### Requirement: Logstash Identifier Normalization
+The system SHALL accept both canonical Logstash `sources.yml` keys and legacy short Logstash identifiers for include/exclude handling, and it SHALL normalize the final execution plan to canonical source keys.
+
+#### Scenario: User includes a legacy short Logstash identifier
+- **GIVEN** the existing short identifier `node_stats` maps to the canonical source key `logstash_node_stats`
+- **WHEN** the user runs `esdiag collect logstash --include node_stats`
+- **THEN** the resolver accepts the request
+- **AND** the final execution plan records `logstash_node_stats` as the collected API identifier
+
+#### Scenario: User includes a canonical Logstash source key
+- **GIVEN** `logstash_nodes_hot_threads_human` is defined in `assets/logstash/sources.yml`
+- **WHEN** the user runs `esdiag collect logstash --include logstash_nodes_hot_threads_human`
+- **THEN** the resolver accepts the request and includes that source in the final execution plan

--- a/openspec/changes/collect-logstash/specs/support-diagnostics-parity/spec.md
+++ b/openspec/changes/collect-logstash/specs/support-diagnostics-parity/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Full Logstash Support Collection
+The system SHALL collect every selected Logstash endpoint defined in `assets/logstash/sources.yml` during a Logstash support diagnostic run.
+
+#### Scenario: Support run expands to all Logstash source entries
+- **GIVEN** the user runs `esdiag collect logstash --type support`
+- **WHEN** the collection plan is built from `assets/logstash/sources.yml`
+- **THEN** the collector schedules every selected Logstash source for download
+- **AND** the resulting archive contains one output file per successfully collected Logstash source
+
+### Requirement: Typed Logstash Endpoint Reuse
+The system SHALL use dedicated typed collection handlers for Logstash sources that already have explicit implementations, and it SHALL avoid scheduling an additional raw fetch for the same canonical source.
+
+#### Scenario: Node sources are collected through typed handlers
+- **GIVEN** the canonical Logstash sources `logstash_node` and `logstash_node_stats` are selected for collection
+- **WHEN** the collector partitions the execution plan
+- **THEN** it routes those sources through their typed Logstash save handlers
+- **AND** it does not enqueue a duplicate raw fetch for either source
+
+### Requirement: Raw Logstash Endpoint Collection
+The system SHALL fetch and store selected Logstash endpoints without typed handlers as raw files using the URL, file path, and extension defined in `assets/logstash/sources.yml`.
+
+#### Scenario: Human hot threads output preserves text extension
+- **GIVEN** `logstash_nodes_hot_threads_human` is selected for collection
+- **WHEN** the collector resolves that source from `assets/logstash/sources.yml`
+- **THEN** it fetches the configured request path for the target version
+- **AND** it stores the response as `logstash_nodes_hot_threads_human.txt`
+
+### Requirement: Cross-Version Logstash Compatibility Validation
+The system SHALL include ignored integration tests that exercise Logstash collection against externally managed Logstash instances for the supported compatibility matrix.
+
+#### Scenario: Validate Logstash 6.8 support collection
+- **GIVEN** an externally reachable Logstash `6.8.x` test instance is available
+- **WHEN** the ignored compatibility test suite is run
+- **THEN** it verifies that Logstash collection completes successfully for that instance
+
+#### Scenario: Validate Logstash 7.17 support collection
+- **GIVEN** an externally reachable Logstash `7.17.x` test instance is available
+- **WHEN** the ignored compatibility test suite is run
+- **THEN** it verifies that Logstash collection completes successfully for that instance
+
+#### Scenario: Validate Logstash 8.19 support collection
+- **GIVEN** an externally reachable Logstash `8.19.x` test instance is available
+- **WHEN** the ignored compatibility test suite is run
+- **THEN** it verifies that Logstash collection completes successfully for that instance
+
+#### Scenario: Validate Logstash 9.x support collection
+- **GIVEN** an externally reachable Logstash `9.x` test instance is available
+- **WHEN** the ignored compatibility test suite is run
+- **THEN** it verifies that Logstash collection completes successfully for that instance

--- a/openspec/changes/collect-logstash/specs/support-diagnostics-parity/spec.md
+++ b/openspec/changes/collect-logstash/specs/support-diagnostics-parity/spec.md
@@ -27,6 +27,15 @@ The system SHALL fetch and store selected Logstash endpoints without typed handl
 - **THEN** it fetches the configured request path for the target version
 - **AND** it stores the response as `logstash_nodes_hot_threads_human.txt`
 
+### Requirement: Dedicated Logstash Transport Path
+The system SHALL use Logstash-specific client and receiver implementations for Logstash known-host collection instead of routing Logstash traffic through the Elasticsearch transport stack.
+
+#### Scenario: Logstash known host creates Logstash transport types
+- **GIVEN** a configured known host whose product is `logstash`
+- **WHEN** the user runs `esdiag collect` or validates that host connection
+- **THEN** the system constructs Logstash-specific client and receiver implementations
+- **AND** Logstash root-response validation is performed against the Logstash response shape rather than the Elasticsearch response shape
+
 ### Requirement: Cross-Version Logstash Compatibility Validation
 The system SHALL include ignored integration tests that exercise Logstash collection against externally managed Logstash instances for the supported compatibility matrix.
 

--- a/openspec/changes/collect-logstash/specs/version-dependent-sources/spec.md
+++ b/openspec/changes/collect-logstash/specs/version-dependent-sources/spec.md
@@ -17,6 +17,23 @@ The system SHALL choose the active `sources.yml` product from the current collec
 - **THEN** the receiver selects the Logstash source registry for subsequent file-path and URL resolution
 - **AND** Logstash `DataSource` implementations do not need to declare the product statically
 
+### Requirement: SourceContext-Backed API Resolution
+The system SHALL resolve `sources.yml`-backed API request paths, file paths, and output extensions through `DataSource` methods that consume a receiver-provided source context.
+
+#### Scenario: API source path resolution uses receiver metadata
+- **GIVEN** a receiver has identified the active sources product and target version for the current execution
+- **WHEN** an API-backed `DataSource` resolves its request path or file path
+- **THEN** it uses the receiver-provided source context rather than ad hoc product or version lookup at the call site
+
+### Requirement: Bundle Metadata Files Are Not API Data Sources
+The system SHALL treat bundle metadata files like `manifest.json` and `diagnostic_manifest.json` as explicit bundle-file reads rather than as `sources.yml`-defined `DataSource` entries.
+
+#### Scenario: Processing reads bundle manifests without source lookup
+- **GIVEN** a directory or archive receiver is identifying a diagnostic bundle
+- **WHEN** it loads `diagnostic_manifest.json` or falls back to `manifest.json`
+- **THEN** it reads those files directly by filename
+- **AND** no `sources.yml` lookup is required for bundle manifest loading
+
 ### Requirement: Logstash Source URL Resolution
 The system SHALL resolve Logstash API request paths dynamically from `assets/logstash/sources.yml` using the target Logstash version.
 

--- a/openspec/changes/collect-logstash/specs/version-dependent-sources/spec.md
+++ b/openspec/changes/collect-logstash/specs/version-dependent-sources/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Product-Scoped Sources Registry
+The system SHALL load and expose source definitions separately for each supported product, including `assets/logstash/sources.yml` for Logstash.
+
+#### Scenario: Logstash source definitions are available by product key
+- **GIVEN** the application initializes its embedded source configuration
+- **WHEN** a Logstash data source lookup is requested
+- **THEN** the system resolves the lookup against the Logstash source registry rather than the Elasticsearch source registry
+
+### Requirement: Logstash Source URL Resolution
+The system SHALL resolve Logstash API request paths dynamically from `assets/logstash/sources.yml` using the target Logstash version.
+
+#### Scenario: Matching a Logstash version rule
+- **GIVEN** the source key `logstash_health_report` is defined in `assets/logstash/sources.yml` with a semver rule for `>= 8.16.0`
+- **WHEN** the target Logstash version is `8.16.0` or newer
+- **THEN** the system resolves the request path `/_health_report` for that source
+
+### Requirement: Alias-Backed Logstash File Resolution
+The system SHALL allow Logstash data sources with legacy short internal names to resolve file paths through canonical `logstash_*` source keys.
+
+#### Scenario: Short Logstash data source name resolves through canonical alias
+- **GIVEN** a Logstash data source uses the internal name `node` and the canonical source key `logstash_node`
+- **WHEN** the system resolves the file path for that data source
+- **THEN** it returns the file path defined by the `logstash_node` source configuration
+- **AND** the resulting output filename is `logstash_node.json`

--- a/openspec/changes/collect-logstash/specs/version-dependent-sources/spec.md
+++ b/openspec/changes/collect-logstash/specs/version-dependent-sources/spec.md
@@ -8,6 +8,15 @@ The system SHALL load and expose source definitions separately for each supporte
 - **WHEN** a Logstash data source lookup is requested
 - **THEN** the system resolves the lookup against the Logstash source registry rather than the Elasticsearch source registry
 
+### Requirement: Receiver-Owned Source Product Resolution
+The system SHALL choose the active `sources.yml` product from the current collect/process execution context rather than from a static property on each `DataSource`.
+
+#### Scenario: Processing a Logstash bundle initializes Logstash file resolution once
+- **GIVEN** a diagnostic bundle contains a manifest whose product is `logstash`
+- **WHEN** `esdiag process` initializes the receiver for that bundle
+- **THEN** the receiver selects the Logstash source registry for subsequent file-path and URL resolution
+- **AND** Logstash `DataSource` implementations do not need to declare the product statically
+
 ### Requirement: Logstash Source URL Resolution
 The system SHALL resolve Logstash API request paths dynamically from `assets/logstash/sources.yml` using the target Logstash version.
 

--- a/openspec/changes/collect-logstash/tasks.md
+++ b/openspec/changes/collect-logstash/tasks.md
@@ -5,6 +5,8 @@
 - [x] 1.3 Update `src/processor/api.rs` so Logstash include/exclude validation accepts canonical source keys and legacy short identifiers, then normalizes the execution plan to canonical keys
 - [x] 1.4 Add unit tests covering Logstash source loading, version/path resolution, and canonical alias normalization
 - [x] 1.5 Move source file and URL resolution into the active receiver or command product context so each execution uses a single product registry
+- [x] 1.6 Add a shared source context and explicit `DataSource` source-path resolution methods for API-backed entries
+- [x] 1.7 Split bundle metadata files out of `DataSource` and load them through explicit receiver bundle-file reads
 
 ## 2. Logstash Collection Pipeline
 

--- a/openspec/changes/collect-logstash/tasks.md
+++ b/openspec/changes/collect-logstash/tasks.md
@@ -1,0 +1,23 @@
+## 1. Source Registry And Identifier Normalization
+
+- [x] 1.1 Extend `src/processor/diagnostic/data_source.rs` to embed and expose `assets/logstash/sources.yml` under a Logstash product key
+- [x] 1.2 Update Logstash `DataSource` implementations to resolve through the Logstash product registry and declare canonical `logstash_*` aliases where needed
+- [x] 1.3 Update `src/processor/api.rs` so Logstash include/exclude validation accepts canonical source keys and legacy short identifiers, then normalizes the execution plan to canonical keys
+- [x] 1.4 Add unit tests covering Logstash source loading, version/path resolution, and canonical alias normalization
+
+## 2. Logstash Collection Pipeline
+
+- [x] 2.1 Extend `src/processor/collector.rs` to dispatch `collect` for `Product::Logstash` instead of rejecting non-Elasticsearch products
+- [x] 2.2 Implement a Logstash collector module that mirrors the existing retry, manifest, and archive-save flow used by the Elasticsearch collector
+- [x] 2.3 Add typed save handling for `logstash_node` and `logstash_node_stats`, and raw save handling for the remaining Logstash `sources.yml` entries
+- [x] 2.4 Ensure Logstash support collections expand from all `assets/logstash/sources.yml` keys while `minimal`, `standard`, and `light` preserve their bounded subsets
+- [x] 2.5 Record the canonical collected Logstash API list and detected Logstash version in the diagnostic manifest
+
+## 3. Verification
+
+- [x] 3.1 Add coverage for Logstash support-profile expansion and duplicate-free alias normalization in collector or resolver tests
+- [x] 3.2 Add coverage that `logstash_nodes_hot_threads_human` resolves and saves with the `.txt` extension
+- [x] 3.3 Add ignored integration tests for externally managed Logstash `6.8.x`, `7.17.x`, `8.19.x`, and `9.x` instances
+- [x] 3.4 Document the external-service assumptions or configuration needed to run the ignored Logstash compatibility tests
+- [x] 3.5 Run `cargo clippy`
+- [x] 3.6 Run `cargo test`

--- a/openspec/changes/collect-logstash/tasks.md
+++ b/openspec/changes/collect-logstash/tasks.md
@@ -1,9 +1,10 @@
 ## 1. Source Registry And Identifier Normalization
 
 - [x] 1.1 Extend `src/processor/diagnostic/data_source.rs` to embed and expose `assets/logstash/sources.yml` under a Logstash product key
-- [x] 1.2 Update Logstash `DataSource` implementations to resolve through the Logstash product registry and declare canonical `logstash_*` aliases where needed
+- [x] 1.2 Keep Logstash `DataSource` implementations product-agnostic while declaring canonical `logstash_*` aliases where needed
 - [x] 1.3 Update `src/processor/api.rs` so Logstash include/exclude validation accepts canonical source keys and legacy short identifiers, then normalizes the execution plan to canonical keys
 - [x] 1.4 Add unit tests covering Logstash source loading, version/path resolution, and canonical alias normalization
+- [x] 1.5 Move source file and URL resolution into the active receiver or command product context so each execution uses a single product registry
 
 ## 2. Logstash Collection Pipeline
 
@@ -12,6 +13,7 @@
 - [x] 2.3 Add typed save handling for `logstash_node` and `logstash_node_stats`, and raw save handling for the remaining Logstash `sources.yml` entries
 - [x] 2.4 Ensure Logstash support collections expand from all `assets/logstash/sources.yml` keys while `minimal`, `standard`, and `light` preserve their bounded subsets
 - [x] 2.5 Record the canonical collected Logstash API list and detected Logstash version in the diagnostic manifest
+- [x] 2.6 Add dedicated Logstash client and receiver implementations for known-host collection instead of reusing Elasticsearch transport types
 
 ## 3. Verification
 

--- a/openspec/specs/api-selection/spec.md
+++ b/openspec/specs/api-selection/spec.md
@@ -97,3 +97,38 @@ The system SHALL validate requested `--include` and `--exclude` flags against th
 - **GIVEN** a user executes `esdiag collect --include not_a_real_api` where the string does not exist as a key in `sources.yml`
 - **WHEN** the `ApiResolver` evaluates the inclusion list
 - **THEN** it rejects the API name and throws a validation error aborting the process before execution begins
+
+### Requirement: Logstash Support Diagnostic Type Expansion
+The system SHALL resolve the Logstash `support` diagnostic type from the top-level keys defined in `assets/logstash/sources.yml` instead of a hardcoded API subset.
+
+#### Scenario: Support type includes every configured Logstash source
+- **GIVEN** `assets/logstash/sources.yml` defines the canonical Logstash sources
+- **WHEN** the user runs `esdiag collect logstash --type support`
+- **THEN** the resolver includes every top-level Logstash source key in the requested collection set before dependency resolution and exclusions are applied
+
+### Requirement: Logstash Lighter Profile Stability
+The system SHALL preserve bounded Logstash `minimal`, `standard`, and `light` profiles until `assets/logstash/sources.yml` provides metadata that defines lighter-weight subsets.
+
+#### Scenario: Minimal Logstash collection stays narrow
+- **GIVEN** the user runs `esdiag collect logstash --type minimal`
+- **WHEN** the resolver builds the Logstash API plan
+- **THEN** it includes only the required baseline Logstash node source and any required dependencies
+
+#### Scenario: Standard and light keep the current bounded subset
+- **GIVEN** the user runs `esdiag collect logstash --type standard` or `esdiag collect logstash --type light`
+- **WHEN** the resolver builds the Logstash API plan
+- **THEN** it includes the existing bounded Logstash subset rather than expanding to every key in `assets/logstash/sources.yml`
+
+### Requirement: Logstash Identifier Normalization
+The system SHALL accept both canonical Logstash `sources.yml` keys and legacy short Logstash identifiers for include/exclude handling, and it SHALL normalize the final execution plan to canonical source keys.
+
+#### Scenario: User includes a legacy short Logstash identifier
+- **GIVEN** the existing short identifier `node_stats` maps to the canonical source key `logstash_node_stats`
+- **WHEN** the user runs `esdiag collect logstash --include node_stats`
+- **THEN** the resolver accepts the request
+- **AND** the final execution plan records `logstash_node_stats` as the collected API identifier
+
+#### Scenario: User includes a canonical Logstash source key
+- **GIVEN** `logstash_nodes_hot_threads_human` is defined in `assets/logstash/sources.yml`
+- **WHEN** the user runs `esdiag collect logstash --include logstash_nodes_hot_threads_human`
+- **THEN** the resolver accepts the request and includes that source in the final execution plan

--- a/openspec/specs/support-diagnostics-parity/spec.md
+++ b/openspec/specs/support-diagnostics-parity/spec.md
@@ -20,3 +20,62 @@ The system SHALL execute the collection of all generic raw API endpoints concurr
 - **GIVEN** a `sources.yml` file defining 80+ endpoints that lack strong type implementations
 - **WHEN** the `ElasticsearchDiagnostic::process` method executes
 - **THEN** all raw endpoints are fetched in parallel (e.g. using `tokio::spawn` or concurrent streams) alongside the core typed APIs, and their execution time does not block the core data processing tasks.
+
+### Requirement: Full Logstash Support Collection
+The system SHALL collect every selected Logstash endpoint defined in `assets/logstash/sources.yml` during a Logstash support diagnostic run.
+
+#### Scenario: Support run expands to all Logstash source entries
+- **GIVEN** the user runs `esdiag collect logstash --type support`
+- **WHEN** the collection plan is built from `assets/logstash/sources.yml`
+- **THEN** the collector schedules every selected Logstash source for download
+- **AND** the resulting archive contains one output file per successfully collected Logstash source
+
+### Requirement: Typed Logstash Endpoint Reuse
+The system SHALL use dedicated typed collection handlers for Logstash sources that already have explicit implementations, and it SHALL avoid scheduling an additional raw fetch for the same canonical source.
+
+#### Scenario: Node sources are collected through typed handlers
+- **GIVEN** the canonical Logstash sources `logstash_node` and `logstash_node_stats` are selected for collection
+- **WHEN** the collector partitions the execution plan
+- **THEN** it routes those sources through their typed Logstash save handlers
+- **AND** it does not enqueue a duplicate raw fetch for either source
+
+### Requirement: Raw Logstash Endpoint Collection
+The system SHALL fetch and store selected Logstash endpoints without typed handlers as raw files using the URL, file path, and extension defined in `assets/logstash/sources.yml`.
+
+#### Scenario: Human hot threads output preserves text extension
+- **GIVEN** `logstash_nodes_hot_threads_human` is selected for collection
+- **WHEN** the collector resolves that source from `assets/logstash/sources.yml`
+- **THEN** it fetches the configured request path for the target version
+- **AND** it stores the response as `logstash_nodes_hot_threads_human.txt`
+
+### Requirement: Dedicated Logstash Transport Path
+The system SHALL use Logstash-specific client and receiver implementations for Logstash known-host collection instead of routing Logstash traffic through the Elasticsearch transport stack.
+
+#### Scenario: Logstash known host creates Logstash transport types
+- **GIVEN** a configured known host whose product is `logstash`
+- **WHEN** the user runs `esdiag collect` or validates that host connection
+- **THEN** the system constructs Logstash-specific client and receiver implementations
+- **AND** Logstash root-response validation is performed against the Logstash response shape rather than the Elasticsearch response shape
+
+### Requirement: Cross-Version Logstash Compatibility Validation
+The system SHALL include ignored integration tests that exercise Logstash collection against externally managed Logstash instances for the supported compatibility matrix.
+
+#### Scenario: Validate Logstash 6.8 support collection
+- **GIVEN** an externally reachable Logstash `6.8.x` test instance is available
+- **WHEN** the ignored compatibility test suite is run
+- **THEN** it verifies that Logstash collection completes successfully for that instance
+
+#### Scenario: Validate Logstash 7.17 support collection
+- **GIVEN** an externally reachable Logstash `7.17.x` test instance is available
+- **WHEN** the ignored compatibility test suite is run
+- **THEN** it verifies that Logstash collection completes successfully for that instance
+
+#### Scenario: Validate Logstash 8.19 support collection
+- **GIVEN** an externally reachable Logstash `8.19.x` test instance is available
+- **WHEN** the ignored compatibility test suite is run
+- **THEN** it verifies that Logstash collection completes successfully for that instance
+
+#### Scenario: Validate Logstash 9.x support collection
+- **GIVEN** an externally reachable Logstash `9.x` test instance is available
+- **WHEN** the ignored compatibility test suite is run
+- **THEN** it verifies that Logstash collection completes successfully for that instance

--- a/openspec/specs/version-dependent-sources/spec.md
+++ b/openspec/specs/version-dependent-sources/spec.md
@@ -38,3 +38,54 @@ The system SHALL load the `sources.yml` file into memory once during initializat
 - **GIVEN** the cached `sources.yml` configuration
 - **WHEN** the system is requested to resolve a data source name that does not exist in the YAML file
 - **THEN** the system returns an error indicating the data source configuration is missing
+
+### Requirement: Product-Scoped Sources Registry
+The system SHALL load and expose source definitions separately for each supported product, including `assets/logstash/sources.yml` for Logstash.
+
+#### Scenario: Logstash source definitions are available by product key
+- **GIVEN** the application initializes its embedded source configuration
+- **WHEN** a Logstash data source lookup is requested
+- **THEN** the system resolves the lookup against the Logstash source registry rather than the Elasticsearch source registry
+
+### Requirement: Receiver-Owned Source Product Resolution
+The system SHALL choose the active `sources.yml` product from the current collect/process execution context rather than from a static property on each `DataSource`.
+
+#### Scenario: Processing a Logstash bundle initializes Logstash file resolution once
+- **GIVEN** a diagnostic bundle contains a manifest whose product is `logstash`
+- **WHEN** `esdiag process` initializes the receiver for that bundle
+- **THEN** the receiver selects the Logstash source registry for subsequent file-path and URL resolution
+- **AND** Logstash `DataSource` implementations do not need to declare the product statically
+
+### Requirement: SourceContext-Backed API Resolution
+The system SHALL resolve `sources.yml`-backed API request paths, file paths, and output extensions through `DataSource` methods that consume a receiver-provided source context.
+
+#### Scenario: API source path resolution uses receiver metadata
+- **GIVEN** a receiver has identified the active sources product and target version for the current execution
+- **WHEN** an API-backed `DataSource` resolves its request path or file path
+- **THEN** it uses the receiver-provided source context rather than ad hoc product or version lookup at the call site
+
+### Requirement: Bundle Metadata Files Are Not API Data Sources
+The system SHALL treat bundle metadata files like `manifest.json` and `diagnostic_manifest.json` as explicit bundle-file reads rather than as `sources.yml`-defined `DataSource` entries.
+
+#### Scenario: Processing reads bundle manifests without source lookup
+- **GIVEN** a directory or archive receiver is identifying a diagnostic bundle
+- **WHEN** it loads `diagnostic_manifest.json` or falls back to `manifest.json`
+- **THEN** it reads those files directly by filename
+- **AND** no `sources.yml` lookup is required for bundle manifest loading
+
+### Requirement: Logstash Source URL Resolution
+The system SHALL resolve Logstash API request paths dynamically from `assets/logstash/sources.yml` using the target Logstash version.
+
+#### Scenario: Matching a Logstash version rule
+- **GIVEN** the source key `logstash_health_report` is defined in `assets/logstash/sources.yml` with a semver rule for `>= 8.16.0`
+- **WHEN** the target Logstash version is `8.16.0` or newer
+- **THEN** the system resolves the request path `/_health_report` for that source
+
+### Requirement: Alias-Backed Logstash File Resolution
+The system SHALL allow Logstash data sources with legacy short internal names to resolve file paths through canonical `logstash_*` source keys.
+
+#### Scenario: Short Logstash data source name resolves through canonical alias
+- **GIVEN** a Logstash data source uses the internal name `node` and the canonical source key `logstash_node`
+- **WHEN** the system resolves the file path for that data source
+- **THEN** it returns the file path defined by the `logstash_node` source configuration
+- **AND** the resulting output filename is `logstash_node.json`

--- a/src/client/logstash.rs
+++ b/src/client/logstash.rs
@@ -62,7 +62,7 @@ impl LogstashClient {
 
         let request = match path.split_once('?') {
             Some((p, query)) => {
-                let query: Vec<_> = query.split('&').filter_map(|s| s.split_once('=')).collect();
+                let query = Self::query_pairs(query);
                 self.client
                     .request(method, self.url.join(p)?)
                     .query(&query)
@@ -80,6 +80,14 @@ impl LogstashClient {
         };
 
         response.map_err(|e| eyre!("Failed to send request: {}", e))
+    }
+
+    fn query_pairs(query: &str) -> Vec<(&str, &str)> {
+        query
+            .split('&')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.split_once('=').unwrap_or((s, "")))
+            .collect()
     }
 
     /// Verify the connection and authentication to Logstash
@@ -102,5 +110,18 @@ impl TryFrom<KnownHost> for LogstashClient {
 impl std::fmt::Display for LogstashClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.url)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LogstashClient;
+
+    #[test]
+    fn query_pairs_preserve_valueless_parameters() {
+        assert_eq!(
+            LogstashClient::query_pairs("human&threads=10000"),
+            vec![("human", ""), ("threads", "10000")]
+        );
     }
 }

--- a/src/client/logstash.rs
+++ b/src/client/logstash.rs
@@ -1,0 +1,106 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+use crate::data::{Auth, KnownHost};
+use base64::Engine;
+use eyre::{Result, eyre};
+use reqwest::{Client, Method};
+use std::collections::HashMap;
+use url::Url;
+
+/// A reqwest-based client with authentication for Logstash
+#[derive(Clone)]
+pub struct LogstashClient {
+    client: Client,
+    url: Url,
+}
+
+impl LogstashClient {
+    /// Create a new Logstash client from a URL and Auth
+    pub fn try_new(url: Url, auth: Auth, ignore_certs: bool) -> Result<Self> {
+        let mut headers = reqwest::header::HeaderMap::new();
+
+        match auth {
+            Auth::Basic(username, password) => {
+                let credentials = base64::engine::general_purpose::STANDARD
+                    .encode(format!("{}:{}", username, password));
+                headers.append(
+                    reqwest::header::AUTHORIZATION,
+                    format!("Basic {}", credentials).parse()?,
+                );
+            }
+            Auth::Apikey(apikey) => {
+                headers.append(
+                    reqwest::header::AUTHORIZATION,
+                    format!("ApiKey {}", apikey).parse()?,
+                );
+            }
+            Auth::None => {}
+        }
+
+        let client = Client::builder()
+            .default_headers(headers)
+            .danger_accept_invalid_certs(ignore_certs)
+            .build()?;
+
+        Ok(Self { client, url })
+    }
+
+    /// Send a request to a given path on the Logstash client
+    pub async fn request(
+        &self,
+        method: Method,
+        headers: &HashMap<String, String>,
+        path: &str,
+        body: Option<&[u8]>,
+    ) -> Result<reqwest::Response> {
+        let headers: reqwest::header::HeaderMap = headers
+            .iter()
+            .map(|(k, v)| (k.parse().unwrap(), v.parse().unwrap()))
+            .collect();
+
+        let request = match path.split_once('?') {
+            Some((p, query)) => {
+                let query: Vec<_> = query.split('&').filter_map(|s| s.split_once('=')).collect();
+                self.client
+                    .request(method, self.url.join(p)?)
+                    .query(&query)
+                    .headers(headers)
+            }
+            None => self
+                .client
+                .request(method, self.url.join(path)?)
+                .headers(headers),
+        };
+
+        let response = match body {
+            Some(body) => request.body(body.to_vec()).send().await,
+            None => request.send().await,
+        };
+
+        response.map_err(|e| eyre!("Failed to send request: {}", e))
+    }
+
+    /// Verify the connection and authentication to Logstash
+    pub async fn test_connection(&self) -> Result<reqwest::Response> {
+        self.request(Method::GET, &HashMap::new(), "/", None).await
+    }
+}
+
+impl TryFrom<KnownHost> for LogstashClient {
+    type Error = eyre::Report;
+
+    fn try_from(host: KnownHost) -> Result<Self> {
+        let url = host.get_url();
+        let ignore_certs = host.accept_invalid_certs();
+        let auth = host.get_auth()?;
+        LogstashClient::try_new(url, auth, ignore_certs)
+    }
+}
+
+impl std::fmt::Display for LogstashClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.url)
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -96,12 +96,19 @@ impl Client {
                     .map_err(|e| format!("Failed to read test body: {e}"))?;
                 log::debug!("Test response {} ", json);
 
-                match json.get("tagline") {
-                    Some(_) => Ok(format!("{} ✅ Elasticsearch", status)),
-                    None => Err(format!(
-                        "{} ❌ No tagline? Host is not an Elasticsearch cluster!",
+                if json.get("tagline").is_some() {
+                    Ok(format!("{} ✅ Elasticsearch", status))
+                } else if let Some(version) = json.get("version").and_then(|v| v.as_str()) {
+                    let name = json
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown");
+                    Ok(format!("{status} ✅ Logstash: {name} ({version})"))
+                } else {
+                    Err(format!(
+                        "{} ❌ Root response did not match Elasticsearch or Logstash",
                         status
-                    )),
+                    ))
                 }
             }
             Client::Kibana(client) => {
@@ -210,7 +217,7 @@ impl TryFrom<Uri> for Client {
         match uri {
             Uri::KnownHost(host) => match host.app() {
                 Product::Kibana => Ok(Client::Kibana(KibanaClient::try_from(host)?)),
-                Product::Elasticsearch => {
+                Product::Elasticsearch | Product::Logstash => {
                     Ok(Client::Elasticsearch(ElasticsearchClient::try_from(host)?))
                 }
                 _ => Err(eyre!("Unsupported product: {}", host.app())),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -6,9 +6,12 @@
 mod elasticsearch;
 /// Client for Kibana APIs
 mod kibana;
+/// Client for Logstash APIs
+mod logstash;
 
 pub use elasticsearch::{ElasticsearchBuilder, ElasticsearchClient};
 pub use kibana::KibanaClient;
+pub use logstash::LogstashClient;
 
 extern crate elasticsearch as es;
 use crate::data::{Product, Uri};
@@ -20,6 +23,7 @@ use std::collections::HashMap;
 pub enum Client {
     Elasticsearch(ElasticsearchClient),
     Kibana(KibanaClient),
+    Logstash(LogstashClient),
 }
 
 impl Client {
@@ -70,6 +74,7 @@ impl Client {
                 Ok(response.into())
             }
             Client::Kibana(client) => client.request(method, headers, path, body).await,
+            Client::Logstash(client) => client.request(method, headers, path, body).await,
         }
     }
 
@@ -98,15 +103,9 @@ impl Client {
 
                 if json.get("tagline").is_some() {
                     Ok(format!("{} ✅ Elasticsearch", status))
-                } else if let Some(version) = json.get("version").and_then(|v| v.as_str()) {
-                    let name = json
-                        .get("name")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("unknown");
-                    Ok(format!("{status} ✅ Logstash: {name} ({version})"))
                 } else {
                     Err(format!(
-                        "{} ❌ Root response did not match Elasticsearch or Logstash",
+                        "{} ❌ Root response did not match Elasticsearch",
                         status
                     ))
                 }
@@ -124,13 +123,35 @@ impl Client {
                     None => Err(format!("{status} ❌ Host is not an Kibana node!")),
                 }
             }
+            Client::Logstash(client) => {
+                let response = client.test_connection().await.map_err(|e| format!("{e}"))?;
+                let status = response.status();
+                let json: serde_json::Value = response
+                    .json::<serde_json::Value>()
+                    .await
+                    .map_err(|e| format!("Failed to read test body: {e}"))?;
+                log::debug!("Test response {} ", json);
+
+                if let Some(version) = json.get("version").and_then(|v| v.as_str()) {
+                    let name = json
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown");
+                    Ok(format!("{status} ✅ Logstash: {name} ({version})"))
+                } else {
+                    Err(format!(
+                        "{} ❌ Root response did not match Logstash",
+                        status
+                    ))
+                }
+            }
         }
     }
 
     /// Check if security is enabled on the cluster.
     ///
     /// For Elasticsearch, this checks the `security.enabled` flag in `/_xpack/usage`.
-    /// For Kibana, this currently always returns `true`.
+    /// For Kibana and Logstash, this currently always returns `true`.
     pub async fn has_security_enabled(&self) -> Result<bool> {
         match self {
             Client::Elasticsearch(client) => {
@@ -179,6 +200,10 @@ impl Client {
                 // For Kibana we assume true for now as requested
                 Ok(true)
             }
+            Client::Logstash(_) => {
+                // Logstash does not expose the Elasticsearch security usage endpoint
+                Ok(true)
+            }
         }
     }
 }
@@ -188,6 +213,7 @@ impl From<Client> for Product {
         match client {
             Client::Elasticsearch(_) => Product::Elasticsearch,
             Client::Kibana(_) => Product::Kibana,
+            Client::Logstash(_) => Product::Logstash,
         }
     }
 }
@@ -197,6 +223,7 @@ impl From<&Client> for Product {
         match client {
             Client::Elasticsearch(_) => Product::Elasticsearch,
             Client::Kibana(_) => Product::Kibana,
+            Client::Logstash(_) => Product::Logstash,
         }
     }
 }
@@ -206,6 +233,7 @@ impl std::fmt::Display for Client {
         match self {
             Client::Elasticsearch(_) => write!(f, "elasticsearch"),
             Client::Kibana(_) => write!(f, "kibana"),
+            Client::Logstash(_) => write!(f, "logstash"),
         }
     }
 }
@@ -217,9 +245,10 @@ impl TryFrom<Uri> for Client {
         match uri {
             Uri::KnownHost(host) => match host.app() {
                 Product::Kibana => Ok(Client::Kibana(KibanaClient::try_from(host)?)),
-                Product::Elasticsearch | Product::Logstash => {
+                Product::Elasticsearch => {
                     Ok(Client::Elasticsearch(ElasticsearchClient::try_from(host)?))
                 }
+                Product::Logstash => Ok(Client::Logstash(LogstashClient::try_from(host)?)),
                 _ => Err(eyre!("Unsupported product: {}", host.app())),
             },
             _ => Err(eyre!("Unsupported URI")),

--- a/src/main.rs
+++ b/src/main.rs
@@ -694,14 +694,8 @@ async fn run(cli: Cli) -> Result<&'static str> {
 }
 
 fn sources_product_key(product: &Product) -> Result<&'static str> {
-    match product {
-        Product::Elasticsearch => Ok("elasticsearch"),
-        Product::Logstash => Ok("logstash"),
-        _ => Err(eyre!(
-            "--sources is only supported for Elasticsearch and Logstash, got {}",
-            product
-        )),
-    }
+    esdiag::processor::diagnostic::data_source::source_product_key(product)
+        .map_err(|_| eyre!("--sources is only supported for Elasticsearch-family and Logstash inputs, got {}", product))
 }
 
 async fn detect_sources_product_for_process(input_uri: &Uri, receiver: &Receiver) -> Result<Product> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,10 +290,6 @@ async fn main() -> Result<()> {
 
     clear_last_run_files()?;
 
-    if let Some(sources) = cli.sources.clone() {
-        esdiag::processor::init_sources(Some(sources))?;
-    }
-
     match run(cli).await {
         Ok(cmd) => {
             log::debug!("{cmd} complete");
@@ -307,6 +303,7 @@ async fn main() -> Result<()> {
 }
 
 async fn run(cli: Cli) -> Result<&'static str> {
+    let sources_override = cli.sources.clone();
     // If there are CLI arguments but no subcommand, avoid starting the desktop/Tauri
     // entrypoint. The desktop UI should only start when launched absolutely without arguments.
     if should_error_for_missing_subcommand(std::env::args_os().len(), cli.command.is_none()) {
@@ -383,6 +380,12 @@ async fn run(cli: Cli) -> Result<&'static str> {
                     | Uri::ElasticGovCloudAdmin(host) => {
                         ensure_host_role(&host, HostRole::Collect, "collect")?;
                         let product = host.app().clone();
+                        if let Some(sources) = sources_override.clone() {
+                            esdiag::processor::init_sources(
+                                sources_product_key(&product)?,
+                                sources,
+                            )?;
+                        }
                         let known_host = Uri::try_from(host)?;
                         log::info!("Collecting diagnostic from {known_host}");
                         log::info!("Saving diagnostic to {output}");
@@ -527,7 +530,12 @@ async fn run(cli: Cli) -> Result<&'static str> {
 
                 log::info!("input: {}", input_uri);
 
-                let receiver = Arc::new(Receiver::try_from(input_uri)?);
+                let receiver = Receiver::try_from(input_uri.clone())?;
+                if let Some(sources) = sources_override.clone() {
+                    let product = detect_sources_product_for_process(&input_uri, &receiver).await?;
+                    esdiag::processor::init_sources(sources_product_key(&product)?, sources)?;
+                }
+                let receiver = Arc::new(receiver);
                 let exporter = Arc::new(Exporter::try_from(output_uri)?);
 
                 let identifiers =
@@ -682,6 +690,26 @@ async fn run(cli: Cli) -> Result<&'static str> {
                 "No command provided. If you want to use the Desktop UI, compile with the 'desktop' feature."
             ))
         }
+    }
+}
+
+fn sources_product_key(product: &Product) -> Result<&'static str> {
+    match product {
+        Product::Elasticsearch => Ok("elasticsearch"),
+        Product::Logstash => Ok("logstash"),
+        _ => Err(eyre!(
+            "--sources is only supported for Elasticsearch and Logstash, got {}",
+            product
+        )),
+    }
+}
+
+async fn detect_sources_product_for_process(input_uri: &Uri, receiver: &Receiver) -> Result<Product> {
+    match input_uri {
+        Uri::KnownHost(host) | Uri::ElasticCloudAdmin(host) | Uri::ElasticGovCloudAdmin(host) => {
+            Ok(host.app().clone())
+        }
+        _ => Ok(receiver.try_get_manifest_without_fallback().await?.product),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -695,7 +695,7 @@ async fn run(cli: Cli) -> Result<&'static str> {
 
 fn sources_product_key(product: &Product) -> Result<&'static str> {
     esdiag::processor::diagnostic::data_source::source_product_key(product)
-        .map_err(|_| eyre!("--sources is only supported for Elasticsearch-family and Logstash inputs, got {}", product))
+        .map_err(|_| eyre!("--sources is only supported for Elasticsearch and Logstash inputs, got {}", product))
 }
 
 async fn detect_sources_product_for_process(input_uri: &Uri, receiver: &Receiver) -> Result<Product> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,8 @@ struct Cli {
     /// Enable debug logging
     #[arg(global = true, long)]
     debug: bool,
-    /// Override the path to sources.yml
+    /// Override the embedded Elasticsearch sources.yml path.
+    /// Logstash sources continue to use the embedded assets/logstash/sources.yml.
     #[arg(global = true, long)]
     sources: Option<String>,
     /// Commands

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,8 @@ struct Cli {
     /// Enable debug logging
     #[arg(global = true, long)]
     debug: bool,
-    /// Override the embedded Elasticsearch sources.yml path.
-    /// Logstash sources continue to use the embedded assets/logstash/sources.yml.
+    /// Override the embedded sources.yml for the detected Elasticsearch or Logstash workflow.
+    /// The file must match the active product or the command fails before collection/processing.
     #[arg(global = true, long)]
     sources: Option<String>,
     /// Commands
@@ -709,7 +709,7 @@ async fn detect_sources_product_for_process(input_uri: &Uri, receiver: &Receiver
         Uri::KnownHost(host) | Uri::ElasticCloudAdmin(host) | Uri::ElasticGovCloudAdmin(host) => {
             Ok(host.app().clone())
         }
-        _ => Ok(receiver.try_get_manifest_without_fallback().await?.product),
+        _ => Ok(receiver.try_get_manifest_from_files().await?.product),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -381,6 +381,7 @@ async fn run(cli: Cli) -> Result<&'static str> {
                     | Uri::ElasticCloudAdmin(host)
                     | Uri::ElasticGovCloudAdmin(host) => {
                         ensure_host_role(&host, HostRole::Collect, "collect")?;
+                        let product = host.app().clone();
                         let known_host = Uri::try_from(host)?;
                         log::info!("Collecting diagnostic from {known_host}");
                         log::info!("Saving diagnostic to {output}");
@@ -401,6 +402,7 @@ async fn run(cli: Cli) -> Result<&'static str> {
                         let collector = Collector::try_new(
                             receiver,
                             exporter,
+                            product,
                             r#type,
                             include,
                             exclude,

--- a/src/processor/api.rs
+++ b/src/processor/api.rs
@@ -168,28 +168,67 @@ impl std::str::FromStr for ElasticsearchApi {
 pub enum LogstashApi {
     Node,
     NodeStats,
+    Raw(String, ApiWeight),
 }
 
 impl LogstashApi {
+    fn normalize_name(s: &str) -> Result<String> {
+        let canonical = match s {
+            "node" | "logstash_node" => "logstash_node",
+            "node_stats" | "logstash_node_stats" => "logstash_node_stats",
+            "plugins" | "logstash_plugins" => "logstash_plugins",
+            "version" | "logstash_version" => "logstash_version",
+            "health_report" | "logstash_health_report" => "logstash_health_report",
+            "hot_threads" | "logstash_nodes_hot_threads" => "logstash_nodes_hot_threads",
+            "hot_threads_human" | "logstash_nodes_hot_threads_human" => {
+                "logstash_nodes_hot_threads_human"
+            }
+            other => other,
+        };
+
+        crate::processor::diagnostic::data_source::get_source("logstash", canonical, &[])
+            .map_err(|_| eyre!("Invalid Logstash API: {}", s))?;
+        Ok(canonical.to_string())
+    }
+
     pub fn weight(&self) -> ApiWeight {
         match self {
             LogstashApi::Node => ApiWeight::Light,
             LogstashApi::NodeStats => ApiWeight::Heavy,
+            LogstashApi::Raw(_, weight) => weight.clone(),
         }
     }
 
-    pub fn as_str(&self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         match self {
-            LogstashApi::Node => "node",
-            LogstashApi::NodeStats => "node_stats",
+            LogstashApi::Node => "logstash_node",
+            LogstashApi::NodeStats => "logstash_node_stats",
+            LogstashApi::Raw(name, _) => name.as_str(),
         }
     }
 
     pub fn parse(s: &str) -> Result<Self> {
-        match s {
-            "node" => Ok(LogstashApi::Node),
-            "node_stats" => Ok(LogstashApi::NodeStats),
-            _ => Err(eyre!("Invalid Logstash API: {}", s)),
+        let canonical = Self::normalize_name(s)?;
+        match canonical.as_str() {
+            "logstash_node" => Ok(LogstashApi::Node),
+            "logstash_node_stats" => Ok(LogstashApi::NodeStats),
+            _ => {
+                let weight = match crate::processor::diagnostic::data_source::get_source(
+                    "logstash",
+                    canonical.as_str(),
+                    &[],
+                ) {
+                    Ok((_, source)) => {
+                        if source.tags.as_deref() == Some("light") {
+                            ApiWeight::Light
+                        } else {
+                            ApiWeight::Heavy
+                        }
+                    }
+                    Err(_) => return Err(eyre!("Invalid Logstash API: {}", s)),
+                };
+                Ok(LogstashApi::Raw(canonical, weight))
+            }
         }
     }
 }
@@ -210,7 +249,7 @@ impl ApiResolver {
     }
 
     pub fn ls_minimum_required() -> Vec<&'static str> {
-        vec!["node"]
+        vec!["logstash_node"]
     }
 
     pub fn es_dependencies() -> HashMap<&'static str, Vec<&'static str>> {
@@ -222,7 +261,8 @@ impl ApiResolver {
 
     pub fn ls_dependencies() -> HashMap<&'static str, Vec<&'static str>> {
         let mut deps = HashMap::new();
-        deps.insert("node_stats", vec!["node"]);
+        deps.insert("logstash_node", vec!["logstash_version", "logstash_plugins"]);
+        deps.insert("logstash_node_stats", vec!["logstash_node"]);
         deps
     }
 
@@ -358,26 +398,37 @@ impl ApiResolver {
     ) -> Result<Vec<LogstashApi>> {
         let mut requested: IndexSet<String> = IndexSet::new();
 
-        for api in match diag_type {
-            DiagnosticType::Minimal => vec!["node"],
-            DiagnosticType::Standard | DiagnosticType::Support | DiagnosticType::Light => {
-                vec!["node", "node_stats"]
+        let base_apis: Vec<String> = match diag_type {
+            DiagnosticType::Minimal => vec!["logstash_node".to_string()],
+            DiagnosticType::Standard | DiagnosticType::Light => vec![
+                "logstash_node".to_string(),
+                "logstash_node_stats".to_string(),
+            ],
+            DiagnosticType::Support => {
+                let sources = crate::processor::diagnostic::data_source::get_sources();
+                if let Some(logstash_sources) = sources.get("logstash") {
+                    logstash_sources.keys().cloned().collect()
+                } else {
+                    vec![]
+                }
             }
-        } {
-            requested.insert(api.to_string());
+        };
+
+        for api in base_apis {
+            requested.insert(api);
         }
 
         if let Some(incs) = include {
             for api in incs {
-                LogstashApi::parse(api)?;
-                requested.insert(api.to_string());
+                let normalized = LogstashApi::normalize_name(api)?;
+                requested.insert(normalized);
             }
         }
 
         if let Some(excs) = exclude {
             for api in excs {
-                LogstashApi::parse(api)?;
-                requested.swap_remove(api);
+                let normalized = LogstashApi::normalize_name(api)?;
+                requested.swap_remove(&normalized);
             }
         }
 
@@ -490,5 +541,55 @@ mod tests {
             .filter(|api| matches!(api, ElasticsearchApi::Cluster))
             .count();
         assert_eq!(cluster_count, 1);
+    }
+
+    #[test]
+    fn test_ls_support_resolves_all_sources() {
+        let apis = ApiResolver::resolve_ls(&DiagnosticType::Support, None, None).unwrap();
+        let api_strs: Vec<&str> = apis.iter().map(|a| a.as_str()).collect();
+
+        assert!(api_strs.contains(&"logstash_health_report"));
+        assert!(api_strs.contains(&"logstash_node"));
+        assert!(api_strs.contains(&"logstash_nodes_hot_threads_human"));
+        assert!(api_strs.contains(&"logstash_node_stats"));
+        assert!(api_strs.contains(&"logstash_plugins"));
+        assert!(api_strs.contains(&"logstash_version"));
+    }
+
+    #[test]
+    fn test_ls_normalizes_aliases_and_dependencies() {
+        let apis = ApiResolver::resolve_ls(
+            &DiagnosticType::Minimal,
+            Some(&vec!["node_stats".to_string(), "version".to_string()]),
+            None,
+        )
+        .unwrap();
+
+        let api_strs: Vec<&str> = apis.iter().map(|a| a.as_str()).collect();
+        assert!(api_strs.contains(&"logstash_node_stats"));
+        assert!(api_strs.contains(&"logstash_node"));
+        assert!(api_strs.contains(&"logstash_version"));
+        assert!(api_strs.contains(&"logstash_plugins"));
+        assert_eq!(
+            api_strs
+                .iter()
+                .filter(|&&name| name == "logstash_version")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_ls_human_hot_threads_is_valid_raw_api() {
+        let apis = ApiResolver::resolve_ls(
+            &DiagnosticType::Minimal,
+            Some(&vec!["logstash_nodes_hot_threads_human".to_string()]),
+            None,
+        )
+        .unwrap();
+
+        assert!(apis
+            .iter()
+            .any(|api| api.as_str() == "logstash_nodes_hot_threads_human"));
     }
 }

--- a/src/processor/collector.rs
+++ b/src/processor/collector.rs
@@ -2,12 +2,18 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::elasticsearch::ElasticsearchCollector;
-use crate::{exporter::Exporter, processor::Identifiers, receiver::Receiver};
+use super::{elasticsearch::ElasticsearchCollector, logstash::LogstashCollector};
+use crate::{
+    data::Product,
+    exporter::Exporter,
+    processor::Identifiers,
+    receiver::Receiver,
+};
 use eyre::{Result, eyre};
 
 #[derive(Debug, Clone)]
 pub struct CollectOptions {
+    pub product: Product,
     pub r#type: String,
     pub include: Option<Vec<String>>,
     pub exclude: Option<Vec<String>>,
@@ -16,40 +22,53 @@ pub struct CollectOptions {
 
 pub enum Collector {
     Elasticsearch(ElasticsearchCollector),
+    Logstash(LogstashCollector),
 }
 
 impl Collector {
     pub async fn try_new(
         receiver: Receiver,
         exporter: Exporter,
+        product: Product,
         r#type: String,
         include: Option<Vec<String>>,
         exclude: Option<Vec<String>>,
         identifiers: Identifiers,
     ) -> Result<Self> {
         let options = CollectOptions {
+            product,
             r#type,
             include,
             exclude,
             identifiers,
         };
 
-        match receiver {
-            receiver @ (Receiver::Elasticsearch(_) | Receiver::ElasticCloudAdmin(_)) => {
+        match (options.product.clone(), receiver) {
+            (
+                Product::Elasticsearch,
+                receiver @ (Receiver::Elasticsearch(_) | Receiver::ElasticCloudAdmin(_)),
+            ) => {
                 let collect_exporter = exporter.into_collect_exporter()?;
                 let collector =
                     ElasticsearchCollector::new(receiver, collect_exporter, options).await?;
                 Ok(Self::Elasticsearch(collector))
             }
-            _ => Err(eyre!(
-                "Collect is only implemented for Elasticsearch-based receivers"
+            (Product::Logstash, receiver @ Receiver::Elasticsearch(_)) => {
+                let collect_exporter = exporter.into_collect_exporter()?;
+                let collector = LogstashCollector::new(receiver, collect_exporter, options).await?;
+                Ok(Self::Logstash(collector))
+            }
+            (Product::Logstash, _) => Err(eyre!(
+                "Collect for Logstash requires a standard known-host endpoint"
             )),
+            _ => Err(eyre!("Collect is only implemented for Elasticsearch and Logstash hosts")),
         }
     }
 
     pub async fn collect(&self) -> Result<CollectionResult> {
         let result = match self {
             Self::Elasticsearch(collector) => collector.collect().await?,
+            Self::Logstash(collector) => collector.collect().await?,
         };
 
         log::info!(

--- a/src/processor/collector.rs
+++ b/src/processor/collector.rs
@@ -53,7 +53,7 @@ impl Collector {
                     ElasticsearchCollector::new(receiver, collect_exporter, options).await?;
                 Ok(Self::Elasticsearch(collector))
             }
-            (Product::Logstash, receiver @ Receiver::Elasticsearch(_)) => {
+            (Product::Logstash, receiver @ Receiver::Logstash(_)) => {
                 let collect_exporter = exporter.into_collect_exporter()?;
                 let collector = LogstashCollector::new(receiver, collect_exporter, options).await?;
                 Ok(Self::Logstash(collector))

--- a/src/processor/diagnostic/data_source.rs
+++ b/src/processor/diagnostic/data_source.rs
@@ -100,23 +100,7 @@ impl std::fmt::Display for Source {
 
 static SOURCES: OnceLock<HashMap<&'static str, HashMap<String, Source>>> = OnceLock::new();
 
-pub fn get_sources() -> &'static HashMap<&'static str, HashMap<String, Source>> {
-    SOURCES.get_or_init(|| {
-        let mut products = HashMap::new();
-
-        let es_sources: HashMap<String, Source> =
-            serde_yaml::from_str(include_str!("../../../assets/elasticsearch/sources.yml"))
-                .expect("Valid elasticsearch sources.yml");
-        products.insert("elasticsearch", es_sources);
-
-        // Add other products here as their sources.yml files become available.
-        // E.g., kibana, logstash, etc.
-
-        products
-    })
-}
-
-pub fn init_sources(override_path: Option<String>) -> Result<()> {
+fn load_embedded_sources(override_path: Option<String>) -> Result<HashMap<&'static str, HashMap<String, Source>>> {
     let mut products = HashMap::new();
 
     let es_content = if let Some(path) = override_path {
@@ -127,10 +111,23 @@ pub fn init_sources(override_path: Option<String>) -> Result<()> {
     };
 
     let es_sources: HashMap<String, Source> = serde_yaml::from_str(&es_content)
-        .map_err(|e| eyre!("Failed to parse sources.yml: {}", e))?;
-
+        .map_err(|e| eyre!("Failed to parse Elasticsearch sources.yml: {}", e))?;
     products.insert("elasticsearch", es_sources);
 
+    let logstash_sources: HashMap<String, Source> =
+        serde_yaml::from_str(include_str!("../../../assets/logstash/sources.yml"))
+            .map_err(|e| eyre!("Failed to parse Logstash sources.yml: {}", e))?;
+    products.insert("logstash", logstash_sources);
+
+    Ok(products)
+}
+
+pub fn get_sources() -> &'static HashMap<&'static str, HashMap<String, Source>> {
+    SOURCES.get_or_init(|| load_embedded_sources(None).expect("Valid embedded sources.yml files"))
+}
+
+pub fn init_sources(override_path: Option<String>) -> Result<()> {
+    let products = load_embedded_sources(override_path)?;
     SOURCES
         .set(products)
         .map_err(|_| eyre!("Sources already initialized"))?;
@@ -265,5 +262,33 @@ mod tests {
 
         let tasks = es_sources.get("tasks").unwrap();
         assert_eq!(tasks.get_file_path("tasks"), "tasks.json"); // no subdir, default extension is json if missing from yaml
+    }
+
+    #[test]
+    fn test_logstash_sources_are_loaded() {
+        let sources = get_sources();
+        let logstash_sources = sources.get("logstash").unwrap();
+        assert!(logstash_sources.contains_key("logstash_node"));
+        assert!(logstash_sources.contains_key("logstash_nodes_hot_threads_human"));
+    }
+
+    #[test]
+    fn test_logstash_source_url_and_extension_resolution() {
+        let sources = get_sources();
+        let logstash_sources = sources.get("logstash").unwrap();
+
+        let health = logstash_sources.get("logstash_health_report").unwrap();
+        let v_8_15 = Version::parse("8.15.0").unwrap();
+        let v_8_16 = Version::parse("8.16.0").unwrap();
+        assert!(health.get_url(&v_8_15).is_err());
+        assert_eq!(health.get_url(&v_8_16).unwrap(), "/_health_report");
+
+        let hot_threads_human = logstash_sources
+            .get("logstash_nodes_hot_threads_human")
+            .unwrap();
+        assert_eq!(
+            hot_threads_human.get_file_path("logstash_nodes_hot_threads_human"),
+            "logstash_nodes_hot_threads_human.txt"
+        );
     }
 }

--- a/src/processor/diagnostic/data_source.rs
+++ b/src/processor/diagnostic/data_source.rs
@@ -2,17 +2,13 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
+use crate::data::Product;
 use eyre::{Result, eyre};
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::OnceLock;
 use tokio::sync::mpsc::Sender;
-
-pub enum PathType {
-    Url,
-    File,
-}
 
 #[derive(Debug)]
 pub enum DataSourceError {
@@ -42,21 +38,85 @@ pub trait DataSource {
     fn aliases() -> Vec<&'static str> {
         Vec::new()
     }
-    fn product() -> &'static str {
-        "elasticsearch"
+    fn filename() -> Option<&'static str> {
+        None
     }
-    fn source(path: PathType, version: Option<&Version>) -> Result<String> {
-        let name = Self::name();
-        let aliases = Self::aliases();
-        let (matched_name, source_conf) = get_source(Self::product(), &name, &aliases)?;
-        match path {
-            PathType::File => Ok(source_conf.get_file_path(matched_name)),
-            PathType::Url => {
-                let v = version.ok_or_else(|| eyre!("Version required for URL"))?;
-                source_conf.get_url(v)
+}
+
+pub fn source_product_key(product: &Product) -> Result<&'static str> {
+    match product {
+        Product::Elasticsearch
+        | Product::ECE
+        | Product::ECK
+        | Product::ElasticCloudHosted
+        | Product::KubernetesPlatform => Ok("elasticsearch"),
+        Product::Logstash => Ok("logstash"),
+        _ => Err(eyre!(
+            "sources.yml overrides are not supported for product {}",
+            product
+        )),
+    }
+}
+
+pub fn resolve_file_path_for<T: DataSource>(product: &str) -> Result<String> {
+    if let Some(filename) = T::filename() {
+        return Ok(filename.to_string());
+    }
+
+    let name = T::name();
+    let aliases = T::aliases();
+    let (matched_name, source_conf) = get_source(product, &name, &aliases)?;
+    Ok(source_conf.get_file_path(matched_name))
+}
+
+pub fn resolve_url_for<T: DataSource>(product: &str, version: Option<&Version>) -> Result<String> {
+    if T::filename().is_some() {
+        return Err(eyre!("{} is file-only and has no live API URL", T::name()));
+    }
+
+    let v = version.ok_or_else(|| eyre!("Version required for URL"))?;
+    let name = T::name();
+    let aliases = T::aliases();
+    let (_, source_conf) = get_source(product, &name, &aliases)?;
+    source_conf.get_url(v)
+}
+
+pub fn resolve_extension_for<T: DataSource>(product: &str) -> Result<String> {
+    if let Some(filename) = T::filename() {
+        return Ok(match filename.rsplit_once('.') {
+            Some((_, extension)) => format!(".{extension}"),
+            None => ".json".to_string(),
+        });
+    }
+
+    let name = T::name();
+    let aliases = T::aliases();
+    let (_, source_conf) = get_source(product, &name, &aliases)?;
+    Ok(source_conf.extension.as_deref().unwrap_or(".json").to_string())
+}
+
+pub fn candidate_file_paths_for<T: DataSource>(product: &str) -> Result<Vec<String>> {
+    if let Some(filename) = T::filename() {
+        return Ok(vec![filename.to_string()]);
+    }
+
+    let name = T::name();
+    let aliases = T::aliases();
+    let mut paths = Vec::new();
+
+    let (matched_name, source_conf) = get_source(product, &name, &aliases)?;
+    paths.push(source_conf.get_file_path(matched_name));
+
+    for alias in aliases {
+        if let Ok((matched_name, source_conf)) = get_source(product, alias, &[]) {
+            let path = source_conf.get_file_path(matched_name);
+            if !paths.contains(&path) {
+                paths.push(path);
             }
         }
     }
+
+    Ok(paths)
 }
 
 pub trait StreamingDataSource: DataSource {
@@ -69,7 +129,6 @@ pub trait StreamingDataSource: DataSource {
         D: Deserializer<'de>;
 }
 
-#[allow(dead_code)] // For future use deserialzing the sources.yml
 #[derive(Clone, PartialEq, Serialize, Deserialize, Eq)]
 pub struct Source {
     pub extension: Option<String>,
@@ -120,7 +179,11 @@ fn parse_sources_content(label: &str, content: &str) -> Result<HashMap<String, S
     serde_yaml::from_str(content).map_err(|e| eyre!("Failed to parse {}: {}", label, e))
 }
 
-fn validate_sources_product(product: &str, sources: &HashMap<String, Source>, label: &str) -> Result<()> {
+fn validate_sources_product(
+    product: &str,
+    sources: &HashMap<String, Source>,
+    label: &str,
+) -> Result<()> {
     let required = required_source_keys(product);
     let missing: Vec<&str> = required
         .iter()
@@ -151,8 +214,9 @@ fn load_embedded_sources(
                 override_path.ok_or_else(|| eyre!("Override path missing for {}", product))?;
             (
                 format!("override sources file at {}", path),
-                std::fs::read_to_string(path)
-                    .map_err(|e| eyre!("Failed to read override sources file at {}: {}", path, e))?,
+                std::fs::read_to_string(path).map_err(|e| {
+                    eyre!("Failed to read override sources file at {}: {}", path, e)
+                })?,
             )
         } else {
             (

--- a/src/processor/diagnostic/data_source.rs
+++ b/src/processor/diagnostic/data_source.rs
@@ -100,10 +100,12 @@ impl std::fmt::Display for Source {
 
 static SOURCES: OnceLock<HashMap<&'static str, HashMap<String, Source>>> = OnceLock::new();
 
-fn load_embedded_sources(override_path: Option<String>) -> Result<HashMap<&'static str, HashMap<String, Source>>> {
+fn load_embedded_sources(
+    es_override_path: Option<String>,
+) -> Result<HashMap<&'static str, HashMap<String, Source>>> {
     let mut products = HashMap::new();
 
-    let es_content = if let Some(path) = override_path {
+    let es_content = if let Some(path) = es_override_path {
         std::fs::read_to_string(&path)
             .map_err(|e| eyre!("Failed to read override sources file at {}: {}", path, e))?
     } else {
@@ -126,8 +128,8 @@ pub fn get_sources() -> &'static HashMap<&'static str, HashMap<String, Source>> 
     SOURCES.get_or_init(|| load_embedded_sources(None).expect("Valid embedded sources.yml files"))
 }
 
-pub fn init_sources(override_path: Option<String>) -> Result<()> {
-    let products = load_embedded_sources(override_path)?;
+pub fn init_sources(es_override_path: Option<String>) -> Result<()> {
+    let products = load_embedded_sources(es_override_path)?;
     SOURCES
         .set(products)
         .map_err(|_| eyre!("Sources already initialized"))?;

--- a/src/processor/diagnostic/data_source.rs
+++ b/src/processor/diagnostic/data_source.rs
@@ -33,13 +33,67 @@ impl std::fmt::Display for DataSourceError {
 
 impl std::error::Error for DataSourceError {}
 
+#[derive(Clone, Debug, Default)]
+pub struct SourceContext {
+    pub product: &'static str,
+    pub version: Option<Version>,
+}
+
+impl SourceContext {
+    pub fn new(product: &'static str, version: Option<Version>) -> Self {
+        Self { product, version }
+    }
+}
+
 pub trait DataSource {
     fn name() -> String;
     fn aliases() -> Vec<&'static str> {
         Vec::new()
     }
-    fn filename() -> Option<&'static str> {
-        None
+
+    fn resolve_source_request_path(ctx: &SourceContext) -> Result<String> {
+        let version = ctx
+            .version
+            .as_ref()
+            .ok_or_else(|| eyre!("Version required for request path"))?;
+        let name = Self::name();
+        let aliases = Self::aliases();
+        let (_, source_conf) = get_source(ctx.product, &name, &aliases)?;
+        source_conf.get_url(version)
+    }
+
+    fn resolve_source_file_path(ctx: &SourceContext) -> Result<String> {
+        let name = Self::name();
+        let aliases = Self::aliases();
+        let (matched_name, source_conf) = get_source(ctx.product, &name, &aliases)?;
+        Ok(source_conf.get_file_path(matched_name))
+    }
+
+    fn resolve_source_extension(ctx: &SourceContext) -> Result<String> {
+        let name = Self::name();
+        let aliases = Self::aliases();
+        let (_, source_conf) = get_source(ctx.product, &name, &aliases)?;
+        Ok(source_conf.extension.as_deref().unwrap_or(".json").to_string())
+    }
+
+    fn candidate_source_file_paths(ctx: &SourceContext) -> Result<Vec<String>> {
+        let name = Self::name();
+        let aliases = Self::aliases();
+        let mut paths = Vec::new();
+
+        let (matched_name, source_conf) = get_source(ctx.product, &name, &aliases)?;
+        paths.push(source_conf.get_file_path(matched_name));
+
+        for alias in aliases {
+            if let Ok((matched_name, source_conf)) = get_source(ctx.product, alias, &[]) {
+                let path = source_conf.get_file_path(matched_name);
+                if !paths.contains(&path) {
+                    paths.push(path);
+                }
+            }
+        }
+
+        Ok(paths)
     }
 }
 
@@ -52,67 +106,6 @@ pub fn source_product_key(product: &Product) -> Result<&'static str> {
             product
         )),
     }
-}
-
-pub fn resolve_file_path_for<T: DataSource>(product: &str) -> Result<String> {
-    if let Some(filename) = T::filename() {
-        return Ok(filename.to_string());
-    }
-
-    let name = T::name();
-    let aliases = T::aliases();
-    let (matched_name, source_conf) = get_source(product, &name, &aliases)?;
-    Ok(source_conf.get_file_path(matched_name))
-}
-
-pub fn resolve_url_for<T: DataSource>(product: &str, version: Option<&Version>) -> Result<String> {
-    if T::filename().is_some() {
-        return Err(eyre!("{} is file-only and has no live API URL", T::name()));
-    }
-
-    let v = version.ok_or_else(|| eyre!("Version required for URL"))?;
-    let name = T::name();
-    let aliases = T::aliases();
-    let (_, source_conf) = get_source(product, &name, &aliases)?;
-    source_conf.get_url(v)
-}
-
-pub fn resolve_extension_for<T: DataSource>(product: &str) -> Result<String> {
-    if let Some(filename) = T::filename() {
-        return Ok(match filename.rsplit_once('.') {
-            Some((_, extension)) => format!(".{extension}"),
-            None => ".json".to_string(),
-        });
-    }
-
-    let name = T::name();
-    let aliases = T::aliases();
-    let (_, source_conf) = get_source(product, &name, &aliases)?;
-    Ok(source_conf.extension.as_deref().unwrap_or(".json").to_string())
-}
-
-pub fn candidate_file_paths_for<T: DataSource>(product: &str) -> Result<Vec<String>> {
-    if let Some(filename) = T::filename() {
-        return Ok(vec![filename.to_string()]);
-    }
-
-    let name = T::name();
-    let aliases = T::aliases();
-    let mut paths = Vec::new();
-
-    let (matched_name, source_conf) = get_source(product, &name, &aliases)?;
-    paths.push(source_conf.get_file_path(matched_name));
-
-    for alias in aliases {
-        if let Ok((matched_name, source_conf)) = get_source(product, alias, &[]) {
-            let path = source_conf.get_file_path(matched_name);
-            if !paths.contains(&path) {
-                paths.push(path);
-            }
-        }
-    }
-
-    Ok(paths)
 }
 
 pub trait StreamingDataSource: DataSource {

--- a/src/processor/diagnostic/data_source.rs
+++ b/src/processor/diagnostic/data_source.rs
@@ -45,11 +45,7 @@ pub trait DataSource {
 
 pub fn source_product_key(product: &Product) -> Result<&'static str> {
     match product {
-        Product::Elasticsearch
-        | Product::ECE
-        | Product::ECK
-        | Product::ElasticCloudHosted
-        | Product::KubernetesPlatform => Ok("elasticsearch"),
+        Product::Elasticsearch => Ok("elasticsearch"),
         Product::Logstash => Ok("logstash"),
         _ => Err(eyre!(
             "sources.yml overrides are not supported for product {}",

--- a/src/processor/diagnostic/data_source.rs
+++ b/src/processor/diagnostic/data_source.rs
@@ -100,36 +100,83 @@ impl std::fmt::Display for Source {
 
 static SOURCES: OnceLock<HashMap<&'static str, HashMap<String, Source>>> = OnceLock::new();
 
+fn embedded_sources_str(product: &str) -> Result<&'static str> {
+    match product {
+        "elasticsearch" => Ok(include_str!("../../../assets/elasticsearch/sources.yml")),
+        "logstash" => Ok(include_str!("../../../assets/logstash/sources.yml")),
+        other => Err(eyre!("Unsupported sources product: {}", other)),
+    }
+}
+
+fn required_source_keys(product: &str) -> &'static [&'static str] {
+    match product {
+        "elasticsearch" => &["version"],
+        "logstash" => &["logstash_node", "logstash_version"],
+        _ => &[],
+    }
+}
+
+fn parse_sources_content(label: &str, content: &str) -> Result<HashMap<String, Source>> {
+    serde_yaml::from_str(content).map_err(|e| eyre!("Failed to parse {}: {}", label, e))
+}
+
+fn validate_sources_product(product: &str, sources: &HashMap<String, Source>, label: &str) -> Result<()> {
+    let required = required_source_keys(product);
+    let missing: Vec<&str> = required
+        .iter()
+        .copied()
+        .filter(|key| !sources.contains_key(*key))
+        .collect();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(eyre!(
+            "{} does not look like a valid {} sources.yml; missing required keys: {}",
+            label,
+            product,
+            missing.join(", ")
+        ))
+    }
+}
+
 fn load_embedded_sources(
-    es_override_path: Option<String>,
+    override_product: Option<&str>,
+    override_path: Option<&str>,
 ) -> Result<HashMap<&'static str, HashMap<String, Source>>> {
     let mut products = HashMap::new();
 
-    let es_content = if let Some(path) = es_override_path {
-        std::fs::read_to_string(&path)
-            .map_err(|e| eyre!("Failed to read override sources file at {}: {}", path, e))?
-    } else {
-        include_str!("../../../assets/elasticsearch/sources.yml").to_string()
-    };
+    for product in ["elasticsearch", "logstash"] {
+        let (label, content) = if override_product == Some(product) {
+            let path =
+                override_path.ok_or_else(|| eyre!("Override path missing for {}", product))?;
+            (
+                format!("override sources file at {}", path),
+                std::fs::read_to_string(path)
+                    .map_err(|e| eyre!("Failed to read override sources file at {}: {}", path, e))?,
+            )
+        } else {
+            (
+                format!("embedded {} sources.yml", product),
+                embedded_sources_str(product)?.to_string(),
+            )
+        };
 
-    let es_sources: HashMap<String, Source> = serde_yaml::from_str(&es_content)
-        .map_err(|e| eyre!("Failed to parse Elasticsearch sources.yml: {}", e))?;
-    products.insert("elasticsearch", es_sources);
-
-    let logstash_sources: HashMap<String, Source> =
-        serde_yaml::from_str(include_str!("../../../assets/logstash/sources.yml"))
-            .map_err(|e| eyre!("Failed to parse Logstash sources.yml: {}", e))?;
-    products.insert("logstash", logstash_sources);
+        let sources = parse_sources_content(&label, &content)?;
+        validate_sources_product(product, &sources, &label)?;
+        products.insert(product, sources);
+    }
 
     Ok(products)
 }
 
 pub fn get_sources() -> &'static HashMap<&'static str, HashMap<String, Source>> {
-    SOURCES.get_or_init(|| load_embedded_sources(None).expect("Valid embedded sources.yml files"))
+    SOURCES.get_or_init(|| {
+        load_embedded_sources(None, None).expect("Valid embedded sources.yml files")
+    })
 }
 
-pub fn init_sources(es_override_path: Option<String>) -> Result<()> {
-    let products = load_embedded_sources(es_override_path)?;
+pub fn init_sources(product: &str, override_path: String) -> Result<()> {
+    let products = load_embedded_sources(Some(product), Some(&override_path))?;
     SOURCES
         .set(products)
         .map_err(|_| eyre!("Sources already initialized"))?;
@@ -292,5 +339,65 @@ mod tests {
             hot_threads_human.get_file_path("logstash_nodes_hot_threads_human"),
             "logstash_nodes_hot_threads_human.txt"
         );
+    }
+
+    #[test]
+    fn test_product_specific_override_only_replaces_target_product() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let override_path = dir.path().join("sources.yml");
+        std::fs::write(
+            &override_path,
+            r#"
+logstash_node:
+  versions:
+    "> 5.0.0": "/custom_node"
+logstash_version:
+  versions:
+    "> 5.0.0": "/custom_version"
+"#,
+        )
+        .expect("write override");
+
+        let products = super::load_embedded_sources(
+            Some("logstash"),
+            Some(override_path.to_str().expect("override path")),
+        )
+        .expect("load sources");
+
+        let es_sources = products.get("elasticsearch").unwrap();
+        let logstash_sources = products.get("logstash").unwrap();
+        assert!(es_sources.contains_key("version"));
+        assert_eq!(
+            logstash_sources
+                .get("logstash_node")
+                .unwrap()
+                .get_url(&Version::parse("8.19.0").unwrap())
+                .unwrap(),
+            "/custom_node"
+        );
+    }
+
+    #[test]
+    fn test_product_specific_override_rejects_wrong_product_shape() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let override_path = dir.path().join("sources.yml");
+        std::fs::write(
+            &override_path,
+            r#"
+version:
+  versions:
+    "> 5.0.0": "/"
+"#,
+        )
+        .expect("write override");
+
+        let err = match super::load_embedded_sources(
+            Some("logstash"),
+            Some(override_path.to_str().expect("override path")),
+        ) {
+            Ok(_) => panic!("override should fail"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("valid logstash sources.yml"));
     }
 }

--- a/src/processor/diagnostic/diagnostic_manifest.rs
+++ b/src/processor/diagnostic/diagnostic_manifest.rs
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use super::super::Identifiers;
-use super::{DataSource, DiagPath, Manifest};
+use super::{DiagPath, Manifest};
 use crate::data::Product;
 use chrono::{DateTime, SecondsFormat, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
@@ -162,14 +162,8 @@ impl DiagnosticManifest {
     }
 }
 
-impl DataSource for DiagnosticManifest {
-    fn name() -> String {
-        "diagnostic_manifest".to_string()
-    }
-
-    fn filename() -> Option<&'static str> {
-        Some("diagnostic_manifest.json")
-    }
+impl DiagnosticManifest {
+    pub const FILENAME: &'static str = "diagnostic_manifest.json";
 }
 
 impl From<Manifest> for DiagnosticManifest {

--- a/src/processor/diagnostic/diagnostic_manifest.rs
+++ b/src/processor/diagnostic/diagnostic_manifest.rs
@@ -3,10 +3,9 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use super::super::Identifiers;
-use super::{DataSource, DiagPath, Manifest, data_source::PathType};
+use super::{DataSource, DiagPath, Manifest};
 use crate::data::Product;
 use chrono::{DateTime, SecondsFormat, TimeZone, Utc};
-use eyre::{Result, eyre};
 use serde::{Deserialize, Serialize};
 use std::sync::RwLock;
 
@@ -164,15 +163,12 @@ impl DiagnosticManifest {
 }
 
 impl DataSource for DiagnosticManifest {
-    fn source(path: PathType, _version: Option<&semver::Version>) -> Result<String> {
-        match path {
-            PathType::File => Ok("diagnostic_manifest.json".to_string()),
-            _ => Err(eyre!("Unsupported source for manifest")),
-        }
-    }
-
     fn name() -> String {
         "diagnostic_manifest".to_string()
+    }
+
+    fn filename() -> Option<&'static str> {
+        Some("diagnostic_manifest.json")
     }
 }
 

--- a/src/processor/diagnostic/manifest.rs
+++ b/src/processor/diagnostic/manifest.rs
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use super::super::elasticsearch;
-use super::{DataSource, DiagPath};
+use super::DiagPath;
 use crate::data::Product;
 use eyre::Result;
 use serde::{Deserialize, Serialize};
@@ -143,12 +143,6 @@ impl TryFrom<elasticsearch::Cluster> for Manifest {
     }
 }
 
-impl DataSource for Manifest {
-    fn name() -> String {
-        "manifest".to_string()
-    }
-
-    fn filename() -> Option<&'static str> {
-        Some("manifest.json")
-    }
+impl Manifest {
+    pub const FILENAME: &'static str = "manifest.json";
 }

--- a/src/processor/diagnostic/manifest.rs
+++ b/src/processor/diagnostic/manifest.rs
@@ -3,9 +3,9 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use super::super::elasticsearch;
-use super::{DataSource, DiagPath, data_source::PathType};
+use super::{DataSource, DiagPath};
 use crate::data::Product;
-use eyre::{Result, eyre};
+use eyre::Result;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -144,14 +144,11 @@ impl TryFrom<elasticsearch::Cluster> for Manifest {
 }
 
 impl DataSource for Manifest {
-    fn source(path: PathType, _version: Option<&semver::Version>) -> Result<String> {
-        match path {
-            PathType::File => Ok("manifest.json".to_string()),
-            _ => Err(eyre!("Unsupported source for manifest")),
-        }
-    }
-
     fn name() -> String {
         "manifest".to_string()
+    }
+
+    fn filename() -> Option<&'static str> {
+        Some("manifest.json")
     }
 }

--- a/src/processor/diagnostic/mod.rs
+++ b/src/processor/diagnostic/mod.rs
@@ -17,7 +17,7 @@ pub mod manifest;
 /// Diagnostic job report
 pub mod report;
 
-pub use data_source::DataSource;
+pub use data_source::{DataSource, SourceContext};
 pub use data_stream_name::DataStreamName;
 pub use diagnostic_manifest::DiagnosticManifest;
 pub use doc::DiagnosticMetadata;

--- a/src/processor/diagnostic/mod.rs
+++ b/src/processor/diagnostic/mod.rs
@@ -17,7 +17,7 @@ pub mod manifest;
 /// Diagnostic job report
 pub mod report;
 
-pub use data_source::{DataSource, PathType};
+pub use data_source::DataSource;
 pub use data_stream_name::DataStreamName;
 pub use diagnostic_manifest::DiagnosticManifest;
 pub use doc::DiagnosticMetadata;

--- a/src/processor/elasticsearch/collector.rs
+++ b/src/processor/elasticsearch/collector.rs
@@ -4,7 +4,7 @@
 
 use super::super::{
     collector::{CollectOptions, CollectionResult},
-    diagnostic::data_source::resolve_file_path_for,
+    SourceContext,
 };
 use super::{
     AliasList, Cluster, ClusterSettings, DataSource, DataStreams, DiagnosticManifest, HealthReport,
@@ -248,7 +248,8 @@ impl ElasticsearchCollector {
                 return Err(e);
             }
         };
-        let path = PathBuf::from(resolve_file_path_for::<T>("elasticsearch")?);
+        let ctx = SourceContext::new("elasticsearch", None);
+        let path = PathBuf::from(T::resolve_source_file_path(&ctx)?);
         let filename = format!("{}", path.display());
         match self.exporter.save(path, content).await {
             Ok(()) => {
@@ -281,9 +282,7 @@ impl ElasticsearchCollector {
         .with_identifiers(self.options.identifiers.clone())
         .with_collected_apis(collected_api_names);
 
-        let path = PathBuf::from(
-            DiagnosticManifest::filename().expect("diagnostic manifest filename is fixed"),
-        );
+        let path = PathBuf::from(DiagnosticManifest::FILENAME);
         let filename = format!("{}", path.display());
         let content = serde_json::to_string_pretty(&manifest)?;
         self.exporter.save(path, content).await?;

--- a/src/processor/elasticsearch/collector.rs
+++ b/src/processor/elasticsearch/collector.rs
@@ -4,7 +4,7 @@
 
 use super::super::{
     collector::{CollectOptions, CollectionResult},
-    diagnostic::PathType,
+    diagnostic::data_source::resolve_file_path_for,
 };
 use super::{
     AliasList, Cluster, ClusterSettings, DataSource, DataStreams, DiagnosticManifest, HealthReport,
@@ -248,7 +248,7 @@ impl ElasticsearchCollector {
                 return Err(e);
             }
         };
-        let path = PathBuf::from(T::source(PathType::File, None)?);
+        let path = PathBuf::from(resolve_file_path_for::<T>("elasticsearch")?);
         let filename = format!("{}", path.display());
         match self.exporter.save(path, content).await {
             Ok(()) => {
@@ -281,7 +281,9 @@ impl ElasticsearchCollector {
         .with_identifiers(self.options.identifiers.clone())
         .with_collected_apis(collected_api_names);
 
-        let path = PathBuf::from(DiagnosticManifest::source(PathType::File, None)?);
+        let path = PathBuf::from(
+            DiagnosticManifest::filename().expect("diagnostic manifest filename is fixed"),
+        );
         let filename = format!("{}", path.display());
         let content = serde_json::to_string_pretty(&manifest)?;
         self.exporter.save(path, content).await?;

--- a/src/processor/logstash/collector.rs
+++ b/src/processor/logstash/collector.rs
@@ -13,7 +13,10 @@ use crate::{
     processor::{
         api::{ApiResolver, ApiWeight, DiagnosticType, LogstashApi},
         collector::{CollectOptions, CollectionResult},
-        diagnostic::{DataSource, DiagnosticManifest, data_source::PathType},
+        diagnostic::{
+            DataSource, DiagnosticManifest,
+            data_source::resolve_file_path_for,
+        },
     },
     receiver::Receiver,
 };
@@ -225,7 +228,7 @@ impl LogstashCollector {
             }
         };
 
-        let path = PathBuf::from(T::source(PathType::File, None)?);
+        let path = PathBuf::from(resolve_file_path_for::<T>("logstash")?);
         let filename = format!("{}", path.display());
         match self.exporter.save(path, content).await {
             Ok(()) => {
@@ -257,7 +260,9 @@ impl LogstashCollector {
         .with_identifiers(self.options.identifiers.clone())
         .with_collected_apis(collected_api_names);
 
-        let path = PathBuf::from(DiagnosticManifest::source(PathType::File, None)?);
+        let path = PathBuf::from(
+            DiagnosticManifest::filename().expect("diagnostic manifest filename is fixed"),
+        );
         let filename = format!("{}", path.display());
         let content = serde_json::to_string_pretty(&manifest)?;
         self.exporter.save(path, content).await?;

--- a/src/processor/logstash/collector.rs
+++ b/src/processor/logstash/collector.rs
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 use super::{
     node::Node,
     node_stats::NodeStats,

--- a/src/processor/logstash/collector.rs
+++ b/src/processor/logstash/collector.rs
@@ -242,7 +242,30 @@ impl LogstashCollector {
 
     async fn save_diagnostic_manifest(&self, apis: &[LogstashApi]) -> Result<usize> {
         let version = self.receiver.get::<Version>().await?;
-        let collected_api_names: Vec<String> = apis.iter().map(|a| a.as_str().to_string()).collect();
+        let parsed_version = semver::Version::parse(&version.version)?;
+        let collected_api_names: Vec<String> = apis
+            .iter()
+            .filter_map(|api| match api {
+                LogstashApi::Node => Some(api.as_str().to_string()),
+                LogstashApi::NodeStats => Some(api.as_str().to_string()),
+                LogstashApi::Raw(name, _) => {
+                    match crate::processor::diagnostic::data_source::get_source(
+                        "logstash",
+                        name,
+                        &[],
+                    ) {
+                        Ok((_, source_conf)) => {
+                            if source_conf.get_url(&parsed_version).is_ok() {
+                                Some(api.as_str().to_string())
+                            } else {
+                                None
+                            }
+                        }
+                        Err(_) => None,
+                    }
+                }
+            })
+            .collect();
 
         let manifest = DiagnosticManifest::new(
             chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),

--- a/src/processor/logstash/collector.rs
+++ b/src/processor/logstash/collector.rs
@@ -189,7 +189,7 @@ impl LogstashCollector {
             Ok(c) => c,
             Err(e) => {
                 log::warn!("Failed to get raw API {}: {}", name, e);
-                return Err(eyre::eyre!(e));
+                return Err(e);
             }
         };
 

--- a/src/processor/logstash/collector.rs
+++ b/src/processor/logstash/collector.rs
@@ -1,0 +1,263 @@
+use super::{
+    node::Node,
+    node_stats::NodeStats,
+    version::Version,
+};
+use crate::{
+    data::Product,
+    exporter::ArchiveExporter,
+    processor::{
+        api::{ApiResolver, ApiWeight, DiagnosticType, LogstashApi},
+        collector::{CollectOptions, CollectionResult},
+        diagnostic::{DataSource, DiagnosticManifest, data_source::PathType},
+    },
+    receiver::Receiver,
+};
+use eyre::{Result, WrapErr};
+use futures::stream::{self, StreamExt};
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::time::Duration;
+
+pub struct LogstashCollector {
+    receiver: Receiver,
+    exporter: ArchiveExporter,
+    options: CollectOptions,
+}
+
+impl LogstashCollector {
+    pub async fn new(
+        receiver: Receiver,
+        exporter: ArchiveExporter,
+        options: CollectOptions,
+    ) -> Result<Self> {
+        let timestamp = chrono::Local::now().format("%Y%m%d-%H%M%S").to_string();
+        let collection_name = options
+            .identifiers
+            .filename
+            .as_ref()
+            .and_then(|name| std::path::Path::new(name).file_stem())
+            .map(|stem| stem.to_string_lossy().to_string())
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| format!("api-diagnostics-{}", timestamp));
+        Ok(Self {
+            receiver,
+            exporter: exporter.with_archive_name(&collection_name)?,
+            options,
+        })
+    }
+
+    pub async fn collect(&self) -> Result<CollectionResult> {
+        let collect_result: Result<CollectionResult> = async {
+            let diag_type = DiagnosticType::from_str(&self.options.r#type)?;
+            let apis = ApiResolver::resolve_ls(
+                &diag_type,
+                self.options.include.as_ref(),
+                self.options.exclude.as_ref(),
+            )?;
+
+            let api_names: Vec<&str> = apis.iter().map(|a| a.as_str()).collect();
+            log::debug!("Resolved Logstash APIs for collection: {:?}", api_names);
+
+            let mut result = CollectionResult {
+                path: self.exporter.to_string(),
+                success: 0,
+                total: apis.len() + 1,
+            };
+
+            let mut heavy_apis = Vec::new();
+            let mut light_apis = Vec::new();
+
+            result.success += self.save_diagnostic_manifest(&apis).await?;
+
+            for api in apis {
+                if api.weight() == ApiWeight::Heavy {
+                    heavy_apis.push(api);
+                } else {
+                    light_apis.push(api);
+                }
+            }
+
+            let mut light_stream = stream::iter(light_apis)
+                .map(|api| async move { self.save_api_with_retry(&api).await })
+                .buffer_unordered(5);
+
+            while let Some(res) = light_stream.next().await {
+                result.success += res;
+            }
+
+            for api in heavy_apis {
+                result.success += self.save_api_with_retry(&api).await;
+            }
+
+            Ok(result)
+        }
+        .await;
+
+        let finalize_result = self.exporter.finalize();
+
+        match (collect_result, finalize_result) {
+            (Ok(result), Ok(())) => Ok(result),
+            (Err(err), Ok(())) => Err(err),
+            (Ok(_), Err(finalize_err)) => Err(finalize_err),
+            (Err(err), Err(finalize_err)) => {
+                Err(err).wrap_err(format!("Failed to finalize archive: {}", finalize_err))
+            }
+        }
+    }
+
+    async fn save_api_with_retry(&self, api: &LogstashApi) -> usize {
+        let max_duration = Duration::from_secs(300);
+        let start_time = std::time::Instant::now();
+        let mut attempt = 1;
+        let mut delay = Duration::from_secs(2);
+
+        loop {
+            match self.save_api(api).await {
+                Ok(success) => return success,
+                Err(e) => {
+                    if start_time.elapsed() > max_duration {
+                        log::error!(
+                            "Failed to save {} after {} attempts (5 min timeout): {}",
+                            api.as_str(),
+                            attempt,
+                            e
+                        );
+                        return 0;
+                    }
+                    log::warn!(
+                        "Attempt {} failed for {}: {}. Retrying in {:?}...",
+                        attempt,
+                        api.as_str(),
+                        e,
+                        delay
+                    );
+                    tokio::time::sleep(delay).await;
+                    attempt += 1;
+                    delay = std::cmp::min(delay * 2, Duration::from_secs(60));
+                }
+            }
+        }
+    }
+
+    async fn save_api(&self, api: &LogstashApi) -> Result<usize> {
+        match api {
+            LogstashApi::Node => self.save::<Node>().await,
+            LogstashApi::NodeStats => self.save::<NodeStats>().await,
+            LogstashApi::Raw(name, _) => self.save_raw(name).await,
+        }
+    }
+
+    async fn save_raw(&self, name: &str) -> Result<usize> {
+        let source_conf = match crate::processor::diagnostic::data_source::get_source(
+            "logstash",
+            name,
+            &[],
+        ) {
+            Ok((_, conf)) => conf,
+            Err(e) => {
+                log::debug!("Skipping {} collection: {}", name, e);
+                return Ok(0);
+            }
+        };
+
+        let version = match &self.receiver {
+            Receiver::Elasticsearch(r) => match r.get_version().await {
+                Ok(v) => v,
+                Err(e) => {
+                    log::debug!("Cannot collect raw API without version: {}", e);
+                    return Ok(0);
+                }
+            },
+            _ => return Ok(0),
+        };
+
+        let path = match source_conf.get_url(version) {
+            Ok(p) => p,
+            Err(e) => {
+                log::debug!("Skipping {} collection on version {}: {}", name, version, e);
+                return Ok(0);
+            }
+        };
+
+        let extension = source_conf.extension.as_deref().unwrap_or(".json");
+        let content = match self.receiver.get_raw_by_path(&path, extension).await {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("Failed to get raw API {}: {}", name, e);
+                return Err(eyre::eyre!(e));
+            }
+        };
+
+        let file_path = PathBuf::from(source_conf.get_file_path(name));
+        let filename = format!("{}", file_path.display());
+
+        match self.exporter.save(file_path, content).await {
+            Ok(()) => {
+                log::info!("Saved {filename}");
+                Ok(1)
+            }
+            Err(e) => {
+                log::error!("Failed to save {filename}: {e}");
+                Ok(0)
+            }
+        }
+    }
+
+    async fn save<T>(&self) -> Result<usize>
+    where
+        T: DataSource,
+    {
+        let content = match self.receiver.get_raw::<T>().await {
+            Ok(c) => c,
+            Err(e) => {
+                if let Some(ds_err) =
+                    e.downcast_ref::<crate::processor::diagnostic::data_source::DataSourceError>()
+                {
+                    log::debug!("Skipping {} collection: {}", T::name(), ds_err);
+                    return Ok(0);
+                }
+                return Err(e);
+            }
+        };
+
+        let path = PathBuf::from(T::source(PathType::File, None)?);
+        let filename = format!("{}", path.display());
+        match self.exporter.save(path, content).await {
+            Ok(()) => {
+                log::info!("Saved {filename}");
+                Ok(1)
+            }
+            Err(e) => {
+                log::error!("Failed to save {filename}: {e}");
+                Ok(0)
+            }
+        }
+    }
+
+    async fn save_diagnostic_manifest(&self, apis: &[LogstashApi]) -> Result<usize> {
+        let version = self.receiver.get::<Version>().await?;
+        let collected_api_names: Vec<String> = apis.iter().map(|a| a.as_str().to_string()).collect();
+
+        let manifest = DiagnosticManifest::new(
+            chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            Some(format!("esdiag-{}", env!("CARGO_PKG_VERSION"))),
+            None,
+            None,
+            Some(self.options.r#type.clone()),
+            Product::Logstash,
+            Some("logstash_diagnostic".to_string()),
+            Some("esdiag".to_string()),
+            Some(version.version),
+        )
+        .with_identifiers(self.options.identifiers.clone())
+        .with_collected_apis(collected_api_names);
+
+        let path = PathBuf::from(DiagnosticManifest::source(PathType::File, None)?);
+        let filename = format!("{}", path.display());
+        let content = serde_json::to_string_pretty(&manifest)?;
+        self.exporter.save(path, content).await?;
+        log::info!("Saved {filename}");
+        Ok(1)
+    }
+}

--- a/src/processor/logstash/collector.rs
+++ b/src/processor/logstash/collector.rs
@@ -13,10 +13,7 @@ use crate::{
     processor::{
         api::{ApiResolver, ApiWeight, DiagnosticType, LogstashApi},
         collector::{CollectOptions, CollectionResult},
-        diagnostic::{
-            DataSource, DiagnosticManifest,
-            data_source::resolve_file_path_for,
-        },
+        DataSource, DiagnosticManifest, SourceContext,
     },
     receiver::Receiver,
 };
@@ -169,7 +166,7 @@ impl LogstashCollector {
         };
 
         let version = match &self.receiver {
-            Receiver::Elasticsearch(r) => match r.get_version().await {
+            Receiver::Logstash(r) => match r.get_version().await {
                 Ok(v) => v,
                 Err(e) => {
                     log::debug!("Cannot collect raw API without version: {}", e);
@@ -228,7 +225,8 @@ impl LogstashCollector {
             }
         };
 
-        let path = PathBuf::from(resolve_file_path_for::<T>("logstash")?);
+        let ctx = SourceContext::new("logstash", None);
+        let path = PathBuf::from(T::resolve_source_file_path(&ctx)?);
         let filename = format!("{}", path.display());
         match self.exporter.save(path, content).await {
             Ok(()) => {
@@ -260,9 +258,7 @@ impl LogstashCollector {
         .with_identifiers(self.options.identifiers.clone())
         .with_collected_apis(collected_api_names);
 
-        let path = PathBuf::from(
-            DiagnosticManifest::filename().expect("diagnostic manifest filename is fixed"),
-        );
+        let path = PathBuf::from(DiagnosticManifest::FILENAME);
         let filename = format!("{}", path.display());
         let content = serde_json::to_string_pretty(&manifest)?;
         self.exporter.save(path, content).await?;

--- a/src/processor/logstash/hot_threads/data.rs
+++ b/src/processor/logstash/hot_threads/data.rs
@@ -38,8 +38,4 @@ impl DataSource for NodeHotThreads {
     fn aliases() -> Vec<&'static str> {
         vec!["logstash_nodes_hot_threads"]
     }
-
-    fn product() -> &'static str {
-        "logstash"
-    }
 }

--- a/src/processor/logstash/hot_threads/data.rs
+++ b/src/processor/logstash/hot_threads/data.rs
@@ -2,8 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::super::super::diagnostic::{DataSource, data_source::PathType};
-use eyre::Result;
+use super::super::super::diagnostic::DataSource;
 use serde::{Deserialize, Serialize};
 
 #[allow(dead_code)] // Future use for processing hot threads data
@@ -32,14 +31,15 @@ struct Thread {
 }
 
 impl DataSource for NodeHotThreads {
-    fn source(path: PathType, _version: Option<&semver::Version>) -> Result<String> {
-        match path {
-            PathType::File => Ok("logstash_nodes_hot_threads.json".to_string()),
-            PathType::Url => Ok("_node/hot_threads?threads=10000".to_string()),
-        }
-    }
-
     fn name() -> String {
         "hot_threads".to_string()
+    }
+
+    fn aliases() -> Vec<&'static str> {
+        vec!["logstash_nodes_hot_threads"]
+    }
+
+    fn product() -> &'static str {
+        "logstash"
     }
 }

--- a/src/processor/logstash/mod.rs
+++ b/src/processor/logstash/mod.rs
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
+/// Collector definition for Logstash diagnostics
+mod collector;
 /// Logstash hot threads
 mod hot_threads;
 /// Logstash diagnostic metadata
@@ -16,6 +18,7 @@ mod plugins;
 mod version;
 
 pub use metadata::LogstashMetadata;
+pub use collector::LogstashCollector;
 
 use super::{
     DiagnosticProcessor, DocumentExporter, Metadata, ProcessorSummary,

--- a/src/processor/logstash/mod.rs
+++ b/src/processor/logstash/mod.rs
@@ -17,8 +17,8 @@ mod plugins;
 /// Logstash version
 mod version;
 
-pub use metadata::LogstashMetadata;
 pub use collector::LogstashCollector;
+pub use metadata::LogstashMetadata;
 
 use super::{
     DiagnosticProcessor, DocumentExporter, Metadata, ProcessorSummary,

--- a/src/processor/logstash/node/data.rs
+++ b/src/processor/logstash/node/data.rs
@@ -30,7 +30,7 @@ impl Node {
 
 #[derive(Deserialize, Serialize)]
 pub struct Pipeline {
-    ephemeral_id: String,
+    ephemeral_id: Option<String>,
     hash: String,
     workers: u32,
     batch_size: u32,

--- a/src/processor/logstash/node/data.rs
+++ b/src/processor/logstash/node/data.rs
@@ -78,8 +78,4 @@ impl DataSource for Node {
     fn aliases() -> Vec<&'static str> {
         vec!["logstash_node"]
     }
-
-    fn product() -> &'static str {
-        "logstash"
-    }
 }

--- a/src/processor/logstash/node/data.rs
+++ b/src/processor/logstash/node/data.rs
@@ -2,8 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::super::super::diagnostic::{DataSource, data_source::PathType};
-use eyre::Result;
+use super::super::super::diagnostic::DataSource;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -72,14 +71,15 @@ struct Memory {
 }
 
 impl DataSource for Node {
-    fn source(path: PathType, _version: Option<&semver::Version>) -> Result<String> {
-        match path {
-            PathType::File => Ok("logstash_node.json".to_string()),
-            PathType::Url => Ok("_node".to_string()),
-        }
-    }
-
     fn name() -> String {
         "node".to_string()
+    }
+
+    fn aliases() -> Vec<&'static str> {
+        vec!["logstash_node"]
+    }
+
+    fn product() -> &'static str {
+        "logstash"
     }
 }

--- a/src/processor/logstash/node_stats/data.rs
+++ b/src/processor/logstash/node_stats/data.rs
@@ -127,7 +127,7 @@ pub struct PipelineStats {
     reloads: PipelineReloadStats,
     queue: PipelineQueueStats,
     hash: String,
-    ephemeral_id: String,
+    ephemeral_id: Option<String>,
 }
 
 impl PipelineStats {

--- a/src/processor/logstash/node_stats/data.rs
+++ b/src/processor/logstash/node_stats/data.rs
@@ -294,10 +294,6 @@ impl DataSource for NodeStats {
     fn aliases() -> Vec<&'static str> {
         vec!["logstash_node_stats"]
     }
-
-    fn product() -> &'static str {
-        "logstash"
-    }
 }
 
 #[derive(Serialize)]

--- a/src/processor/logstash/node_stats/data.rs
+++ b/src/processor/logstash/node_stats/data.rs
@@ -2,8 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::super::super::diagnostic::{DataSource, data_source::PathType};
-use eyre::Result;
+use super::super::super::diagnostic::DataSource;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -288,15 +287,16 @@ struct QueueStats {
 }
 
 impl DataSource for NodeStats {
-    fn source(path: PathType, _version: Option<&semver::Version>) -> Result<String> {
-        match path {
-            PathType::File => Ok("logstash_node_stats.json".to_string()),
-            PathType::Url => Ok("_node/stats".to_string()),
-        }
-    }
-
     fn name() -> String {
         "node_stats".to_string()
+    }
+
+    fn aliases() -> Vec<&'static str> {
+        vec!["logstash_node_stats"]
+    }
+
+    fn product() -> &'static str {
+        "logstash"
     }
 }
 

--- a/src/processor/logstash/plugins/data.rs
+++ b/src/processor/logstash/plugins/data.rs
@@ -26,8 +26,4 @@ impl DataSource for Plugins {
     fn aliases() -> Vec<&'static str> {
         vec!["logstash_plugins"]
     }
-
-    fn product() -> &'static str {
-        "logstash"
-    }
 }

--- a/src/processor/logstash/plugins/data.rs
+++ b/src/processor/logstash/plugins/data.rs
@@ -2,8 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::super::super::diagnostic::{DataSource, data_source::PathType};
-use eyre::Result;
+use super::super::super::diagnostic::DataSource;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]
@@ -20,14 +19,15 @@ pub struct Plugin {
 }
 
 impl DataSource for Plugins {
-    fn source(path: PathType, _version: Option<&semver::Version>) -> Result<String> {
-        match path {
-            PathType::File => Ok("logstash_plugins.json".to_string()),
-            PathType::Url => Ok("_node/plugins".to_string()),
-        }
-    }
-
     fn name() -> String {
         "plugins".to_string()
+    }
+
+    fn aliases() -> Vec<&'static str> {
+        vec!["logstash_plugins"]
+    }
+
+    fn product() -> &'static str {
+        "logstash"
     }
 }

--- a/src/processor/logstash/version/data.rs
+++ b/src/processor/logstash/version/data.rs
@@ -12,10 +12,11 @@ pub struct Version {
     http_address: String,
     pub id: String,
     pub name: String,
-    ephemeral_id: String,
-    status: String,
-    snapshot: bool,
-    pipeline: Pipeline,
+    ephemeral_id: Option<String>,
+    status: Option<String>,
+    snapshot: Option<bool>,
+    build_snapshot: Option<bool>,
+    pipeline: Option<Pipeline>,
 }
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/src/processor/logstash/version/data.rs
+++ b/src/processor/logstash/version/data.rs
@@ -2,14 +2,13 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::super::super::diagnostic::{DataSource, data_source::PathType};
-use eyre::Result;
+use super::super::super::diagnostic::DataSource;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct Version {
     host: String,
-    version: String,
+    pub version: String,
     http_address: String,
     pub id: String,
     pub name: String,
@@ -27,14 +26,15 @@ struct Pipeline {
 }
 
 impl DataSource for Version {
-    fn source(path: PathType, _version: Option<&semver::Version>) -> Result<String> {
-        match path {
-            PathType::File => Ok("logstash_version.json".to_string()),
-            PathType::Url => Ok("/".to_string()),
-        }
-    }
-
     fn name() -> String {
         "version".to_string()
+    }
+
+    fn aliases() -> Vec<&'static str> {
+        vec!["logstash_version"]
+    }
+
+    fn product() -> &'static str {
+        "logstash"
     }
 }

--- a/src/processor/logstash/version/data.rs
+++ b/src/processor/logstash/version/data.rs
@@ -33,8 +33,4 @@ impl DataSource for Version {
     fn aliases() -> Vec<&'static str> {
         vec!["logstash_version"]
     }
-
-    fn product() -> &'static str {
-        "logstash"
-    }
 }

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -18,7 +18,7 @@ mod logstash;
 
 pub use collector::Collector;
 pub use diagnostic::{
-    DataSource, DiagnosticManifest, DiagnosticReport, Manifest,
+    DataSource, DiagnosticManifest, DiagnosticReport, Manifest, SourceContext,
     data_source::init_sources,
     manifest::ManifestBuilder,
     report::{BatchResponse, Identifiers, ProcessorSummary},

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -19,7 +19,7 @@ mod logstash;
 pub use collector::Collector;
 pub use diagnostic::{
     DataSource, DiagnosticManifest, DiagnosticReport, Manifest,
-    data_source::{PathType, init_sources},
+    data_source::init_sources,
     manifest::ManifestBuilder,
     report::{BatchResponse, Identifiers, ProcessorSummary},
 };

--- a/src/receiver/archive.rs
+++ b/src/receiver/archive.rs
@@ -2,8 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use crate::processor::{DataSource, StreamingDataSource};
-use crate::processor::diagnostic::data_source::resolve_file_path_for;
+use crate::processor::{DataSource, SourceContext, StreamingDataSource};
 use eyre::Result;
 use futures::stream::{self, BoxStream};
 use serde::de::DeserializeOwned;
@@ -24,7 +23,7 @@ pub use file::*;
 pub async fn get_stream_from_archive<R, T>(
     archive: Arc<RwLock<ZipArchive<R>>>,
     subdir: Option<PathBuf>,
-    product: &'static str,
+    ctx: SourceContext,
 ) -> Result<BoxStream<'static, Result<T::Item>>>
 where
     R: Read + Seek + Send + Sync + 'static,
@@ -36,7 +35,7 @@ where
     let tx_err = tx.clone();
     let handle = tokio::task::spawn_blocking(move || {
         let mut archive_guard = archive.blocking_write();
-        let source_path = match resolve_file_path_for::<T>(product) {
+        let source_path = match T::resolve_source_file_path(&ctx) {
             Ok(s) => s,
             Err(e) => {
                 let _ = tx.blocking_send(Err(eyre::eyre!(e)));

--- a/src/receiver/archive.rs
+++ b/src/receiver/archive.rs
@@ -2,7 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use crate::processor::{PathType, StreamingDataSource};
+use crate::processor::{DataSource, StreamingDataSource};
+use crate::processor::diagnostic::data_source::resolve_file_path_for;
 use eyre::Result;
 use futures::stream::{self, BoxStream};
 use serde::de::DeserializeOwned;
@@ -23,10 +24,11 @@ pub use file::*;
 pub async fn get_stream_from_archive<R, T>(
     archive: Arc<RwLock<ZipArchive<R>>>,
     subdir: Option<PathBuf>,
+    product: &'static str,
 ) -> Result<BoxStream<'static, Result<T::Item>>>
 where
     R: Read + Seek + Send + Sync + 'static,
-    T: StreamingDataSource + DeserializeOwned,
+    T: StreamingDataSource + DeserializeOwned + DataSource,
     T::Item: DeserializeOwned + Send + 'static,
 {
     let (tx, rx) = mpsc::channel(100);
@@ -34,7 +36,7 @@ where
     let tx_err = tx.clone();
     let handle = tokio::task::spawn_blocking(move || {
         let mut archive_guard = archive.blocking_write();
-        let source_path = match T::source(PathType::File, None) {
+        let source_path = match resolve_file_path_for::<T>(product) {
             Ok(s) => s,
             Err(e) => {
                 let _ = tx.blocking_send(Err(eyre::eyre!(e)));

--- a/src/receiver/archive/bytes.rs
+++ b/src/receiver/archive/bytes.rs
@@ -4,8 +4,8 @@
 
 use super::resolve_archive_path;
 use crate::{
-    processor::diagnostic::data_source::get_source,
-    processor::{DataSource, PathType, StreamingDataSource},
+    processor::diagnostic::data_source::candidate_file_paths_for,
+    processor::{DataSource, StreamingDataSource},
     receiver::{Receive, ReceiveMultiple},
 };
 use bytes::Bytes;
@@ -16,6 +16,7 @@ use std::{
     io::{BufReader, Cursor},
     path::PathBuf,
     sync::Arc,
+    sync::OnceLock,
 };
 use tokio::sync::RwLock;
 use zip::ZipArchive;
@@ -27,6 +28,7 @@ type ArchivePointer = Arc<RwLock<ArchiveCursor>>;
 pub struct ArchiveBytesReceiver {
     archive: ArchivePointer,
     subdir: Option<PathBuf>,
+    source_product: Arc<OnceLock<&'static str>>,
 }
 
 /// A receiver for the Elastic Uploader service (https://upload.elastic.co).
@@ -50,7 +52,12 @@ impl Receive for ArchiveBytesReceiver {
         T: DataSource + DeserializeOwned,
     {
         let mut archive = self.archive.write().await;
-        let source_paths = candidate_file_paths::<T>()?;
+        let product = if T::filename().is_some() {
+            "elasticsearch"
+        } else {
+            self.source_product()?
+        };
+        let source_paths = candidate_file_paths_for::<T>(product)?;
         let mut last_resolve_error = None;
 
         for source_path in source_paths {
@@ -86,9 +93,15 @@ impl Receive for ArchiveBytesReceiver {
         T: StreamingDataSource + DeserializeOwned,
         T::Item: DeserializeOwned + Send + 'static,
     {
+        let product = if T::filename().is_some() {
+            "elasticsearch"
+        } else {
+            self.source_product()?
+        };
         super::get_stream_from_archive::<BufReader<Cursor<Bytes>>, T>(
             self.archive.clone(),
             self.subdir.clone(),
+            product,
         )
         .await
     }
@@ -111,6 +124,7 @@ impl TryFrom<Bytes> for ArchiveBytesReceiver {
         Ok(Self {
             archive: Arc::new(RwLock::new(archive)),
             subdir: None,
+            source_product: Arc::new(OnceLock::new()),
         })
     }
 }
@@ -121,18 +135,26 @@ impl std::fmt::Display for ArchiveBytesReceiver {
     }
 }
 
-fn candidate_file_paths<T: DataSource>() -> Result<Vec<String>> {
-    let mut paths = Vec::new();
-    paths.push(T::source(PathType::File, None)?);
-
-    for alias in T::aliases() {
-        if let Ok((matched_name, source_conf)) = get_source(T::product(), alias, &[]) {
-            let path = source_conf.get_file_path(matched_name);
-            if !paths.contains(&path) {
-                paths.push(path);
-            }
+impl ArchiveBytesReceiver {
+    pub fn set_source_product(&self, product: &'static str) -> Result<()> {
+        match self.source_product.get() {
+            Some(existing) if *existing != product => Err(eyre!(
+                "Archive receiver source product already set to {}, cannot change to {}",
+                existing,
+                product
+            )),
+            Some(_) => Ok(()),
+            None => self
+                .source_product
+                .set(product)
+                .map_err(|_| eyre!("Failed to initialize archive receiver source product")),
         }
     }
 
-    Ok(paths)
+    pub fn source_product(&self) -> Result<&'static str> {
+        self.source_product
+            .get()
+            .copied()
+            .ok_or_else(|| eyre!("Archive receiver source product is not initialized"))
+    }
 }

--- a/src/receiver/archive/bytes.rs
+++ b/src/receiver/archive/bytes.rs
@@ -4,8 +4,7 @@
 
 use super::resolve_archive_path;
 use crate::{
-    processor::diagnostic::data_source::candidate_file_paths_for,
-    processor::{DataSource, StreamingDataSource},
+    processor::{DataSource, SourceContext, StreamingDataSource},
     receiver::{Receive, ReceiveMultiple},
 };
 use bytes::Bytes;
@@ -52,12 +51,8 @@ impl Receive for ArchiveBytesReceiver {
         T: DataSource + DeserializeOwned,
     {
         let mut archive = self.archive.write().await;
-        let product = if T::filename().is_some() {
-            "elasticsearch"
-        } else {
-            self.source_product()?
-        };
-        let source_paths = candidate_file_paths_for::<T>(product)?;
+        let ctx = self.source_context()?;
+        let source_paths = T::candidate_source_file_paths(&ctx)?;
         let mut last_resolve_error = None;
 
         for source_path in source_paths {
@@ -93,15 +88,11 @@ impl Receive for ArchiveBytesReceiver {
         T: StreamingDataSource + DeserializeOwned,
         T::Item: DeserializeOwned + Send + 'static,
     {
-        let product = if T::filename().is_some() {
-            "elasticsearch"
-        } else {
-            self.source_product()?
-        };
+        let ctx = self.source_context()?;
         super::get_stream_from_archive::<BufReader<Cursor<Bytes>>, T>(
             self.archive.clone(),
             self.subdir.clone(),
-            product,
+            ctx,
         )
         .await
     }
@@ -136,6 +127,21 @@ impl std::fmt::Display for ArchiveBytesReceiver {
 }
 
 impl ArchiveBytesReceiver {
+    pub async fn read_bundle_json<T>(&self, filename: &str) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        let mut archive = self.archive.write().await;
+        let filename = resolve_archive_path(self.subdir.as_ref(), &mut *archive, filename)?;
+        log::debug!("Reading bundle file {}", filename);
+        let file = match archive.by_name(&filename) {
+            Ok(file) => file,
+            Err(_) => return Err(eyre!("Failed to read file {filename} from archive")),
+        };
+        let reader = BufReader::new(file);
+        serde_json::from_reader(reader).map_err(Into::into)
+    }
+
     pub fn set_source_product(&self, product: &'static str) -> Result<()> {
         match self.source_product.get() {
             Some(existing) if *existing != product => Err(eyre!(
@@ -156,5 +162,9 @@ impl ArchiveBytesReceiver {
             .get()
             .copied()
             .ok_or_else(|| eyre!("Archive receiver source product is not initialized"))
+    }
+
+    pub fn source_context(&self) -> Result<SourceContext> {
+        Ok(SourceContext::new(self.source_product()?, None))
     }
 }

--- a/src/receiver/archive/file.rs
+++ b/src/receiver/archive/file.rs
@@ -4,8 +4,8 @@
 
 use super::resolve_archive_path;
 use crate::{
-    processor::diagnostic::data_source::get_source,
-    processor::{DataSource, PathType, StreamingDataSource},
+    processor::diagnostic::data_source::candidate_file_paths_for,
+    processor::{DataSource, StreamingDataSource},
     receiver::{Receive, ReceiveMultiple, ReceiveRaw},
 };
 use eyre::{Result, eyre};
@@ -16,6 +16,7 @@ use std::{
     io::{BufReader, Read},
     path::PathBuf,
     sync::Arc,
+    sync::OnceLock,
     time::SystemTime,
 };
 use tokio::sync::RwLock;
@@ -27,6 +28,7 @@ pub struct ArchiveFileReceiver {
     filename: String,
     subdir: Option<PathBuf>,
     modified_date: SystemTime,
+    source_product: Arc<OnceLock<&'static str>>,
 }
 
 impl TryFrom<PathBuf> for ArchiveFileReceiver {
@@ -45,6 +47,7 @@ impl TryFrom<PathBuf> for ArchiveFileReceiver {
                     modified_date,
                     filename,
                     subdir: None,
+                    source_product: Arc::new(OnceLock::new()),
                 })
             }
             false => {
@@ -82,7 +85,12 @@ impl Receive for ArchiveFileReceiver {
         T: DeserializeOwned + DataSource,
     {
         let mut archive = self.archive.write().await;
-        let source_paths = candidate_file_paths::<T>()?;
+        let product = if T::filename().is_some() {
+            "elasticsearch"
+        } else {
+            self.source_product()?
+        };
+        let source_paths = candidate_file_paths_for::<T>(product)?;
         let mut last_resolve_error = None;
 
         for source_path in source_paths {
@@ -115,7 +123,17 @@ impl Receive for ArchiveFileReceiver {
         T: StreamingDataSource + DeserializeOwned,
         T::Item: DeserializeOwned + Send + 'static,
     {
-        super::get_stream_from_archive::<File, T>(self.archive.clone(), self.subdir.clone()).await
+        let product = if T::filename().is_some() {
+            "elasticsearch"
+        } else {
+            self.source_product()?
+        };
+        super::get_stream_from_archive::<File, T>(
+            self.archive.clone(),
+            self.subdir.clone(),
+            product,
+        )
+        .await
     }
 }
 
@@ -125,7 +143,12 @@ impl ReceiveRaw for ArchiveFileReceiver {
         T: DataSource,
     {
         let mut archive = self.archive.write().await;
-        let source_paths = candidate_file_paths::<T>()?;
+        let product = if T::filename().is_some() {
+            "elasticsearch"
+        } else {
+            self.source_product()?
+        };
+        let source_paths = candidate_file_paths_for::<T>(product)?;
         let mut last_resolve_error = None;
 
         for source_path in source_paths {
@@ -169,18 +192,26 @@ impl std::fmt::Display for ArchiveFileReceiver {
     }
 }
 
-fn candidate_file_paths<T: DataSource>() -> Result<Vec<String>> {
-    let mut paths = Vec::new();
-    paths.push(T::source(PathType::File, None)?);
-
-    for alias in T::aliases() {
-        if let Ok((matched_name, source_conf)) = get_source(T::product(), alias, &[]) {
-            let path = source_conf.get_file_path(matched_name);
-            if !paths.contains(&path) {
-                paths.push(path);
-            }
+impl ArchiveFileReceiver {
+    pub fn set_source_product(&self, product: &'static str) -> Result<()> {
+        match self.source_product.get() {
+            Some(existing) if *existing != product => Err(eyre!(
+                "Archive receiver source product already set to {}, cannot change to {}",
+                existing,
+                product
+            )),
+            Some(_) => Ok(()),
+            None => self
+                .source_product
+                .set(product)
+                .map_err(|_| eyre!("Failed to initialize archive receiver source product")),
         }
     }
 
-    Ok(paths)
+    pub fn source_product(&self) -> Result<&'static str> {
+        self.source_product
+            .get()
+            .copied()
+            .ok_or_else(|| eyre!("Archive receiver source product is not initialized"))
+    }
 }

--- a/src/receiver/archive/file.rs
+++ b/src/receiver/archive/file.rs
@@ -4,8 +4,7 @@
 
 use super::resolve_archive_path;
 use crate::{
-    processor::diagnostic::data_source::candidate_file_paths_for,
-    processor::{DataSource, StreamingDataSource},
+    processor::{DataSource, SourceContext, StreamingDataSource},
     receiver::{Receive, ReceiveMultiple, ReceiveRaw},
 };
 use eyre::{Result, eyre};
@@ -85,12 +84,8 @@ impl Receive for ArchiveFileReceiver {
         T: DeserializeOwned + DataSource,
     {
         let mut archive = self.archive.write().await;
-        let product = if T::filename().is_some() {
-            "elasticsearch"
-        } else {
-            self.source_product()?
-        };
-        let source_paths = candidate_file_paths_for::<T>(product)?;
+        let ctx = self.source_context()?;
+        let source_paths = T::candidate_source_file_paths(&ctx)?;
         let mut last_resolve_error = None;
 
         for source_path in source_paths {
@@ -123,15 +118,11 @@ impl Receive for ArchiveFileReceiver {
         T: StreamingDataSource + DeserializeOwned,
         T::Item: DeserializeOwned + Send + 'static,
     {
-        let product = if T::filename().is_some() {
-            "elasticsearch"
-        } else {
-            self.source_product()?
-        };
+        let ctx = self.source_context()?;
         super::get_stream_from_archive::<File, T>(
             self.archive.clone(),
             self.subdir.clone(),
-            product,
+            ctx,
         )
         .await
     }
@@ -143,12 +134,8 @@ impl ReceiveRaw for ArchiveFileReceiver {
         T: DataSource,
     {
         let mut archive = self.archive.write().await;
-        let product = if T::filename().is_some() {
-            "elasticsearch"
-        } else {
-            self.source_product()?
-        };
-        let source_paths = candidate_file_paths_for::<T>(product)?;
+        let ctx = self.source_context()?;
+        let source_paths = T::candidate_source_file_paths(&ctx)?;
         let mut last_resolve_error = None;
 
         for source_path in source_paths {
@@ -193,6 +180,18 @@ impl std::fmt::Display for ArchiveFileReceiver {
 }
 
 impl ArchiveFileReceiver {
+    pub async fn read_bundle_json<T>(&self, filename: &str) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        let mut archive = self.archive.write().await;
+        let filename = resolve_archive_path(self.subdir.as_ref(), &mut *archive, filename)?;
+        log::debug!("Reading bundle file {}", filename);
+        let file = archive.by_name(&filename)?;
+        let reader = BufReader::new(file);
+        serde_json::from_reader(reader).map_err(Into::into)
+    }
+
     pub fn set_source_product(&self, product: &'static str) -> Result<()> {
         match self.source_product.get() {
             Some(existing) if *existing != product => Err(eyre!(
@@ -213,5 +212,9 @@ impl ArchiveFileReceiver {
             .get()
             .copied()
             .ok_or_else(|| eyre!("Archive receiver source product is not initialized"))
+    }
+
+    pub fn source_context(&self) -> Result<SourceContext> {
+        Ok(SourceContext::new(self.source_product()?, None))
     }
 }

--- a/src/receiver/directory.rs
+++ b/src/receiver/directory.rs
@@ -2,9 +2,11 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::super::processor::{DataSource, PathType, StreamingDataSource};
+use super::super::processor::{DataSource, StreamingDataSource};
 use super::{Receive, ReceiveMultiple, ReceiveRaw};
-use crate::processor::diagnostic::data_source::get_source;
+use crate::processor::diagnostic::data_source::{
+    candidate_file_paths_for, resolve_file_path_for,
+};
 use eyre::{Result, eyre};
 use futures::stream::{self, BoxStream};
 use serde::de::DeserializeOwned;
@@ -12,6 +14,8 @@ use std::{
     fs::File,
     io::{BufReader, Read},
     path::PathBuf,
+    sync::Arc,
+    sync::OnceLock,
     time::SystemTime,
 };
 use tokio::sync::mpsc;
@@ -21,6 +25,7 @@ pub struct DirectoryReceiver {
     path: PathBuf,
     work_dir: String,
     modified_date: SystemTime,
+    source_product: Arc<OnceLock<&'static str>>,
 }
 
 impl TryFrom<PathBuf> for DirectoryReceiver {
@@ -34,6 +39,7 @@ impl TryFrom<PathBuf> for DirectoryReceiver {
                     path: path.clone(),
                     work_dir: String::from(""),
                     modified_date: path.metadata()?.modified()?,
+                    source_product: Arc::new(OnceLock::new()),
                 })
             }
             false => {
@@ -67,7 +73,12 @@ impl Receive for DirectoryReceiver {
     where
         T: DeserializeOwned + DataSource,
     {
-        let source_paths = candidate_file_paths::<T>()?;
+        let product = if T::filename().is_some() {
+            "elasticsearch"
+        } else {
+            self.source_product()?
+        };
+        let source_paths = candidate_file_paths_for::<T>(product)?;
         let mut last_open_error = None;
 
         for source_path in source_paths {
@@ -101,10 +112,16 @@ impl Receive for DirectoryReceiver {
         T: StreamingDataSource + DeserializeOwned,
         T::Item: DeserializeOwned + Send + 'static,
     {
+        let product = if T::filename().is_some() {
+            "elasticsearch"
+        } else {
+            self.source_product()?
+        };
+        let source_path = resolve_file_path_for::<T>(product)?;
         let filename = self
             .path
             .join(&self.work_dir)
-            .join(T::source(PathType::File, None)?);
+            .join(source_path);
         log::debug!("Streaming file: {}", &filename.display());
 
         let filename_clone = filename.clone();
@@ -142,7 +159,12 @@ impl ReceiveRaw for DirectoryReceiver {
     where
         T: DataSource,
     {
-        let source_paths = candidate_file_paths::<T>()?;
+        let product = if T::filename().is_some() {
+            "elasticsearch"
+        } else {
+            self.source_product()?
+        };
+        let source_paths = candidate_file_paths_for::<T>(product)?;
         let mut last_open_error = None;
 
         for source_path in source_paths {
@@ -186,18 +208,26 @@ impl std::fmt::Display for DirectoryReceiver {
     }
 }
 
-fn candidate_file_paths<T: DataSource>() -> Result<Vec<String>> {
-    let mut paths = Vec::new();
-    paths.push(T::source(PathType::File, None)?);
-
-    for alias in T::aliases() {
-        if let Ok((matched_name, source_conf)) = get_source(T::product(), alias, &[]) {
-            let path = source_conf.get_file_path(matched_name);
-            if !paths.contains(&path) {
-                paths.push(path);
-            }
+impl DirectoryReceiver {
+    pub fn set_source_product(&self, product: &'static str) -> Result<()> {
+        match self.source_product.get() {
+            Some(existing) if *existing != product => Err(eyre!(
+                "Directory receiver source product already set to {}, cannot change to {}",
+                existing,
+                product
+            )),
+            Some(_) => Ok(()),
+            None => self
+                .source_product
+                .set(product)
+                .map_err(|_| eyre!("Failed to initialize directory receiver source product")),
         }
     }
 
-    Ok(paths)
+    pub fn source_product(&self) -> Result<&'static str> {
+        self.source_product
+            .get()
+            .copied()
+            .ok_or_else(|| eyre!("Directory receiver source product is not initialized"))
+    }
 }

--- a/src/receiver/directory.rs
+++ b/src/receiver/directory.rs
@@ -2,11 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::super::processor::{DataSource, StreamingDataSource};
+use super::super::processor::{DataSource, SourceContext, StreamingDataSource};
 use super::{Receive, ReceiveMultiple, ReceiveRaw};
-use crate::processor::diagnostic::data_source::{
-    candidate_file_paths_for, resolve_file_path_for,
-};
 use eyre::{Result, eyre};
 use futures::stream::{self, BoxStream};
 use serde::de::DeserializeOwned;
@@ -73,12 +70,8 @@ impl Receive for DirectoryReceiver {
     where
         T: DeserializeOwned + DataSource,
     {
-        let product = if T::filename().is_some() {
-            "elasticsearch"
-        } else {
-            self.source_product()?
-        };
-        let source_paths = candidate_file_paths_for::<T>(product)?;
+        let ctx = self.source_context()?;
+        let source_paths = T::candidate_source_file_paths(&ctx)?;
         let mut last_open_error = None;
 
         for source_path in source_paths {
@@ -112,12 +105,8 @@ impl Receive for DirectoryReceiver {
         T: StreamingDataSource + DeserializeOwned,
         T::Item: DeserializeOwned + Send + 'static,
     {
-        let product = if T::filename().is_some() {
-            "elasticsearch"
-        } else {
-            self.source_product()?
-        };
-        let source_path = resolve_file_path_for::<T>(product)?;
+        let ctx = self.source_context()?;
+        let source_path = T::resolve_source_file_path(&ctx)?;
         let filename = self
             .path
             .join(&self.work_dir)
@@ -159,12 +148,8 @@ impl ReceiveRaw for DirectoryReceiver {
     where
         T: DataSource,
     {
-        let product = if T::filename().is_some() {
-            "elasticsearch"
-        } else {
-            self.source_product()?
-        };
-        let source_paths = candidate_file_paths_for::<T>(product)?;
+        let ctx = self.source_context()?;
+        let source_paths = T::candidate_source_file_paths(&ctx)?;
         let mut last_open_error = None;
 
         for source_path in source_paths {
@@ -209,6 +194,17 @@ impl std::fmt::Display for DirectoryReceiver {
 }
 
 impl DirectoryReceiver {
+    pub async fn read_bundle_json<T>(&self, filename: &str) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        let path = self.path.join(&self.work_dir).join(filename);
+        log::debug!("Reading bundle file: {}", path.display());
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+        serde_json::from_reader(reader).map_err(Into::into)
+    }
+
     pub fn set_source_product(&self, product: &'static str) -> Result<()> {
         match self.source_product.get() {
             Some(existing) if *existing != product => Err(eyre!(
@@ -229,5 +225,9 @@ impl DirectoryReceiver {
             .get()
             .copied()
             .ok_or_else(|| eyre!("Directory receiver source product is not initialized"))
+    }
+
+    pub fn source_context(&self) -> Result<SourceContext> {
+        Ok(SourceContext::new(self.source_product()?, None))
     }
 }

--- a/src/receiver/elastic_cloud_admin.rs
+++ b/src/receiver/elastic_cloud_admin.rs
@@ -3,11 +3,10 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use super::super::processor::{
-    DataSource, DiagnosticManifest, ElasticsearchCluster, ManifestBuilder,
+    DataSource, DiagnosticManifest, ElasticsearchCluster, ManifestBuilder, SourceContext,
 };
 use super::{Receive, ReceiveRaw};
 use crate::data::{Auth, KnownHost};
-use crate::processor::diagnostic::data_source::resolve_url_for;
 use eyre::Result;
 use reqwest::header::{ACCEPT, ACCEPT_ENCODING, AUTHORIZATION};
 use reqwest::{Client, ClientBuilder, header::HeaderMap};
@@ -44,7 +43,7 @@ impl ElasticCloudAdminReceiver {
         })
     }
 
-    async fn get_version(&self) -> Result<&semver::Version> {
+    pub async fn get_version(&self) -> Result<&semver::Version> {
         self.version
             .get_or_try_init(|| async {
                 log::debug!("Fetching version from {}", self.url);
@@ -109,8 +108,8 @@ impl Receive for ElasticCloudAdminReceiver {
     where
         T: DataSource + DeserializeOwned,
     {
-        let version = self.get_version().await.ok();
-        let source_path = resolve_url_for::<T>("elasticsearch", version)?;
+        let ctx = SourceContext::new("elasticsearch", self.get_version().await.ok().cloned());
+        let source_path = T::resolve_source_request_path(&ctx)?;
         // Prepend the API proxy base path
         let path = match source_path.as_str() {
             "/" => format!("{}/", self.url.path()),
@@ -143,8 +142,8 @@ impl ReceiveRaw for ElasticCloudAdminReceiver {
     where
         T: DataSource,
     {
-        let version = self.get_version().await.ok();
-        let source_path = resolve_url_for::<T>("elasticsearch", version)?;
+        let ctx = SourceContext::new("elasticsearch", self.get_version().await.ok().cloned());
+        let source_path = T::resolve_source_request_path(&ctx)?;
         // Prepend the API proxy base path
         let path = match source_path.as_str() {
             "/" => format!("{}/", self.url.path()),

--- a/src/receiver/elastic_cloud_admin.rs
+++ b/src/receiver/elastic_cloud_admin.rs
@@ -3,10 +3,11 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use super::super::processor::{
-    DataSource, DiagnosticManifest, ElasticsearchCluster, ManifestBuilder, PathType,
+    DataSource, DiagnosticManifest, ElasticsearchCluster, ManifestBuilder,
 };
 use super::{Receive, ReceiveRaw};
 use crate::data::{Auth, KnownHost};
+use crate::processor::diagnostic::data_source::resolve_url_for;
 use eyre::Result;
 use reqwest::header::{ACCEPT, ACCEPT_ENCODING, AUTHORIZATION};
 use reqwest::{Client, ClientBuilder, header::HeaderMap};
@@ -108,9 +109,8 @@ impl Receive for ElasticCloudAdminReceiver {
     where
         T: DataSource + DeserializeOwned,
     {
-        // Get the API URL path for the provided type
         let version = self.get_version().await.ok();
-        let source_path = T::source(PathType::Url, version)?;
+        let source_path = resolve_url_for::<T>("elasticsearch", version)?;
         // Prepend the API proxy base path
         let path = match source_path.as_str() {
             "/" => format!("{}/", self.url.path()),
@@ -143,9 +143,8 @@ impl ReceiveRaw for ElasticCloudAdminReceiver {
     where
         T: DataSource,
     {
-        // Get the API URL path for the provided type
         let version = self.get_version().await.ok();
-        let source_path = T::source(PathType::Url, version)?;
+        let source_path = resolve_url_for::<T>("elasticsearch", version)?;
         // Prepend the API proxy base path
         let path = match source_path.as_str() {
             "/" => format!("{}/", self.url.path()),

--- a/src/receiver/elasticsearch.rs
+++ b/src/receiver/elasticsearch.rs
@@ -54,8 +54,11 @@ impl ElasticsearchReceiver {
                 let cluster: Value = serde_json::from_slice(&bytes)?;
                 let version_str = cluster
                     .get("version")
-                    .and_then(|v| v.get("number"))
-                    .and_then(|v| v.as_str())
+                    .and_then(|version| {
+                        version
+                            .as_str()
+                            .or_else(|| version.get("number").and_then(|number| number.as_str()))
+                    })
                     .ok_or_else(|| eyre!("No version found in root response"))?;
                 semver::Version::parse(version_str)
                     .map_err(|e| eyre!("Failed to parse version: {}", e))

--- a/src/receiver/elasticsearch.rs
+++ b/src/receiver/elasticsearch.rs
@@ -54,11 +54,7 @@ impl ElasticsearchReceiver {
                 let cluster: Value = serde_json::from_slice(&bytes)?;
                 let version_str = cluster
                     .get("version")
-                    .and_then(|version| {
-                        version
-                            .as_str()
-                            .or_else(|| version.get("number").and_then(|number| number.as_str()))
-                    })
+                    .and_then(|version| version.get("number").and_then(|number| number.as_str()))
                     .ok_or_else(|| eyre!("No version found in root response"))?;
                 semver::Version::parse(version_str)
                     .map_err(|e| eyre!("Failed to parse version: {}", e))

--- a/src/receiver/elasticsearch.rs
+++ b/src/receiver/elasticsearch.rs
@@ -3,11 +3,13 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use super::super::processor::{
-    DataSource, DiagnosticManifest, ElasticsearchCluster, ManifestBuilder, PathType,
-    StreamingDataSource,
+    DataSource, DiagnosticManifest, ElasticsearchCluster, ManifestBuilder, StreamingDataSource,
 };
 use super::{Receive, ReceiveRaw};
 use crate::data::KnownHost;
+use crate::processor::diagnostic::data_source::{
+    resolve_extension_for, resolve_url_for,
+};
 use elasticsearch::{Elasticsearch, http};
 use eyre::{Result, eyre};
 use futures::stream::BoxStream;
@@ -151,9 +153,8 @@ impl Receive for ElasticsearchReceiver {
     where
         T: DataSource + DeserializeOwned,
     {
-        // Get the API URL path for the provided type
         let version = self.get_version().await.ok();
-        let path = T::source(PathType::Url, version)?;
+        let path = resolve_url_for::<T>("elasticsearch", version)?;
         log::debug!("Getting API: {}", &path);
 
         // Send a simple GET request to the API path
@@ -219,17 +220,11 @@ impl ReceiveRaw for ElasticsearchReceiver {
     where
         T: DataSource,
     {
-        // Get the API URL path for the provided type
         let version = self.get_version().await.ok();
-        let path = T::source(PathType::Url, version)?;
+        let path = resolve_url_for::<T>("elasticsearch", version)?;
+        let extension = resolve_extension_for::<T>("elasticsearch")?;
 
-        let name = T::name();
-        let aliases = T::aliases();
-        let source_conf =
-            crate::processor::diagnostic::data_source::get_source(T::product(), &name, &aliases)?;
-        let extension = source_conf.1.extension.as_deref().unwrap_or(".json");
-
-        self.get_raw_by_path(&path, extension).await
+        self.get_raw_by_path(&path, &extension).await
     }
 }
 

--- a/src/receiver/elasticsearch.rs
+++ b/src/receiver/elasticsearch.rs
@@ -3,13 +3,11 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use super::super::processor::{
-    DataSource, DiagnosticManifest, ElasticsearchCluster, ManifestBuilder, StreamingDataSource,
+    DataSource, DiagnosticManifest, ElasticsearchCluster, ManifestBuilder, SourceContext,
+    StreamingDataSource,
 };
 use super::{Receive, ReceiveRaw};
 use crate::data::KnownHost;
-use crate::processor::diagnostic::data_source::{
-    resolve_extension_for, resolve_url_for,
-};
 use elasticsearch::{Elasticsearch, http};
 use eyre::{Result, eyre};
 use futures::stream::BoxStream;
@@ -153,8 +151,8 @@ impl Receive for ElasticsearchReceiver {
     where
         T: DataSource + DeserializeOwned,
     {
-        let version = self.get_version().await.ok();
-        let path = resolve_url_for::<T>("elasticsearch", version)?;
+        let ctx = SourceContext::new("elasticsearch", self.get_version().await.ok().cloned());
+        let path = T::resolve_source_request_path(&ctx)?;
         log::debug!("Getting API: {}", &path);
 
         // Send a simple GET request to the API path
@@ -220,9 +218,9 @@ impl ReceiveRaw for ElasticsearchReceiver {
     where
         T: DataSource,
     {
-        let version = self.get_version().await.ok();
-        let path = resolve_url_for::<T>("elasticsearch", version)?;
-        let extension = resolve_extension_for::<T>("elasticsearch")?;
+        let ctx = SourceContext::new("elasticsearch", self.get_version().await.ok().cloned());
+        let path = T::resolve_source_request_path(&ctx)?;
+        let extension = T::resolve_source_extension(&ctx)?;
 
         self.get_raw_by_path(&path, &extension).await
     }

--- a/src/receiver/logstash.rs
+++ b/src/receiver/logstash.rs
@@ -2,11 +2,10 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::super::processor::{DataSource, DiagnosticManifest};
+use super::super::processor::{DataSource, DiagnosticManifest, SourceContext};
 use super::{Receive, ReceiveRaw};
 use crate::client::LogstashClient;
 use crate::data::{KnownHost, Product};
-use crate::processor::diagnostic::data_source::{resolve_extension_for, resolve_url_for};
 use eyre::{Result, eyre};
 use futures::stream::BoxStream;
 use reqwest::Method;
@@ -91,8 +90,8 @@ impl Receive for LogstashReceiver {
     where
         T: DataSource + DeserializeOwned,
     {
-        let version = self.get_version().await.ok();
-        let path = resolve_url_for::<T>("logstash", version)?;
+        let ctx = SourceContext::new("logstash", self.get_version().await.ok().cloned());
+        let path = T::resolve_source_request_path(&ctx)?;
         log::debug!("Getting Logstash API: {}", &path);
 
         let response = self
@@ -139,9 +138,9 @@ impl ReceiveRaw for LogstashReceiver {
     where
         T: DataSource,
     {
-        let version = self.get_version().await.ok();
-        let path = resolve_url_for::<T>("logstash", version)?;
-        let extension = resolve_extension_for::<T>("logstash")?;
+        let ctx = SourceContext::new("logstash", self.get_version().await.ok().cloned());
+        let path = T::resolve_source_request_path(&ctx)?;
+        let extension = T::resolve_source_extension(&ctx)?;
         self.get_raw_by_path(&path, &extension).await
     }
 }

--- a/src/receiver/logstash.rs
+++ b/src/receiver/logstash.rs
@@ -1,0 +1,153 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+use super::super::processor::{DataSource, DiagnosticManifest};
+use super::{Receive, ReceiveRaw};
+use crate::client::LogstashClient;
+use crate::data::{KnownHost, Product};
+use crate::processor::diagnostic::data_source::{resolve_extension_for, resolve_url_for};
+use eyre::{Result, eyre};
+use futures::stream::BoxStream;
+use reqwest::Method;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
+use url::Url;
+
+#[derive(Clone)]
+pub struct LogstashReceiver {
+    client: LogstashClient,
+    url: Url,
+    version: Arc<OnceCell<semver::Version>>,
+}
+
+impl LogstashReceiver {
+    pub async fn get_version(&self) -> Result<&semver::Version> {
+        self.version
+            .get_or_try_init(|| async {
+                log::debug!("Fetching Logstash version from {}", self.url);
+                let response = self
+                    .client
+                    .request(Method::GET, &HashMap::new(), "/", None)
+                    .await?;
+                let body: Value = response.json().await?;
+                let version_str = body
+                    .get("version")
+                    .and_then(|version| version.as_str())
+                    .ok_or_else(|| eyre!("No version found in Logstash root response"))?;
+                semver::Version::parse(version_str)
+                    .map_err(|e| eyre!("Failed to parse Logstash version: {}", e))
+            })
+            .await
+    }
+
+    pub async fn get_raw_by_path(&self, path: &str, extension: &str) -> Result<String> {
+        log::debug!("Getting raw Logstash API path: {}", path);
+
+        let accept = if extension == ".txt" {
+            "text/plain"
+        } else {
+            "application/json"
+        };
+        let headers = HashMap::from([("Accept".to_string(), accept.to_string())]);
+        let response = self.client.request(Method::GET, &headers, path, None).await?;
+
+        response.text().await.map_err(Into::into)
+    }
+}
+
+impl TryFrom<KnownHost> for LogstashReceiver {
+    type Error = eyre::Report;
+
+    fn try_from(host: KnownHost) -> Result<Self> {
+        let url = host.get_url();
+        let client = LogstashClient::try_from(host)?;
+        Ok(Self {
+            client,
+            url,
+            version: Arc::new(OnceCell::new()),
+        })
+    }
+}
+
+impl Receive for LogstashReceiver {
+    async fn collection_date(&self) -> String {
+        chrono::Utc::now().to_rfc3339()
+    }
+
+    async fn is_connected(&self) -> bool {
+        log::debug!("Testing Logstash receiver connection");
+        self.client.test_connection().await.is_ok()
+    }
+
+    fn filename(&self) -> Option<String> {
+        None
+    }
+
+    async fn get<T>(&self) -> Result<T>
+    where
+        T: DataSource + DeserializeOwned,
+    {
+        let version = self.get_version().await.ok();
+        let path = resolve_url_for::<T>("logstash", version)?;
+        log::debug!("Getting Logstash API: {}", &path);
+
+        let response = self
+            .client
+            .request(Method::GET, &HashMap::new(), &path, None)
+            .await?;
+
+        match response.status() {
+            reqwest::StatusCode::OK => response.json::<T>().await.map_err(Into::into),
+            status => {
+                let body = response.text().await.unwrap_or_default();
+                log::debug!("Failed to get Logstash API response: {}", body);
+                Err(eyre!("http {} - {}", status, body))
+            }
+        }
+    }
+
+    async fn get_stream<T>(&self) -> Result<BoxStream<'static, Result<T::Item>>>
+    where
+        T: super::super::processor::StreamingDataSource + DeserializeOwned,
+        T::Item: DeserializeOwned + Send + 'static,
+    {
+        Err(eyre!("Streaming is not yet implemented for Logstash receiver"))
+    }
+
+    async fn try_get_manifest(&self) -> Result<DiagnosticManifest> {
+        let version = self.get_version().await?;
+        Ok(DiagnosticManifest::new(
+            chrono::Utc::now().to_rfc3339(),
+            Some(format!("esdiag-{}", env!("CARGO_PKG_VERSION"))),
+            None,
+            None,
+            None,
+            Product::Logstash,
+            Some("logstash_diagnostic".to_string()),
+            Some("esdiag".to_string()),
+            Some(version.to_string()),
+        ))
+    }
+}
+
+impl ReceiveRaw for LogstashReceiver {
+    async fn get_raw<T>(&self) -> Result<String>
+    where
+        T: DataSource,
+    {
+        let version = self.get_version().await.ok();
+        let path = resolve_url_for::<T>("logstash", version)?;
+        let extension = resolve_extension_for::<T>("logstash")?;
+        self.get_raw_by_path(&path, &extension).await
+    }
+}
+
+impl std::fmt::Display for LogstashReceiver {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Logstash {}", self.url)
+    }
+}

--- a/src/receiver/mod.rs
+++ b/src/receiver/mod.rs
@@ -21,8 +21,7 @@ pub use logstash::LogstashReceiver;
 use super::{
     data::{KnownHost, Product, Uri},
     processor::{
-        DataSource, DiagnosticManifest, ElasticsearchCluster, Manifest, ManifestBuilder,
-        StreamingDataSource,
+        DataSource, DiagnosticManifest, Manifest, SourceContext, StreamingDataSource,
     },
 };
 use archive::{ArchiveBytesReceiver, ArchiveFileReceiver};
@@ -47,28 +46,7 @@ pub trait Receive {
         Err(eyre!("Streaming is not supported for this receiver"))
     }
     async fn try_get_manifest(&self) -> Result<DiagnosticManifest> {
-        match self.get::<DiagnosticManifest>().await {
-            Ok(manifest) => {
-                log::debug!("Using diagnostic_manifest.json");
-                return Ok(manifest);
-            }
-            Err(e) => log::debug!("Error reading diagnostic_manifest.json: {e}"),
-        }
-
-        match self.get::<Manifest>().await {
-            Ok(manifest) => {
-                log::warn!("Falling back to manifest.json");
-                return Ok(manifest.into());
-            }
-            Err(e) => log::debug!("Error reading manifest.json: {e}"),
-        }
-
-        let cluster = self.get::<ElasticsearchCluster>().await?;
-        let collection_date = self.collection_date().await;
-        Ok(ManifestBuilder::from(cluster)
-            .collection_date(collection_date)
-            .build()
-            .into())
+        Err(eyre!("Manifest synthesis is not supported for this receiver"))
     }
 }
 
@@ -111,6 +89,25 @@ pub enum Receiver {
 }
 
 impl Receiver {
+    pub async fn source_context(&self) -> Result<SourceContext> {
+        match self {
+            Receiver::ArchiveBytes(receiver) => receiver.source_context(),
+            Receiver::ArchiveFile(receiver) => receiver.source_context(),
+            Receiver::Directory(receiver) => receiver.source_context(),
+            Receiver::Elasticsearch(receiver) => Ok(SourceContext::new(
+                "elasticsearch",
+                Some(receiver.get_version().await?.clone()),
+            )),
+            Receiver::Logstash(receiver) => {
+                Ok(SourceContext::new("logstash", Some(receiver.get_version().await?.clone())))
+            }
+            Receiver::ElasticCloudAdmin(receiver) => Ok(SourceContext::new(
+                "elasticsearch",
+                Some(receiver.get_version().await?.clone()),
+            )),
+        }
+    }
+
     pub async fn get<T>(&self) -> Result<T>
     where
         T: DataSource + DeserializeOwned,
@@ -212,9 +209,9 @@ impl Receiver {
 
     pub async fn try_get_manifest(&self) -> Result<DiagnosticManifest> {
         let manifest = match self {
-            Receiver::ArchiveBytes(receiver) => receiver.try_get_manifest().await,
-            Receiver::ArchiveFile(receiver) => receiver.try_get_manifest().await,
-            Receiver::Directory(receiver) => receiver.try_get_manifest().await,
+            Receiver::ArchiveBytes(_)
+            | Receiver::ArchiveFile(_)
+            | Receiver::Directory(_) => self.try_get_manifest_from_files().await,
             Receiver::Elasticsearch(receiver) => receiver.try_get_manifest().await,
             Receiver::Logstash(receiver) => receiver.try_get_manifest().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.try_get_manifest().await,
@@ -224,7 +221,10 @@ impl Receiver {
     }
 
     pub async fn try_get_manifest_from_files(&self) -> Result<DiagnosticManifest> {
-        match self.get::<DiagnosticManifest>().await {
+        match self
+            .read_bundle_json::<DiagnosticManifest>(DiagnosticManifest::FILENAME)
+            .await
+        {
             Ok(manifest) => {
                 log::debug!("Using diagnostic_manifest.json");
                 self.set_source_product_from_manifest(&manifest.product)?;
@@ -233,7 +233,7 @@ impl Receiver {
             Err(e) => log::debug!("Error reading diagnostic_manifest.json: {e}"),
         }
 
-        match self.get::<Manifest>().await {
+        match self.read_bundle_json::<Manifest>(Manifest::FILENAME).await {
             Ok(manifest) => {
                 log::warn!("Falling back to manifest.json");
                 let manifest: DiagnosticManifest = manifest.into();
@@ -244,6 +244,18 @@ impl Receiver {
                 "Failed to identify product from diagnostic manifest: {}",
                 e
             )),
+        }
+    }
+
+    pub async fn read_bundle_json<T>(&self, filename: &str) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        match self {
+            Receiver::ArchiveBytes(receiver) => receiver.read_bundle_json(filename).await,
+            Receiver::ArchiveFile(receiver) => receiver.read_bundle_json(filename).await,
+            Receiver::Directory(receiver) => receiver.read_bundle_json(filename).await,
+            _ => Err(eyre!("Bundle file reads are only supported for archive and directory receivers")),
         }
     }
 

--- a/src/receiver/mod.rs
+++ b/src/receiver/mod.rs
@@ -10,13 +10,16 @@ mod directory;
 mod elastic_cloud_admin;
 /// Request API calls from Elasticsearch
 mod elasticsearch;
+/// Request API calls from Logstash
+mod logstash;
 /// Get file from https://upload.elastic.co/
 mod upload_service;
 
 pub use elasticsearch::ElasticsearchReceiver;
+pub use logstash::LogstashReceiver;
 
 use super::{
-    data::{KnownHost, Uri},
+    data::{KnownHost, Product, Uri},
     processor::{
         DataSource, DiagnosticManifest, ElasticsearchCluster, Manifest, ManifestBuilder,
         StreamingDataSource,
@@ -101,6 +104,8 @@ pub enum Receiver {
     Directory(DirectoryReceiver),
     /// Request API calls from Elasticsearch
     Elasticsearch(ElasticsearchReceiver),
+    /// Request API calls from Logstash
+    Logstash(LogstashReceiver),
     /// Request API calls from Elastic Cloud admin
     ElasticCloudAdmin(ElasticCloudAdminReceiver),
 }
@@ -115,6 +120,7 @@ impl Receiver {
             Receiver::ArchiveFile(receiver) => receiver.get::<T>().await,
             Receiver::Directory(receiver) => receiver.get::<T>().await,
             Receiver::Elasticsearch(receiver) => receiver.get::<T>().await,
+            Receiver::Logstash(receiver) => receiver.get::<T>().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.get::<T>().await,
         }
     }
@@ -129,6 +135,7 @@ impl Receiver {
             Receiver::ArchiveFile(receiver) => receiver.get_stream::<T>().await,
             Receiver::Directory(receiver) => receiver.get_stream::<T>().await,
             Receiver::Elasticsearch(receiver) => receiver.get_stream::<T>().await,
+            Receiver::Logstash(receiver) => receiver.get_stream::<T>().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.get_stream::<T>().await,
         }
     }
@@ -139,6 +146,7 @@ impl Receiver {
     {
         match self {
             Receiver::Elasticsearch(receiver) => receiver.get_raw::<T>().await,
+            Receiver::Logstash(receiver) => receiver.get_raw::<T>().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.get_raw::<T>().await,
             _ => Err(eyre!("Raw data is not supported for this receiver")),
         }
@@ -147,8 +155,9 @@ impl Receiver {
     pub async fn get_raw_by_path(&self, path: &str, extension: &str) -> Result<String> {
         match self {
             Receiver::Elasticsearch(receiver) => receiver.get_raw_by_path(path, extension).await,
+            Receiver::Logstash(receiver) => receiver.get_raw_by_path(path, extension).await,
             _ => Err(eyre!(
-                "Raw data by path is only supported for Elasticsearch receiver"
+                "Raw data by path is only supported for API receivers"
             )),
         }
     }
@@ -159,6 +168,7 @@ impl Receiver {
             Receiver::ArchiveFile(receiver) => receiver.is_connected().await,
             Receiver::Directory(receiver) => receiver.is_connected().await,
             Receiver::Elasticsearch(receiver) => receiver.is_connected().await,
+            Receiver::Logstash(receiver) => receiver.is_connected().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.is_connected().await,
         }
     }
@@ -184,6 +194,7 @@ impl Receiver {
             Receiver::ArchiveFile(receiver) => receiver.collection_date().await,
             Receiver::Directory(receiver) => receiver.collection_date().await,
             Receiver::Elasticsearch(receiver) => receiver.collection_date().await,
+            Receiver::Logstash(receiver) => receiver.collection_date().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.collection_date().await,
         }
     }
@@ -194,24 +205,29 @@ impl Receiver {
             Receiver::ArchiveFile(receiver) => receiver.filename(),
             Receiver::Directory(receiver) => receiver.filename(),
             Receiver::Elasticsearch(receiver) => receiver.filename(),
+            Receiver::Logstash(receiver) => receiver.filename(),
             Receiver::ElasticCloudAdmin(receiver) => receiver.filename(),
         }
     }
 
     pub async fn try_get_manifest(&self) -> Result<DiagnosticManifest> {
-        match self {
+        let manifest = match self {
             Receiver::ArchiveBytes(receiver) => receiver.try_get_manifest().await,
             Receiver::ArchiveFile(receiver) => receiver.try_get_manifest().await,
             Receiver::Directory(receiver) => receiver.try_get_manifest().await,
             Receiver::Elasticsearch(receiver) => receiver.try_get_manifest().await,
+            Receiver::Logstash(receiver) => receiver.try_get_manifest().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.try_get_manifest().await,
-        }
+        }?;
+        self.set_source_product_from_manifest(&manifest.product)?;
+        Ok(manifest)
     }
 
     pub async fn try_get_manifest_from_files(&self) -> Result<DiagnosticManifest> {
         match self.get::<DiagnosticManifest>().await {
             Ok(manifest) => {
                 log::debug!("Using diagnostic_manifest.json");
+                self.set_source_product_from_manifest(&manifest.product)?;
                 return Ok(manifest);
             }
             Err(e) => log::debug!("Error reading diagnostic_manifest.json: {e}"),
@@ -220,12 +236,28 @@ impl Receiver {
         match self.get::<Manifest>().await {
             Ok(manifest) => {
                 log::warn!("Falling back to manifest.json");
-                Ok(manifest.into())
+                let manifest: DiagnosticManifest = manifest.into();
+                self.set_source_product_from_manifest(&manifest.product)?;
+                Ok(manifest)
             }
             Err(e) => Err(eyre!(
                 "Failed to identify product from diagnostic manifest: {}",
                 e
             )),
+        }
+    }
+
+    fn set_source_product_from_manifest(&self, product: &Product) -> Result<()> {
+        let Ok(product) = crate::processor::diagnostic::data_source::source_product_key(product)
+        else {
+            return Ok(());
+        };
+
+        match self {
+            Receiver::ArchiveBytes(receiver) => receiver.set_source_product(product),
+            Receiver::ArchiveFile(receiver) => receiver.set_source_product(product),
+            Receiver::Directory(receiver) => receiver.set_source_product(product),
+            _ => Ok(()),
         }
     }
 }
@@ -242,7 +274,13 @@ impl TryFrom<Uri> for Receiver {
                 Receiver::ElasticCloudAdmin(ElasticCloudAdminReceiver::try_from(host)?)
             }
             Uri::File(file) => Receiver::ArchiveFile(ArchiveFileReceiver::try_from(file)?),
-            Uri::KnownHost(host) => Receiver::Elasticsearch(ElasticsearchReceiver::try_from(host)?),
+            Uri::KnownHost(host) => match host.app() {
+                Product::Elasticsearch => {
+                    Receiver::Elasticsearch(ElasticsearchReceiver::try_from(host)?)
+                }
+                Product::Logstash => Receiver::Logstash(LogstashReceiver::try_from(host)?),
+                _ => return Err(eyre!("Unsupported known-host receiver product: {}", host.app())),
+            },
             Uri::ServiceLink(url) => {
                 Receiver::ArchiveBytes(UploadServiceDownloader::try_from(url)?.download()?)
             }
@@ -276,6 +314,7 @@ impl std::fmt::Display for Receiver {
             Receiver::ArchiveFile(receiver) => write!(f, "Archive File {receiver}"),
             Receiver::Directory(receiver) => write!(f, "Directory {receiver}"),
             Receiver::Elasticsearch(receiver) => write!(f, "Elasticsearch {receiver}"),
+            Receiver::Logstash(receiver) => write!(f, "Logstash {receiver}"),
             Receiver::ElasticCloudAdmin(receiver) => {
                 write!(f, "ElasticCloudAdmin {receiver}")
             }

--- a/src/receiver/mod.rs
+++ b/src/receiver/mod.rs
@@ -207,6 +207,27 @@ impl Receiver {
             Receiver::ElasticCloudAdmin(receiver) => receiver.try_get_manifest().await,
         }
     }
+
+    pub async fn try_get_manifest_without_fallback(&self) -> Result<DiagnosticManifest> {
+        match self.get::<DiagnosticManifest>().await {
+            Ok(manifest) => {
+                log::debug!("Using diagnostic_manifest.json");
+                return Ok(manifest);
+            }
+            Err(e) => log::debug!("Error reading diagnostic_manifest.json: {e}"),
+        }
+
+        match self.get::<Manifest>().await {
+            Ok(manifest) => {
+                log::warn!("Falling back to manifest.json");
+                Ok(manifest.into())
+            }
+            Err(e) => Err(eyre!(
+                "Failed to identify product from diagnostic manifest: {}",
+                e
+            )),
+        }
+    }
 }
 
 impl TryFrom<Uri> for Receiver {

--- a/src/receiver/mod.rs
+++ b/src/receiver/mod.rs
@@ -208,7 +208,7 @@ impl Receiver {
         }
     }
 
-    pub async fn try_get_manifest_without_fallback(&self) -> Result<DiagnosticManifest> {
+    pub async fn try_get_manifest_from_files(&self) -> Result<DiagnosticManifest> {
         match self.get::<DiagnosticManifest>().await {
             Ok(manifest) => {
                 log::debug!("Using diagnostic_manifest.json");

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -320,7 +320,12 @@ impl ServerState {
                 .ok_or_else(|| eyre!("Missing required header: {}", IAP_USER_EMAIL_HEADER))?
                 .to_str()
                 .map_err(|_| eyre!("Invalid {} header", IAP_USER_EMAIL_HEADER))?;
-            let email = raw.split(':').last().unwrap_or(raw).trim().to_string();
+            let email = raw
+                .split(':')
+                .next_back()
+                .unwrap_or(raw)
+                .trim()
+                .to_string();
             if email.is_empty() {
                 return Err(eyre!("{} header is empty", IAP_USER_EMAIL_HEADER));
             }
@@ -338,7 +343,13 @@ impl ServerState {
         let email = headers
             .get(IAP_USER_EMAIL_HEADER)
             .and_then(|value| value.to_str().ok())
-            .map(|raw| raw.split(':').last().unwrap_or(raw).trim().to_string())
+            .map(|raw| {
+                raw.split(':')
+                    .next_back()
+                    .unwrap_or(raw)
+                    .trim()
+                    .to_string()
+            })
             .filter(|value| !value.is_empty())
             .unwrap_or_else(|| "Anonymous".to_string());
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,36 @@
+# External Collection Tests
+
+The ignored tests in `tests/logstash_collection_tests.rs` validate Logstash support collection
+against real external services. They are intentionally ignored because they depend on
+environment-specific infrastructure.
+
+## Required Environment Variables
+
+Set `*_URL` for each version you want to exercise:
+
+- `ESDIAG_LOGSTASH_68_URL`
+- `ESDIAG_LOGSTASH_717_URL`
+- `ESDIAG_LOGSTASH_819_URL`
+- `ESDIAG_LOGSTASH_9_URL`
+
+Authentication is optional and can be provided per target with either:
+
+- `*_APIKEY`
+- `*_USERNAME` and `*_PASSWORD`
+
+If the target uses a self-signed or otherwise invalid TLS certificate, set:
+
+- `*_ACCEPT_INVALID_CERTS=true`
+
+Examples:
+
+- `ESDIAG_LOGSTASH_68_URL=https://ls68.example.org:9600`
+- `ESDIAG_LOGSTASH_68_USERNAME=elastic`
+- `ESDIAG_LOGSTASH_68_PASSWORD=changeme`
+- `ESDIAG_LOGSTASH_68_ACCEPT_INVALID_CERTS=true`
+
+Run them with:
+
+```sh
+cargo test --test logstash_collection_tests -- --ignored
+```

--- a/tests/logstash_collection_tests.rs
+++ b/tests/logstash_collection_tests.rs
@@ -1,0 +1,261 @@
+use serde_json::Value;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::tempdir;
+use zip::ZipArchive;
+
+struct ExtractedDiag {
+    _tmp: tempfile::TempDir,
+    path: PathBuf,
+}
+
+struct ExternalLogstashConfig {
+    host_name: String,
+    url: String,
+    apikey: Option<String>,
+    username: Option<String>,
+    password: Option<String>,
+    accept_invalid_certs: bool,
+}
+
+impl ExternalLogstashConfig {
+    fn from_env(prefix: &str) -> Option<Self> {
+        let url = env::var(format!("{prefix}_URL")).ok()?;
+        let host_name = format!("{}-host", prefix.to_lowercase());
+        let apikey = env::var(format!("{prefix}_APIKEY")).ok();
+        let username = env::var(format!("{prefix}_USERNAME")).ok();
+        let password = env::var(format!("{prefix}_PASSWORD")).ok();
+        let accept_invalid_certs = env::var(format!("{prefix}_ACCEPT_INVALID_CERTS"))
+            .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+            .unwrap_or(false);
+        Some(Self {
+            host_name,
+            url,
+            apikey,
+            username,
+            password,
+            accept_invalid_certs,
+        })
+    }
+}
+
+#[test]
+#[ignore = "requires an externally managed Logstash 6.8.x instance"]
+fn test_collect_logstash_68_support() {
+    run_external_logstash_collect_test(
+        "ESDIAG_LOGSTASH_68",
+        false,
+        &[
+            "diagnostic_manifest.json",
+            "logstash_node.json",
+            "logstash_node_stats.json",
+            "logstash_nodes_hot_threads.json",
+            "logstash_nodes_hot_threads_human.txt",
+            "logstash_plugins.json",
+            "logstash_version.json",
+        ],
+        &["logstash_health_report.json"],
+    );
+}
+
+#[test]
+#[ignore = "requires an externally managed Logstash 7.17.x instance"]
+fn test_collect_logstash_717_support() {
+    run_external_logstash_collect_test(
+        "ESDIAG_LOGSTASH_717",
+        false,
+        &[
+            "diagnostic_manifest.json",
+            "logstash_node.json",
+            "logstash_node_stats.json",
+            "logstash_nodes_hot_threads.json",
+            "logstash_nodes_hot_threads_human.txt",
+            "logstash_plugins.json",
+            "logstash_version.json",
+        ],
+        &["logstash_health_report.json"],
+    );
+}
+
+#[test]
+#[ignore = "requires an externally managed Logstash 8.19.x instance"]
+fn test_collect_logstash_819_support() {
+    run_external_logstash_collect_test(
+        "ESDIAG_LOGSTASH_819",
+        true,
+        &[
+            "diagnostic_manifest.json",
+            "logstash_node.json",
+            "logstash_node_stats.json",
+            "logstash_nodes_hot_threads.json",
+            "logstash_nodes_hot_threads_human.txt",
+            "logstash_plugins.json",
+            "logstash_version.json",
+            "logstash_health_report.json",
+        ],
+        &[],
+    );
+}
+
+#[test]
+#[ignore = "requires an externally managed Logstash 9.x instance"]
+fn test_collect_logstash_9_support() {
+    run_external_logstash_collect_test(
+        "ESDIAG_LOGSTASH_9",
+        true,
+        &[
+            "diagnostic_manifest.json",
+            "logstash_node.json",
+            "logstash_node_stats.json",
+            "logstash_nodes_hot_threads.json",
+            "logstash_nodes_hot_threads_human.txt",
+            "logstash_plugins.json",
+            "logstash_version.json",
+            "logstash_health_report.json",
+        ],
+        &[],
+    );
+}
+
+fn run_external_logstash_collect_test(
+    env_prefix: &str,
+    expect_health_report: bool,
+    expected_files: &[&str],
+    unexpected_files: &[&str],
+) {
+    let Some(config) = ExternalLogstashConfig::from_env(env_prefix) else {
+        eprintln!("Skipping {env_prefix}: missing {env_prefix}_URL");
+        return;
+    };
+
+    let test_home = tempdir().expect("temp home");
+
+    let mut host_args = vec![
+        "host".to_string(),
+        config.host_name.clone(),
+        "logstash".to_string(),
+        config.url.clone(),
+    ];
+
+    if let Some(apikey) = &config.apikey {
+        host_args.push("--apikey".to_string());
+        host_args.push(apikey.clone());
+    } else if let (Some(username), Some(password)) = (&config.username, &config.password) {
+        host_args.push("--user".to_string());
+        host_args.push(username.clone());
+        host_args.push("--password".to_string());
+        host_args.push(password.clone());
+    }
+
+    if config.accept_invalid_certs {
+        host_args.push("--accept-invalid-certs".to_string());
+    }
+
+    let host_arg_refs: Vec<&str> = host_args.iter().map(String::as_str).collect();
+    let host = run_esdiag(&host_arg_refs, &test_home);
+    assert_success(&host, &format!("{env_prefix} host setup"));
+
+    let collect_out = tempdir().expect("collect output");
+    let collect = run_esdiag(
+        &[
+            "collect",
+            &config.host_name,
+            collect_out.path().to_str().expect("collect path"),
+            "--type",
+            "support",
+        ],
+        &test_home,
+    );
+    assert_success(&collect, &format!("{env_prefix} collect support"));
+
+    let extracted = extract_diag_zip_to_temp(collect_out.path()).expect("should have a zip output");
+    for path in expected_files {
+        assert!(
+            extracted.path.join(path).exists(),
+            "{env_prefix} expected file {path} to exist"
+        );
+    }
+    for path in unexpected_files {
+        assert!(
+            !extracted.path.join(path).exists(),
+            "{env_prefix} expected file {path} to be absent"
+        );
+    }
+
+    let manifest_content =
+        fs::read_to_string(extracted.path.join("diagnostic_manifest.json")).expect("manifest");
+    let manifest: Value = serde_json::from_str(&manifest_content).expect("manifest json");
+    assert_eq!(manifest["product"].as_str(), Some("logstash"));
+    assert_eq!(manifest["mode"].as_str(), Some("support"));
+
+    let apis = manifest["collected_apis"]
+        .as_array()
+        .expect("collected_apis array");
+    let api_names: Vec<&str> = apis.iter().filter_map(|v| v.as_str()).collect();
+    for required in [
+        "logstash_node",
+        "logstash_node_stats",
+        "logstash_plugins",
+        "logstash_version",
+        "logstash_nodes_hot_threads",
+        "logstash_nodes_hot_threads_human",
+    ] {
+        assert!(
+            api_names.contains(&required),
+            "{env_prefix} missing collected api {required}"
+        );
+    }
+    assert_eq!(
+        api_names.contains(&"logstash_health_report"),
+        expect_health_report,
+        "{env_prefix} health report expectation mismatch"
+    );
+}
+
+fn extract_diag_zip_to_temp(path: &Path) -> Option<ExtractedDiag> {
+    let zip_path = find_diag_zip(path)?;
+    let extract_root = tempfile::tempdir().ok()?;
+    let extract_path = extract_root.path().to_path_buf();
+    let file = fs::File::open(zip_path).ok()?;
+    let mut archive = ZipArchive::new(file).ok()?;
+    archive.extract(&extract_path).ok()?;
+    Some(ExtractedDiag {
+        _tmp: extract_root,
+        path: extract_path,
+    })
+}
+
+fn find_diag_zip(path: &Path) -> Option<PathBuf> {
+    for entry in fs::read_dir(path).ok()? {
+        let entry = entry.ok()?;
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        let valid_prefix =
+            file_name.starts_with("api-diagnostics-") || file_name.starts_with("esdiag-");
+        if entry.file_type().ok()?.is_file() && valid_prefix && file_name.ends_with(".zip") {
+            return Some(entry.path());
+        }
+    }
+    None
+}
+
+fn run_esdiag(args: &[&str], home: &tempfile::TempDir) -> Output {
+    let home_path = home.path().to_str().expect("home path");
+    Command::new(env!("CARGO_BIN_EXE_esdiag"))
+        .args(args)
+        .env("HOME", home_path)
+        .env("USERPROFILE", home_path)
+        .env("LOG_LEVEL", "debug")
+        .output()
+        .expect("run esdiag")
+}
+
+fn assert_success(output: &Output, label: &str) {
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!("{label} failed\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+}

--- a/tests/sources_override_tests.rs
+++ b/tests/sources_override_tests.rs
@@ -1,0 +1,232 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use tempfile::tempdir;
+
+#[test]
+fn test_collect_sources_override_rejects_wrong_product_for_logstash_host() {
+    let home = tempdir().expect("temp home");
+    let hosts_path = home.path().join("hosts.yml");
+    fs::write(
+        &hosts_path,
+        r#"logstash-local:
+  auth: NoAuth
+  app: logstash
+  roles:
+    - collect
+  url: http://127.0.0.1:9600
+"#,
+    )
+    .expect("write hosts");
+
+    let override_dir = tempdir().expect("override dir");
+    let override_path = override_dir.path().join("sources.yml");
+    fs::write(
+        &override_path,
+        r#"version:
+  versions:
+    "> 5.0.0": "/"
+"#,
+    )
+    .expect("write override");
+
+    let output_dir = tempdir().expect("output dir");
+    let output = run_esdiag(
+        &[
+            "collect",
+            "logstash-local",
+            output_dir.path().to_str().expect("out path"),
+            "--type",
+            "minimal",
+            "--sources",
+            override_path.to_str().expect("override path"),
+        ],
+        home.path(),
+        Some(&hosts_path),
+    );
+
+    assert!(
+        !output.status.success(),
+        "collect should fail for mismatched override file"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("valid logstash sources.yml"));
+}
+
+#[test]
+fn test_collect_sources_override_accepts_matching_product_before_connection() {
+    let home = tempdir().expect("temp home");
+    let hosts_path = home.path().join("hosts.yml");
+    fs::write(
+        &hosts_path,
+        r#"logstash-local:
+  auth: NoAuth
+  app: logstash
+  roles:
+    - collect
+  url: http://127.0.0.1:9600
+"#,
+    )
+    .expect("write hosts");
+
+    let override_dir = tempdir().expect("override dir");
+    let override_path = override_dir.path().join("sources.yml");
+    fs::write(
+        &override_path,
+        r#"logstash_node:
+  versions:
+    "> 5.0.0": "/_node"
+logstash_node_stats:
+  versions:
+    "> 5.0.0": "/_node/stats"
+logstash_plugins:
+  versions:
+    "> 5.0.0": "/_node/plugins"
+logstash_version:
+  versions:
+    "> 5.0.0": "/"
+"#,
+    )
+    .expect("write override");
+
+    let output_dir = tempdir().expect("output dir");
+    let output = run_esdiag(
+        &[
+            "collect",
+            "logstash-local",
+            output_dir.path().to_str().expect("out path"),
+            "--type",
+            "minimal",
+            "--sources",
+            override_path.to_str().expect("override path"),
+        ],
+        home.path(),
+        Some(&hosts_path),
+    );
+
+    assert!(
+        !output.status.success(),
+        "collect should still fail without a live Logstash endpoint"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("valid logstash sources.yml"),
+        "matching override should not fail product validation: {stderr}"
+    );
+}
+
+#[test]
+fn test_process_sources_override_rejects_wrong_product_for_manifest() {
+    let home = tempdir().expect("temp home");
+    let input_dir = tempdir().expect("input dir");
+    fs::write(
+        input_dir.path().join("diagnostic_manifest.json"),
+        r#"{
+  "product": "logstash",
+  "timestamp": "2026-03-10T00:00:00Z"
+}"#,
+    )
+    .expect("write manifest");
+
+    let override_dir = tempdir().expect("override dir");
+    let override_path = override_dir.path().join("sources.yml");
+    fs::write(
+        &override_path,
+        r#"version:
+  versions:
+    "> 5.0.0": "/"
+"#,
+    )
+    .expect("write override");
+
+    let output = run_esdiag(
+        &[
+            "process",
+            input_dir.path().to_str().expect("input path"),
+            "-",
+            "--sources",
+            override_path.to_str().expect("override path"),
+        ],
+        home.path(),
+        None,
+    );
+
+    assert!(
+        !output.status.success(),
+        "process should fail for mismatched override file"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("valid logstash sources.yml"));
+}
+
+#[test]
+fn test_process_sources_override_accepts_matching_manifest_product() {
+    let home = tempdir().expect("temp home");
+    let input_dir = tempdir().expect("input dir");
+    fs::write(
+        input_dir.path().join("diagnostic_manifest.json"),
+        r#"{
+  "product": "logstash",
+  "timestamp": "2026-03-10T00:00:00Z"
+}"#,
+    )
+    .expect("write manifest");
+
+    let override_dir = tempdir().expect("override dir");
+    let override_path = override_dir.path().join("sources.yml");
+    fs::write(
+        &override_path,
+        r#"logstash_node:
+  versions:
+    "> 5.0.0": "/_node"
+logstash_node_stats:
+  versions:
+    "> 5.0.0": "/_node/stats"
+logstash_plugins:
+  versions:
+    "> 5.0.0": "/_node/plugins"
+logstash_version:
+  versions:
+    "> 5.0.0": "/"
+"#,
+    )
+    .expect("write override");
+
+    let output = run_esdiag(
+        &[
+            "process",
+            input_dir.path().to_str().expect("input path"),
+            "-",
+            "--sources",
+            override_path.to_str().expect("override path"),
+        ],
+        home.path(),
+        None,
+    );
+
+    assert!(
+        !output.status.success(),
+        "process should still fail because required Logstash files are absent"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("valid logstash sources.yml"),
+        "matching override should not fail product validation: {stderr}"
+    );
+}
+
+fn run_esdiag(args: &[&str], home: &Path, hosts_path: Option<&Path>) -> Output {
+    let home_path = home.to_str().expect("home path");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_esdiag"));
+    cmd.args(args)
+        .env("HOME", home_path)
+        .env("USERPROFILE", home_path)
+        .env("LOG_LEVEL", "debug");
+
+    if let Some(hosts_path) = hosts_path {
+        cmd.env("ESDIAG_HOSTS", hosts_path);
+    }
+
+    cmd.output().expect("run esdiag")
+}


### PR DESCRIPTION
## Summary
- add a dedicated Logstash collect path that resolves canonical `logstash_*` APIs from `assets/logstash/sources.yml`, supports support/minimal/standard/light profiles, and records canonical collected APIs in the diagnostic manifest
- normalize legacy short Logstash identifiers to canonical source keys, reuse typed collection for node and node stats, and collect the remaining Logstash endpoints as raw files including `.txt` hot threads output
- add unit coverage for Logstash source resolution and ignored external-service compatibility tests for Logstash 6.8.x, 7.17.x, 8.19.x, and 9.x along with setup docs

## Test plan
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --test logstash_collection_tests -- --ignored` against external Logstash 6.8.x, 7.17.x, 8.19.x, and 9.x instances


Made with [Cursor](https://cursor.com)