### PR TITLE
feat: add Kibana API collection support

### DIFF
--- a/assets/kibana/sources.yml
+++ b/assets/kibana/sources.yml
@@ -1,9 +1,9 @@
 # The new settings format:
-# At the top level the label descring the query that will also be used as the
+# At the top level the label describing the query that will also be used as the
 #   file name for its output.
 #   Below the query label are the following attributes:
 #     * extension - the file extension to be used for output. Optional, defaults to .json.
-#     * subdir - some api's are now grouped in a subdirectory of the output directory to lessen clutter. Optional, defaults to root dir.
+#     * subdir - some APIs are now grouped in a subdirectory of the output directory to lessen clutter. Optional, defaults to root dir.
 #     * retry - whether if a query fails it will be retried for the configured number of attempts. Optional, defaults to false.
 #     * versions - it can be:
 #       * A map constituted of "semver rules" and its associated "url/api" to run (`">= 7.0.0" : "/api/someendpoint/"`)
@@ -16,7 +16,7 @@
 #   NPM mode is the only one used: https://github.com/vdurmont/semver4j
 #   NPM Versioning rules are documented here: https://github.com/npm/node-semver
 #
-#   Note to those adding entries: within each group, cat API's, json API's, and commercial, they are in alphabetical order.
+#   Note to those adding entries: within each group, cat APIs, JSON APIs, and commercial endpoints are in alphabetical order.
 #   Please adhere to this convention when submitting pull requests.
 
 kibana_actions:

--- a/assets/kibana/sources.yml
+++ b/assets/kibana/sources.yml
@@ -1,0 +1,222 @@
+# The new settings format:
+# At the top level the label descring the query that will also be used as the
+#   file name for its output.
+#   Below the query label are the following attributes:
+#     * extension - the file extension to be used for output. Optional, defaults to .json.
+#     * subdir - some api's are now grouped in a subdirectory of the output directory to lessen clutter. Optional, defaults to root dir.
+#     * retry - whether if a query fails it will be retried for the configured number of attempts. Optional, defaults to false.
+#     * versions - it can be:
+#       * A map constituted of "semver rules" and its associated "url/api" to run (`">= 7.0.0" : "/api/someendpoint/"`)
+#       * A map constituted of "semver rules" and its associated structure:
+#         * url - required field representing the API to be used
+#         * spaceaware - optional boolean option representing the fact the field is space aware. IF set, the API will be scraped for each space
+#         * paginate - optional string option representing the pagination field name. If set, the API will be paginated using the field name
+#
+#   The "semver rules" within "versions" must resolve EXACTLY TO ONE "url/api"
+#   NPM mode is the only one used: https://github.com/vdurmont/semver4j
+#   NPM Versioning rules are documented here: https://github.com/npm/node-semver
+#
+#   Note to those adding entries: within each group, cat API's, json API's, and commercial, they are in alphabetical order.
+#   Please adhere to this convention when submitting pull requests.
+
+kibana_actions:
+  versions:
+    ">= 7.0.0":
+      url: "/api/actions"
+      spaceaware: true
+
+kibana_alerts:
+  versions:
+    ">= 7.9.0":
+      url: "/api/alerts/_find"
+      spaceaware: true
+      paginate: per_page
+
+kibana_alerts_health:
+  versions:
+    ">= 7.11.0 < 7.13.0": "/api/alerts/_health"
+    ">= 7.13.0": "/api/alerting/_health"
+
+kibana_data_views:
+  versions:
+    ">= 8.0.0":
+      url: "/api/data_views"
+      spaceaware: true
+
+# Calculates health of Detection Engine and returns a health snapshot.
+# Scope: the whole cluster = all detection rules in all Kibana spaces.
+# https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/common/detection_engine/rule_monitoring/api/detection_engine_health/README.md
+kibana_detection_engine_health_cluster:
+  versions:
+    ">= 8.8.2": "/internal/detection_engine/health/_cluster"
+
+# Calculates health of Detection Engine and returns a health snapshot.
+# Scope: all detection rules in the current/default Kibana space.
+# https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/common/detection_engine/rule_monitoring/api/detection_engine_health/README.md
+kibana_detection_engine_health_space:
+  versions:
+    ">= 8.8.2": "/internal/detection_engine/health/_space"
+
+kibana_detection_engine_privileges:
+  versions:
+    ">= 7.6.0": "/api/detection_engine/privileges"
+
+# Returns installed detection rules, both prebuilt and custom. This endpoint requires pagination.
+# Scope: current/default Kibana space.
+kibana_detection_engine_rules_installed:
+  versions:
+    ">= 7.6.0":
+      url: "/api/detection_engine/rules/_find?sort_field=enabled&sort_order=asc"
+      paginate: per_page
+
+# Returns status of prebuilt detection rules: how many of them are installed, can be installed, can be upgraded, etc.
+# Scope: current/default Kibana space.
+kibana_detection_engine_rules_prebuilt_status:
+  versions:
+    ">= 7.10.0 < 7.15.0": "/api/detection_engine/prepackaged"
+    ">= 7.15.0 < 8.9.0": "/api/detection_engine/rules/prepackaged/_status"
+    ">= 8.9.0": "/internal/detection_engine/prebuilt_rules/status"
+
+kibana_fleet_agents:
+  versions:
+    ">= 7.10.0":
+      url: "/api/fleet/agents"
+      paginate: perPage
+
+kibana_fleet_agent_policies:
+  versions:
+    ">= 7.10.0":
+      url: "/api/fleet/agent_policies"
+      paginate: perPage
+
+kibana_fleet_packages:
+  versions:
+    ">= 7.11.0": "/api/fleet/epm/packages?experimental=true"
+
+kibana_fleet_agent_status:
+  versions:
+    ">= 7.11.0 < 8.0.0": "/api/fleet/agent-status"
+    ">= 8.0.0": "/api/fleet/agent_status"
+
+kibana_fleet_agents_current_upgrades:
+  versions:
+    ">= 8.3.0": "/api/fleet/agents/current_upgrades"
+
+kibana_lists_privileges:
+  versions:
+    ">= 7.9.0": "/api/lists/privileges"
+
+kibana_fleet_settings:
+  versions:
+    ">= 7.14.0": "/api/fleet/settings"
+
+kibana_reporting_diagnose_browser:
+  versions:
+    ">= 8.16.0": "/internal/reporting/diagnose/browser"
+
+kibana_roles:
+  versions:
+    ">= 6.4.0": "/api/security/role"
+
+# These endpoints will return 404 if there are no exceptions
+kibana_security_endpoint_host_isolation:
+  versions:
+    ">= 7.14.0":
+      url: "/api/exception_lists/items/_find?list_id=endpoint_host_isolation_exceptions&namespace_type=agnostic"
+      paginate: per_page
+
+kibana_security_endpoint_event_filters:
+  versions:
+    ">= 7.14.0":
+      url: "/api/exception_lists/items/_find?list_id=endpoint_event_filters&namespace_type=agnostic"
+      paginate: per_page
+
+kibana_security_endpoint_exception_items:
+  versions:
+    ">= 7.14.0":
+      url: "/api/exception_lists/items/_find?list_id=endpoint_list&namespace_type=agnostic"
+      paginate: per_page
+
+kibana_security_endpoint_metadata:
+  versions:
+    ">= 8.0.0":
+      url: "/api/endpoint/metadata"
+      paginate: pageSize
+
+kibana_security_endpoint_trusted_apps:
+  versions:
+    ">= 7.10.0 < 7.14.0": "/api/endpoint/trusted_apps"
+    ">= 7.14.0":
+      url: "/api/exception_lists/items/_find?list_id=endpoint_trusted_apps&namespace_type=agnostic"
+      paginate: per_page
+
+kibana_security_exception_list:
+  versions:
+    ">= 7.10.0":
+      url: "/api/exception_lists/_find?namespace_type=agnostic"
+      paginate: per_page
+
+kibana_security_packages:
+  versions:
+    ">= 7.10.0": "/api/fleet/epm/packages?experimental=true&category=security"
+
+kibana_settings:
+  versions:
+    ">= 6.5.0 < 8.0.0": "/api/settings"
+
+kibana_spaces:
+  versions:
+    ">= 6.5.0": "/api/spaces/space"
+
+kibana_stats:
+  versions:
+    ">= 6.5.0": "/api/stats"
+
+# can be uncommented if there is needed deeper health information on the stats
+#kibana_stats_extended:
+#  versions:
+#    ">= 6.5.0": "/api/stats?extended=true"
+
+kibana_status:
+  versions:
+    ">= 5.0.0": "/api/status"
+
+kibana_synthetics_monitor_filters:
+  versions:
+    ">= 8.12.0": "/internal/synthetics/monitor/filters"
+
+# Disabled pending review
+#kibana_synthetics_monitors:
+#  versions:
+#    ">= 8.12.0":
+#      url: "/internal/synthetics/service/monitors"
+#      paginate: perPage
+
+kibana_synthetics_private_locations:
+  versions:
+    ">= 8.12.0": "/api/synthetics/private_locations"
+
+kibana_task_manager_health:
+  versions:
+    ">= 7.11.0": "/api/task_manager/_health"
+
+kibana_upgrade_assistant:
+  versions:
+    ">= 6.6.0": "/api/upgrade_assistant/status"
+
+kibana_uptime_locations:
+  versions:
+    ">= 8.12.0": "/internal/uptime/service/locations"
+
+kibana_uptime_settings:
+  versions:
+    ">= 8.12.0": "/api/uptime/settings"
+
+kibana_user:
+  versions:
+    ">= 7.6.0": "/internal/security/me"
+    ">= 5.0.0 < 7.6.0": "/api/security/v1/me"
+
+kibana_stack_monitoring_health:
+  versions:
+    ">= 8.3.1": "/api/monitoring/v1/_health"

--- a/openspec/changes/collect-kibana/.openspec.yaml
+++ b/openspec/changes/collect-kibana/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-09

--- a/openspec/changes/collect-kibana/design.md
+++ b/openspec/changes/collect-kibana/design.md
@@ -1,0 +1,70 @@
+## Context
+
+ESDiag already has the building blocks needed to talk to Kibana: `Product::Kibana`, `KibanaClient`, and host/auth plumbing all exist. The missing piece is the collection workflow. Today the shared source loader only embeds `assets/elasticsearch/sources.yml`, the `Source` model assumes every version rule maps to a plain string URL, `ApiResolver` only has concrete logic for Elasticsearch and Logstash, and `Diagnostic::try_new()` still returns an unimplemented error for Kibana.
+
+The supplied `assets/kibana/sources.yml` is richer than the Elasticsearch catalog. A version rule can resolve either to a bare URL or to a structured object containing `url` plus execution metadata like `spaceaware` and `paginate`. That means Kibana support is not only a new product workflow, but also a shared-source model expansion that must remain backward compatible for Elasticsearch.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enable `esdiag collect` to run successfully against Kibana targets.
+- Use `assets/kibana/sources.yml` as the source of truth for Kibana endpoint selection, file naming, pagination, and space awareness.
+- Extend shared source loading so both Elasticsearch and Kibana catalogs can be resolved through the same API.
+- Define Kibana diagnostic type behavior that makes default `collect` usable even before curated Kibana subsets exist.
+- Keep the implementation self-contained and cross-platform, reusing the current async Rust collection stack.
+
+**Non-Goals:**
+- Building strongly typed Kibana parsers, exporters, or enrichment logic for each collected API.
+- Designing curated Kibana subsets beyond the bootstrap `minimal` profile and the full-catalog baseline used by the other types.
+- Changing Elasticsearch collection semantics except where required to preserve compatibility with the new shared source model.
+- Implementing Kibana processing or visualization features beyond raw collection output.
+
+## Decisions
+
+### 1. Use a richer, backward-compatible source configuration model
+- **Decision**: Replace the current `versions: BTreeMap<String, String>` assumption with a product-agnostic model that can deserialize either a bare URL string or a structured version entry containing `url`, `spaceaware`, and `paginate`.
+- **Rationale**: Kibana's catalog cannot be represented by the current type, and duplicating source parsing logic per product would fragment a capability that is already shared.
+- **Alternative considered**: Add a separate Kibana-only parser. Rejected because it would duplicate semver resolution, file path logic, and global source-cache behavior.
+
+### 2. Keep source catalogs keyed by product in one shared cache
+- **Decision**: Expand `get_sources()` and `init_sources()` to load embedded source catalogs into a single product-keyed cache, with Elasticsearch and Kibana registered side by side.
+- **Rationale**: Product-aware source lookup is already implied by `DataSource::product()`, and a shared cache keeps source resolution logic centralized for resolvers and collectors.
+- **Alternative considered**: Add independent globals per product. Rejected because it complicates initialization and makes cross-product validation logic harder to share.
+
+### 3. Introduce a dedicated Kibana execution plan instead of over-generalizing Elasticsearch enums
+- **Decision**: Add a Kibana-specific resolver and collection path that produces raw execution plans containing the API name, resolved URL, output path, space-awareness, pagination field, and any derived scope metadata needed at runtime.
+- **Rationale**: Kibana collection is fully source-driven and does not need a large typed enum surface on day one. A plan struct preserves room for future typed handling without forcing Elasticsearch and Kibana into the same enum hierarchy.
+- **Alternative considered**: Reuse `ElasticsearchApi::Raw` for Kibana. Rejected because Kibana needs additional execution metadata that is not naturally expressible in the existing Elasticsearch API model.
+
+### 4. Make Kibana bootstrap APIs mandatory
+- **Decision**: Treat `kibana_status` as the required version-discovery API and `kibana_spaces` as the required space-discovery API. These remain in the plan even if a user excludes them or only selects space-aware APIs indirectly.
+- **Rationale**: Versioned source resolution and space-aware expansion both depend on bootstrap data. Making them explicit dependencies keeps planning deterministic and makes the manifest reflect what was actually required to execute the run.
+- **Alternative considered**: Issue hidden internal requests outside the resolved API plan. Rejected because it obscures what was collected and complicates debugging and test expectations.
+
+### 5. Default Kibana type behavior should favor usability over premature curation
+- **Decision**: Resolve Kibana `support`, `standard`, and `light` to the full Kibana source catalog for now, and keep `minimal` limited to the bootstrap APIs needed to identify the host and enumerate spaces.
+- **Rationale**: The CLI default remains `standard`, so making `standard` usable is required for Kibana collection to work naturally. We do not yet have enough evidence to define smaller curated Kibana profiles.
+- **Alternative considered**: Error on non-`support` Kibana types. Rejected because the default `collect` path would still fail unless users discovered the extra flag.
+
+### 6. Preserve raw outputs and avoid response-shape rewriting
+- **Decision**: Collect Kibana endpoints as raw responses and write them using the source-defined output naming, while adding scope-specific path segments for per-space and per-page artifacts so repeated requests do not overwrite each other.
+- **Rationale**: This matches the parity goal, avoids inventing product-specific schema mergers, and keeps the collector robust for APIs that change shape over time.
+- **Alternative considered**: Merge paginated results into one synthesized payload per API. Rejected because it changes the original response contract and creates edge cases for text or mixed-shape endpoints.
+
+## Risks / Trade-offs
+
+- **[Risk] Shared source parsing regressions for Elasticsearch** → **Mitigation**: keep deserialization backward compatible, preserve current file-path/url behavior for simple string entries, and add tests that cover both Elasticsearch and Kibana source formats.
+- **[Risk] Kibana support runs can fan out heavily across spaces and paginated endpoints** → **Mitigation**: reuse bounded concurrency patterns and keep the execution plan explicit so pagination and space expansion can be throttled predictably.
+- **[Risk] Partial permissions across spaces produce noisy or incomplete output** → **Mitigation**: record failures per request, continue collecting other spaces/endpoints, and ensure scoped outputs and summaries make partial coverage visible.
+- **[Risk] Defaulting Kibana `standard` and `light` to the full catalog may collect more than some users expect** → **Mitigation**: document the temporary mapping in CLI help/tests and preserve `--include` / `--exclude` controls for operators who want narrower runs.
+
+## Migration Plan
+
+- No persisted data migration is required because this change only adds a new collection path and expands embedded source metadata handling.
+- Roll out by landing the shared source-model changes first, then the Kibana resolver/collector path, then tests that cover default Kibana collection and scoped endpoint behavior.
+- If rollback is needed, Kibana-specific resolver/collector wiring can be removed while keeping the pre-existing Elasticsearch path intact.
+
+## Open Questions
+
+- Should `--sources` remain a single override path applied only to the active target product, or should a future change support per-product override paths when multiple product catalogs are embedded?
+- Do any Kibana endpoints in `assets/kibana/sources.yml` require special request headers or bodies beyond the current `KibanaClient` defaults once collection is implemented at scale?

--- a/openspec/changes/collect-kibana/proposal.md
+++ b/openspec/changes/collect-kibana/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+ESDiag can target Kibana hosts, but `collect` does not yet implement a Kibana diagnostic workflow. We now have a curated `assets/kibana/sources.yml` inventory, and PR260 established the expectation of full support-oriented API collection driven by source definitions, so Kibana needs the same source-driven collection path to reach parity.
+
+## What Changes
+
+- Add Kibana collection support to `esdiag collect` so a Kibana target can execute a support-style diagnostic run instead of failing as unimplemented.
+- Introduce Kibana raw API collection driven by `assets/kibana/sources.yml`, including version-aware endpoint selection, output naming, pagination, and space-aware endpoint expansion.
+- Extend shared source loading and resolution so product-specific source catalogs can be loaded and queried for Kibana as well as Elasticsearch.
+- Update API selection and validation to resolve Kibana API identifiers from the Kibana source catalog rather than Elasticsearch-only definitions.
+
+## Capabilities
+
+### New Capabilities
+- `kibana-diagnostic-collection`: Collect Kibana support diagnostics from the Kibana source catalog, including raw endpoint fetching, space-aware expansion, pagination, and source-defined output paths.
+
+### Modified Capabilities
+- `version-dependent-sources`: Extend source loading and endpoint resolution to support multiple product catalogs, including `assets/kibana/sources.yml`.
+- `api-selection`: Resolve diagnostic type contents and include/exclude validation against the target product's source catalog so Kibana collections use Kibana API keys.
+
+## Impact
+
+- **Core Processing Logic**: Adds a new Kibana collection path and product-aware source resolution in the shared diagnostic pipeline.
+- **CLI Behavior**: `esdiag collect` for Kibana will move from an unimplemented error to an executable support collection workflow.
+- **HTTP Collection**: Kibana collection will issue many additional requests, including per-space and paginated endpoints defined in `assets/kibana/sources.yml`.
+- **Output Shape**: Kibana diagnostics will produce raw JSON and text artifacts using source-defined filenames and subdirectories.

--- a/openspec/changes/collect-kibana/specs/api-selection/spec.md
+++ b/openspec/changes/collect-kibana/specs/api-selection/spec.md
@@ -1,0 +1,61 @@
+## MODIFIED Requirements
+
+### Requirement: Product-Specific API Validation
+The system SHALL validate all requested APIs (via type, include, or exclude arguments) against the valid API identifiers for the target product. If an invalid API identifier is requested, the system MUST fail immediately with an error before any collection operations begin.
+
+#### Scenario: User includes an invalid Kibana API identifier
+- **GIVEN** a Kibana collection run
+- **WHEN** the user runs `esdiag collect --include not_a_real_kibana_api`
+- **THEN** the system validates `not_a_real_kibana_api` against the allowed APIs for Kibana
+- **AND** the system exits with an error before starting collection
+
+#### Scenario: Common logic applies across products
+- **GIVEN** a Logstash collection run
+- **WHEN** the user runs `esdiag collect --type minimal`
+- **THEN** the system validates the Logstash minimal APIs against the valid API list for Logstash
+- **AND** the system proceeds with collection
+
+### Requirement: Minimum Required APIs
+The system MUST ensure that a baseline set of required APIs is always collected for the target product, regardless of the selected diagnostic type or user exclusions.
+
+#### Scenario: User attempts to exclude a required Elasticsearch API
+- **GIVEN** the `cluster` API is defined as a minimum required API for Elasticsearch
+- **WHEN** the user runs `esdiag collect --exclude cluster`
+- **THEN** the system ignores the exclusion for `cluster` and collects it anyway
+
+#### Scenario: User attempts to exclude a required Kibana API
+- **GIVEN** `kibana_status` and `kibana_spaces` are defined as minimum required APIs for Kibana collection
+- **WHEN** the user runs `esdiag collect --exclude kibana_spaces`
+- **THEN** the system ignores the exclusion for `kibana_spaces` and collects it anyway
+
+### Requirement: API Dependency Resolution
+The system MUST resolve and automatically include any dependent APIs required by the selected APIs for the target product.
+
+#### Scenario: Selected Elasticsearch API requires another API
+- **GIVEN** the `nodes_stats` API requires the `nodes` API for enrichment
+- **WHEN** the user runs `esdiag collect --type minimal --include nodes_stats`
+- **THEN** the system automatically includes the `nodes` API in the collection set
+
+#### Scenario: Selected Kibana API requires spaces metadata
+- **GIVEN** a Kibana source entry is marked `spaceaware: true`
+- **WHEN** the user selects that API directly or indirectly through the diagnostic type
+- **THEN** the system automatically includes the `kibana_spaces` API in the collection plan if it is not already present
+
+### Requirement: Dynamic Diagnostic Type Inclusion
+The system SHALL dynamically map diagnostic types to API inclusions using the keys and tags directly from the target product's embedded `sources.yml` definition, replacing product-specific hardcoded support lists where source catalogs exist. For Kibana, `support`, `standard`, and `light` SHALL resolve to the full Kibana source catalog until curated subsets are defined, while `minimal` SHALL resolve only the bootstrap APIs required to identify the Kibana instance and enumerate spaces.
+
+#### Scenario: Evaluating the Kibana support diagnostic type
+- **GIVEN** a user executes `esdiag collect --type support` against a Kibana host
+- **WHEN** the API resolver evaluates the requested endpoints
+- **THEN** it resolves all top-level API keys present in `assets/kibana/sources.yml` to be collected
+
+#### Scenario: Evaluating the Kibana default diagnostic type
+- **GIVEN** a user executes `esdiag collect` against a Kibana host without specifying `--type`
+- **WHEN** the API resolver applies the default `standard` diagnostic type
+- **THEN** it resolves the same full Kibana source catalog used by the Kibana `support` type
+
+#### Scenario: Evaluating the Elasticsearch light diagnostic type
+- **GIVEN** a user executes `esdiag collect --type light` against an Elasticsearch host
+- **WHEN** the API resolver evaluates the requested endpoints
+- **THEN** it resolves all top-level API keys that contain `tags: light` in `assets/elasticsearch/sources.yml`
+- **AND** it includes the required minimum APIs for Elasticsearch

--- a/openspec/changes/collect-kibana/specs/kibana-diagnostic-collection/spec.md
+++ b/openspec/changes/collect-kibana/specs/kibana-diagnostic-collection/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Kibana support collection
+The system SHALL allow `esdiag collect` to execute against a Kibana target and collect the Kibana APIs selected for the diagnostic run using `assets/kibana/sources.yml` as the source of truth for endpoint discovery.
+
+#### Scenario: Running a support collection against Kibana
+- **WHEN** a user runs `esdiag collect` against a Kibana host with a diagnostic selection that includes the full support set
+- **THEN** the system resolves Kibana API identifiers from `assets/kibana/sources.yml`
+- **AND** the system fetches each resolved endpoint from the Kibana host instead of failing with an unimplemented-product error
+
+### Requirement: Space-aware endpoint expansion
+The system SHALL expand Kibana source entries marked `spaceaware: true` across every accessible Kibana space and persist each space-scoped response separately so no space overwrites another.
+
+#### Scenario: Collecting a space-aware Kibana API
+- **WHEN** the system collects a source entry whose resolved configuration has `spaceaware: true`
+- **THEN** the system discovers the accessible Kibana spaces before issuing that request
+- **AND** the system executes the request once per discovered space
+- **AND** the system stores each space-scoped response using a unique output path
+
+### Requirement: Paginated endpoint traversal
+The system SHALL continue requesting Kibana source entries marked with a `paginate` field until every page of results has been collected.
+
+#### Scenario: Collecting a paginated Kibana API
+- **WHEN** the system collects a source entry whose resolved configuration includes `paginate: per_page`
+- **THEN** the system appends the configured pagination parameter to successive requests as needed to retrieve every page
+- **AND** the system persists the complete paginated result set without truncating to the first response page
+
+### Requirement: Source-defined Kibana output layout
+The system SHALL write Kibana collection outputs using the filename, extension, and subdirectory information resolved from the matching Kibana source entry, while adding scope-specific path segments when required to keep per-space or per-page artifacts distinct.
+
+#### Scenario: Writing a scoped Kibana artifact
+- **WHEN** a Kibana source entry resolves to a configured output path and the request is scoped by space or pagination
+- **THEN** the system preserves the configured file naming from `assets/kibana/sources.yml`
+- **AND** the system augments the output path so repeated requests for the same API do not overwrite one another
+
+### Requirement: Kibana version-matrix validation
+The system SHALL include ignored tests that validate Kibana collection behavior against externally managed Kibana instances on `6.8.x`, `7.17.x`, `8.19.x`, and `9.x`.
+
+#### Scenario: Running ignored external Kibana compatibility tests
+- **WHEN** a maintainer runs the ignored Kibana integration test suite with access to the required external services
+- **THEN** the suite executes compatibility coverage against Kibana `6.8.x`, `7.17.x`, `8.19.x`, and `9.x`
+- **AND** the tests may be skipped in normal local and CI runs when the external services are unavailable

--- a/openspec/changes/collect-kibana/specs/version-dependent-sources/spec.md
+++ b/openspec/changes/collect-kibana/specs/version-dependent-sources/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Dynamic Source Endpoint Resolution
+The system SHALL resolve API endpoint queries dynamically using the target product and its corresponding `assets/<product>/sources.yml` mapping file. The system MUST support semver rules whose values resolve either directly to a URL string or to a structured source definition that includes `url` plus optional collection metadata such as pagination or space awareness.
+
+#### Scenario: Host version matches a string-based semver rule
+- **GIVEN** a product source configuration with version rules for a data source
+- **WHEN** the target host's version matches exactly one string-valued semver rule
+- **THEN** the system returns the API query string corresponding to that semver rule
+
+#### Scenario: Host version matches a structured semver rule
+- **GIVEN** a Kibana `sources.yml` configuration whose matching version rule contains a structured object with `url`, `spaceaware`, and `paginate` fields
+- **WHEN** the target host's version matches that rule
+- **THEN** the system returns the configured URL
+- **AND** the system preserves the associated collection metadata for later execution planning
+
+#### Scenario: Host version matches no semver rule
+- **GIVEN** a product source configuration with version rules for a data source
+- **WHEN** the target host's version matches none of the defined semver rules
+- **THEN** the system returns an error indicating the API is unsupported on this version
+
+### Requirement: Dynamic File Path Construction
+The system SHALL construct local output file paths dynamically using the target product's `sources.yml` mapping file.
+
+#### Scenario: Constructing a file path with a subdirectory and extension
+- **GIVEN** a data source name, and a product `sources.yml` entry specifying a `subdir` and `extension`
+- **WHEN** resolving the `PathType::File` for the data source
+- **THEN** the system returns a file path formatted as `subdir/name.extension`
+
+#### Scenario: Constructing a file path with default values
+- **GIVEN** a data source name, and a product `sources.yml` entry specifying no `subdir` or `extension`
+- **WHEN** resolving the `PathType::File` for the data source
+- **THEN** the system returns a file path formatted as `name.json`
+
+### Requirement: Global Sources Configuration Loading
+The system SHALL load embedded product-specific `sources.yml` files into memory once during initialization and make them globally accessible to `DataSource` trait implementations and API resolvers.
+
+#### Scenario: Initializing the configuration cache for multiple products
+- **GIVEN** the application embeds both `assets/elasticsearch/sources.yml` and `assets/kibana/sources.yml`
+- **WHEN** the system starts or is requested to resolve a data source for either product for the first time
+- **THEN** both source catalogs are parsed into a globally accessible product-keyed structure
+
+#### Scenario: Requesting an unknown data source for a product
+- **GIVEN** the cached product source configuration
+- **WHEN** the system is requested to resolve a data source name that does not exist for the target product
+- **THEN** the system returns an error indicating the data source configuration is missing

--- a/openspec/changes/collect-kibana/tasks.md
+++ b/openspec/changes/collect-kibana/tasks.md
@@ -1,0 +1,24 @@
+## 1. Shared Source Model
+
+- [x] 1.1 Refactor the shared source configuration types to deserialize both string-valued and structured version entries with `url`, `spaceaware`, and `paginate` metadata.
+- [x] 1.2 Expand source initialization and lookup helpers to load both embedded Elasticsearch and Kibana catalogs in a product-keyed cache.
+- [x] 1.3 Add unit tests covering Elasticsearch compatibility plus Kibana version resolution, metadata extraction, and file path generation.
+
+## 2. Kibana API Planning
+
+- [x] 2.1 Implement Kibana-specific API resolution that validates include/exclude values against `assets/kibana/sources.yml`.
+- [x] 2.2 Add Kibana diagnostic type mappings so `minimal` resolves bootstrap APIs and `standard`, `support`, and `light` resolve the full Kibana source catalog.
+- [x] 2.3 Encode Kibana required dependencies, especially `kibana_status` for version discovery and `kibana_spaces` for space-aware collection, and test the resolver behavior.
+
+## 3. Kibana Collection Execution
+
+- [x] 3.1 Implement the `src/processor/kibana` collection workflow and wire `Product::Kibana` through diagnostic construction and execution.
+- [x] 3.2 Add raw Kibana request execution that expands `spaceaware` endpoints per discovered space and continues paginated endpoints until all pages are collected.
+- [x] 3.3 Persist Kibana outputs using source-defined file paths plus scope-specific path segments for per-space and per-page artifacts, and report partial failures without aborting the full run.
+
+## 4. Verification
+
+- [x] 4.1 Add representative integration or workflow tests covering plain, space-aware, and paginated Kibana endpoints.
+- [x] 4.2 Add ignored external-service compatibility tests for Kibana `6.8.x`, `7.17.x`, `8.19.x`, and `9.x`.
+- [x] 4.3 Run `cargo clippy --workspace --all-targets`.
+- [x] 4.4 Run `cargo test --workspace`.

--- a/src/client/kibana.rs
+++ b/src/client/kibana.rs
@@ -4,7 +4,7 @@
 
 use crate::data::{Auth, KnownHost};
 use base64::Engine;
-use eyre::{Result, eyre};
+use eyre::Result;
 use reqwest::{Client, Method, multipart};
 use std::collections::HashMap;
 use url::Url;
@@ -86,7 +86,7 @@ impl KibanaClient {
                 .headers(headers),
         };
 
-        let response = match body {
+        match body {
             Some(body) if use_form_data => {
                 // As of October 2025 we're using a static filename, as the only
                 // use of form data is dashboards.ndjson for the saved objects API
@@ -102,8 +102,8 @@ impl KibanaClient {
                 request.body(body.to_vec()).send().await
             }
             None => request.send().await,
-        };
-        response.map_err(|e| eyre!("Failed to send request: {}", e))
+        }
+        .map_err(Into::into)
     }
 
     /// Verify the connection and authentication to Kibana

--- a/src/client/kibana.rs
+++ b/src/client/kibana.rs
@@ -4,7 +4,7 @@
 
 use crate::data::{Auth, KnownHost};
 use base64::Engine;
-use eyre::Result;
+use eyre::{Context, Result};
 use reqwest::{Client, Method, multipart};
 use std::collections::HashMap;
 use url::Url;
@@ -103,7 +103,7 @@ impl KibanaClient {
             }
             None => request.send().await,
         }
-        .map_err(Into::into)
+        .wrap_err("Failed to send request")
     }
 
     /// Verify the connection and authentication to Kibana

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ enum Commands {
     /// Collect a diagnostic bundle from a known host's API endpoints, writes output to a directory
     Collect {
         /// The host to collect diagnostics from
-        #[arg(help = "The Elasticsearch host to collect diagnostics from")]
+        #[arg(help = "The Elastic Stack host to collect diagnostics from")]
         host: String,
         /// The output directory to save the diagnostics to
         #[arg(help = "An existing directory to create a diagnostic directory and files in")]

--- a/src/processor/api.rs
+++ b/src/processor/api.rs
@@ -142,7 +142,7 @@ impl ElasticsearchApi {
                     &[],
                 ) {
                     Ok((_, source)) => {
-                        if source.tags.as_deref() == Some("light") {
+                        if source.has_tag("light") {
                             ApiWeight::Light
                         } else {
                             ApiWeight::Heavy
@@ -157,6 +157,41 @@ impl ElasticsearchApi {
 }
 
 impl std::str::FromStr for ElasticsearchApi {
+    type Err = eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::parse(s)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum KibanaApi {
+    Status,
+    Spaces,
+    Raw(String),
+}
+
+impl KibanaApi {
+    pub fn as_str(&self) -> &str {
+        match self {
+            KibanaApi::Status => "kibana_status",
+            KibanaApi::Spaces => "kibana_spaces",
+            KibanaApi::Raw(name) => name.as_str(),
+        }
+    }
+
+    pub fn parse(s: &str) -> Result<Self> {
+        crate::processor::diagnostic::data_source::get_source("kibana", s, &[])
+            .map_err(|_| eyre!("Invalid Kibana API: {}", s))?;
+        match s {
+            "kibana_status" => Ok(KibanaApi::Status),
+            "kibana_spaces" => Ok(KibanaApi::Spaces),
+            _ => Ok(KibanaApi::Raw(s.to_string())),
+        }
+    }
+}
+
+impl std::str::FromStr for KibanaApi {
     type Err = eyre::Report;
 
     fn from_str(s: &str) -> Result<Self> {
@@ -244,25 +279,84 @@ impl std::str::FromStr for LogstashApi {
 pub struct ApiResolver;
 
 impl ApiResolver {
+    fn resolve_requested(
+        mut requested: IndexSet<String>,
+        minimum_required: &[&str],
+        dependencies: &HashMap<String, Vec<String>>,
+    ) -> IndexSet<String> {
+        for req in minimum_required {
+            requested.insert((*req).to_string());
+        }
+
+        let mut final_set: IndexSet<String> = IndexSet::new();
+
+        fn resolve_deps(
+            api: &str,
+            deps_map: &HashMap<String, Vec<String>>,
+            final_set: &mut IndexSet<String>,
+            visited: &mut IndexSet<String>,
+        ) {
+            if visited.contains(api) {
+                return;
+            }
+            visited.insert(api.to_string());
+            if let Some(api_deps) = deps_map.get(api) {
+                for dep in api_deps {
+                    resolve_deps(dep, deps_map, final_set, visited);
+                }
+            }
+            final_set.insert(api.to_string());
+        }
+
+        let mut visited = IndexSet::new();
+        for api in requested.iter() {
+            resolve_deps(api, dependencies, &mut final_set, &mut visited);
+        }
+
+        final_set
+    }
+
     pub fn es_minimum_required() -> Vec<&'static str> {
         vec!["cluster"]
+    }
+
+    pub fn kb_minimum_required() -> Vec<&'static str> {
+        vec!["kibana_status", "kibana_spaces"]
     }
 
     pub fn ls_minimum_required() -> Vec<&'static str> {
         vec!["logstash_node"]
     }
 
-    pub fn es_dependencies() -> HashMap<&'static str, Vec<&'static str>> {
+    pub fn es_dependencies() -> HashMap<String, Vec<String>> {
         let mut deps = HashMap::new();
-        deps.insert("nodes_stats", vec!["nodes"]);
-        deps.insert("nodes", vec!["cluster_settings"]);
+        deps.insert("nodes_stats".to_string(), vec!["nodes".to_string()]);
+        deps.insert("nodes".to_string(), vec!["cluster_settings".to_string()]);
         deps
     }
 
-    pub fn ls_dependencies() -> HashMap<&'static str, Vec<&'static str>> {
+    pub fn kb_dependencies(requested: &IndexSet<String>) -> HashMap<String, Vec<String>> {
         let mut deps = HashMap::new();
-        deps.insert("logstash_node", vec!["logstash_version", "logstash_plugins"]);
-        deps.insert("logstash_node_stats", vec!["logstash_node"]);
+        for api in requested {
+            if let Ok((_, source)) =
+                crate::processor::diagnostic::data_source::get_source("kibana", api, &[])
+                && source.is_spaceaware()
+            {
+                deps.entry(api.clone())
+                    .or_insert_with(Vec::new)
+                    .push("kibana_spaces".to_string());
+            }
+        }
+        deps
+    }
+
+    pub fn ls_dependencies() -> HashMap<String, Vec<String>> {
+        let mut deps = HashMap::new();
+        deps.insert(
+            "logstash_node".to_string(),
+            vec!["logstash_version".to_string(), "logstash_plugins".to_string()],
+        );
+        deps.insert("logstash_node_stats".to_string(), vec!["logstash_node".to_string()]);
         deps
     }
 
@@ -292,37 +386,33 @@ impl ApiResolver {
                 "tasks".to_string(),
             ],
             DiagnosticType::Support => {
-                let sources = crate::processor::diagnostic::data_source::get_sources();
-                if let Some(es_sources) = sources.get("elasticsearch") {
-                    es_sources.keys().cloned().collect()
-                } else {
-                    vec![]
-                }
+                crate::processor::diagnostic::data_source::get_source_keys("elasticsearch")
             }
             DiagnosticType::Light => {
-                let sources = crate::processor::diagnostic::data_source::get_sources();
-                if let Some(es_sources) = sources.get("elasticsearch") {
-                    let mut light_apis: Vec<String> = es_sources
-                        .iter()
-                        .filter_map(|(k, v)| {
-                            if v.tags.as_deref() == Some("light") {
-                                Some(k.clone())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect();
-                    // Ensure minimums are included
-                    if !light_apis.contains(&"cluster".to_string()) {
-                        light_apis.push("cluster".to_string());
-                    }
-                    if !light_apis.contains(&"nodes".to_string()) {
-                        light_apis.push("nodes".to_string());
-                    }
-                    light_apis
-                } else {
-                    vec![]
+                let mut light_apis =
+                    crate::processor::diagnostic::data_source::get_source_keys_with_tag(
+                        "elasticsearch",
+                        "light",
+                    );
+                if !light_apis.iter().any(|api| api == "cluster") {
+                    light_apis.push("cluster".to_string());
                 }
+                if !light_apis.iter().any(|api| api == "nodes") {
+                    light_apis.push("nodes".to_string());
+                }
+                light_apis
+            }
+        }
+    }
+
+    pub fn kb_base_apis(diag_type: &DiagnosticType) -> Vec<String> {
+        match diag_type {
+            DiagnosticType::Minimal => Self::kb_minimum_required()
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            DiagnosticType::Standard | DiagnosticType::Support | DiagnosticType::Light => {
+                crate::processor::diagnostic::data_source::get_source_keys("kibana")
             }
         }
     }
@@ -352,35 +442,8 @@ impl ApiResolver {
             }
         }
 
-        for req in Self::es_minimum_required() {
-            requested.insert(req.to_string());
-        }
-
-        let deps = Self::es_dependencies();
-        let mut final_set: IndexSet<String> = IndexSet::new();
-
-        fn resolve_deps(
-            api: &str,
-            deps_map: &HashMap<&'static str, Vec<&'static str>>,
-            final_set: &mut IndexSet<String>,
-            visited: &mut IndexSet<String>,
-        ) {
-            if visited.contains(api) {
-                return;
-            }
-            visited.insert(api.to_string());
-            if let Some(api_deps) = deps_map.get(api) {
-                for dep in api_deps {
-                    resolve_deps(dep, deps_map, final_set, visited);
-                }
-            }
-            final_set.insert(api.to_string());
-        }
-
-        let mut visited = IndexSet::new();
-        for api in requested.iter() {
-            resolve_deps(api, &deps, &mut final_set, &mut visited);
-        }
+        let final_set =
+            Self::resolve_requested(requested, &Self::es_minimum_required(), &Self::es_dependencies());
 
         let mut api_set: IndexSet<ElasticsearchApi> = IndexSet::new();
         for api in final_set.iter() {
@@ -389,6 +452,42 @@ impl ApiResolver {
 
         let apis: Vec<ElasticsearchApi> = api_set.into_iter().collect();
         Ok(apis)
+    }
+
+    pub fn resolve_kb(
+        diag_type: &DiagnosticType,
+        include: Option<&Vec<String>>,
+        exclude: Option<&Vec<String>>,
+    ) -> Result<Vec<KibanaApi>> {
+        let mut requested: IndexSet<String> = IndexSet::new();
+
+        for api in Self::kb_base_apis(diag_type) {
+            requested.insert(api);
+        }
+
+        if let Some(incs) = include {
+            for api in incs {
+                KibanaApi::parse(api)?;
+                requested.insert(api.to_string());
+            }
+        }
+
+        if let Some(excs) = exclude {
+            for api in excs {
+                KibanaApi::parse(api)?;
+                requested.swap_remove(api);
+            }
+        }
+
+        let deps = Self::kb_dependencies(&requested);
+        let final_set = Self::resolve_requested(requested, &Self::kb_minimum_required(), &deps);
+
+        let mut api_set: IndexSet<KibanaApi> = IndexSet::new();
+        for api in final_set.iter() {
+            api_set.insert(KibanaApi::parse(api)?);
+        }
+
+        Ok(api_set.into_iter().collect())
     }
 
     pub fn resolve_ls(
@@ -432,35 +531,8 @@ impl ApiResolver {
             }
         }
 
-        for req in Self::ls_minimum_required() {
-            requested.insert(req.to_string());
-        }
-
-        let deps = Self::ls_dependencies();
-        let mut final_set: IndexSet<String> = IndexSet::new();
-
-        fn resolve_deps(
-            api: &str,
-            deps_map: &HashMap<&'static str, Vec<&'static str>>,
-            final_set: &mut IndexSet<String>,
-            visited: &mut IndexSet<String>,
-        ) {
-            if visited.contains(api) {
-                return;
-            }
-            visited.insert(api.to_string());
-            if let Some(api_deps) = deps_map.get(api) {
-                for dep in api_deps {
-                    resolve_deps(dep, deps_map, final_set, visited);
-                }
-            }
-            final_set.insert(api.to_string());
-        }
-
-        let mut visited = IndexSet::new();
-        for api in requested.iter() {
-            resolve_deps(api, &deps, &mut final_set, &mut visited);
-        }
+        let final_set =
+            Self::resolve_requested(requested, &Self::ls_minimum_required(), &Self::ls_dependencies());
 
         let mut apis = Vec::new();
         for api in final_set.iter() {
@@ -591,5 +663,36 @@ mod tests {
         assert!(apis
             .iter()
             .any(|api| api.as_str() == "logstash_nodes_hot_threads_human"));
+    }
+
+    #[test]
+    fn test_kb_invalid_include() {
+        let res = ApiResolver::resolve_kb(
+            &DiagnosticType::Standard,
+            Some(&vec!["not_a_real_kibana_api".to_string()]),
+            None,
+        );
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_kb_minimal_includes_bootstrap_apis() {
+        let apis = ApiResolver::resolve_kb(&DiagnosticType::Minimal, None, None).unwrap();
+        let api_strs: Vec<&str> = apis.iter().map(|a| a.as_str()).collect();
+
+        assert!(api_strs.contains(&"kibana_status"));
+        assert!(api_strs.contains(&"kibana_spaces"));
+    }
+
+    #[test]
+    fn test_kb_excluding_required_api_keeps_it() {
+        let apis = ApiResolver::resolve_kb(
+            &DiagnosticType::Minimal,
+            None,
+            Some(&vec!["kibana_spaces".to_string()]),
+        )
+        .unwrap();
+        let api_strs: Vec<&str> = apis.iter().map(|a| a.as_str()).collect();
+        assert!(api_strs.contains(&"kibana_spaces"));
     }
 }

--- a/src/processor/collector.rs
+++ b/src/processor/collector.rs
@@ -52,7 +52,6 @@ impl Collector {
                 Ok(Self::Elasticsearch(collector))
             }
             (Product::Logstash, receiver @ Receiver::Logstash(_)) => {
-            (Product::Logstash, receiver @ Receiver::Logstash(_)) => {
                 let collect_exporter = exporter.into_collect_exporter()?;
                 let collector = LogstashCollector::new(receiver, collect_exporter, options).await?;
                 Ok(Self::Logstash(collector))

--- a/src/processor/collector.rs
+++ b/src/processor/collector.rs
@@ -2,13 +2,10 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::{elasticsearch::ElasticsearchCollector, logstash::LogstashCollector};
-use crate::{
-    data::Product,
-    exporter::Exporter,
-    processor::Identifiers,
-    receiver::Receiver,
+use super::{
+    elasticsearch::ElasticsearchCollector, kibana::KibanaCollector, logstash::LogstashCollector,
 };
+use crate::{data::Product, exporter::Exporter, processor::Identifiers, receiver::Receiver};
 use eyre::{Result, eyre};
 
 #[derive(Debug, Clone)]
@@ -23,6 +20,7 @@ pub struct CollectOptions {
 pub enum Collector {
     Elasticsearch(ElasticsearchCollector),
     Logstash(LogstashCollector),
+    Kibana(KibanaCollector),
 }
 
 impl Collector {
@@ -54,14 +52,25 @@ impl Collector {
                 Ok(Self::Elasticsearch(collector))
             }
             (Product::Logstash, receiver @ Receiver::Logstash(_)) => {
+            (Product::Logstash, receiver @ Receiver::Logstash(_)) => {
                 let collect_exporter = exporter.into_collect_exporter()?;
                 let collector = LogstashCollector::new(receiver, collect_exporter, options).await?;
                 Ok(Self::Logstash(collector))
             }
+            (Product::Kibana, receiver @ Receiver::Kibana(_)) => {
+                let collect_exporter = exporter.into_collect_exporter()?;
+                let collector = KibanaCollector::new(receiver, collect_exporter, options).await?;
+                Ok(Self::Kibana(collector))
+            }
             (Product::Logstash, _) => Err(eyre!(
                 "Collect for Logstash requires a standard known-host endpoint"
             )),
-            _ => Err(eyre!("Collect is only implemented for Elasticsearch and Logstash hosts")),
+            (Product::Kibana, _) => Err(eyre!(
+                "Collect for Kibana requires a standard known-host endpoint"
+            )),
+            _ => Err(eyre!(
+                "Collect is only implemented for Elasticsearch, Kibana, and Logstash hosts"
+            )),
         }
     }
 
@@ -69,6 +78,7 @@ impl Collector {
         let result = match self {
             Self::Elasticsearch(collector) => collector.collect().await?,
             Self::Logstash(collector) => collector.collect().await?,
+            Self::Kibana(collector) => collector.collect().await?,
         };
 
         log::info!(

--- a/src/processor/diagnostic/data_source.rs
+++ b/src/processor/diagnostic/data_source.rs
@@ -100,6 +100,7 @@ pub trait DataSource {
 pub fn source_product_key(product: &Product) -> Result<&'static str> {
     match product {
         Product::Elasticsearch => Ok("elasticsearch"),
+        Product::Kibana => Ok("kibana"),
         Product::Logstash => Ok("logstash"),
         _ => Err(eyre!(
             "sources.yml overrides are not supported for product {}",
@@ -118,12 +119,35 @@ pub trait StreamingDataSource: DataSource {
         D: Deserializer<'de>;
 }
 
-#[derive(Clone, PartialEq, Serialize, Deserialize, Eq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Eq)]
+#[serde(untagged)]
+pub enum VersionSource {
+    Url(String),
+    Structured(VersionSourceDetails),
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Eq)]
+pub struct VersionSourceDetails {
+    pub url: String,
+    #[serde(default)]
+    pub spaceaware: bool,
+    pub paginate: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedVersionSource {
+    pub url: String,
+    pub spaceaware: bool,
+    pub paginate: Option<String>,
+}
+
+#[allow(dead_code)] // For future use deserialzing the sources.yml
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Eq)]
 pub struct Source {
     pub extension: Option<String>,
     pub subdir: Option<String>,
     pub tags: Option<String>,
-    pub versions: BTreeMap<String, String>,
+    pub versions: BTreeMap<String, VersionSource>,
 }
 
 impl Default for Source {
@@ -151,6 +175,7 @@ static SOURCES: OnceLock<HashMap<&'static str, HashMap<String, Source>>> = OnceL
 fn embedded_sources_str(product: &str) -> Result<&'static str> {
     match product {
         "elasticsearch" => Ok(include_str!("../../../assets/elasticsearch/sources.yml")),
+        "kibana" => Ok(include_str!("../../../assets/kibana/sources.yml")),
         "logstash" => Ok(include_str!("../../../assets/logstash/sources.yml")),
         other => Err(eyre!("Unsupported sources product: {}", other)),
     }
@@ -159,6 +184,7 @@ fn embedded_sources_str(product: &str) -> Result<&'static str> {
 fn required_source_keys(product: &str) -> &'static [&'static str] {
     match product {
         "elasticsearch" => &["version"],
+        "kibana" => &["kibana_status", "kibana_spaces"],
         "logstash" => &["logstash_node", "logstash_version"],
         _ => &[],
     }
@@ -197,7 +223,7 @@ fn load_embedded_sources(
 ) -> Result<HashMap<&'static str, HashMap<String, Source>>> {
     let mut products = HashMap::new();
 
-    for product in ["elasticsearch", "logstash"] {
+    for product in ["elasticsearch", "kibana", "logstash"] {
         let (label, content) = if override_product == Some(product) {
             let path =
                 override_path.ok_or_else(|| eyre!("Override path missing for {}", product))?;
@@ -259,6 +285,27 @@ pub fn get_source<'a>(
     ))
 }
 
+pub fn get_product_sources(product: &str) -> Option<&'static HashMap<String, Source>> {
+    get_sources().get(product)
+}
+
+pub fn get_source_keys(product: &str) -> Vec<String> {
+    get_product_sources(product)
+        .map(|sources| sources.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+pub fn get_source_keys_with_tag(product: &str, tag: &str) -> Vec<String> {
+    get_product_sources(product)
+        .map(|sources| {
+            sources
+                .iter()
+                .filter_map(|(name, source)| source.has_tag(tag).then_some(name.clone()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn convert_npm_semver_to_cargo(req: &str) -> String {
     let parts: Vec<&str> = req.split_whitespace().collect();
     let mut out = String::new();
@@ -290,22 +337,51 @@ impl Source {
         }
     }
 
-    pub fn get_url(&self, version: &Version) -> Result<String> {
+    pub fn has_tag(&self, tag: &str) -> bool {
+        self.tags
+            .as_deref()
+            .map(|tags| tags.split(',').any(|value| value.trim() == tag))
+            .unwrap_or(false)
+    }
+
+    pub fn is_spaceaware(&self) -> bool {
+        self.versions.values().any(|version| match version {
+            VersionSource::Url(_) => false,
+            VersionSource::Structured(details) => details.spaceaware,
+        })
+    }
+
+    pub fn resolve_version(&self, version: &Version) -> Result<ResolvedVersionSource> {
         // Strip pre-release tags (like -SNAPSHOT) to ensure our broad semver matching logic
         // in sources.yml (e.g. ">= 7.0.0") matches properly. Standard semver treats ">= 7.0.0"
         // as NOT matching "8.0.0-SNAPSHOT" by default unless specifically asked to.
         let mut clean_version = version.clone();
         clean_version.pre = semver::Prerelease::EMPTY;
 
-        for (req_str, url) in &self.versions {
+        for (req_str, source) in &self.versions {
             let cargo_req_str = convert_npm_semver_to_cargo(req_str);
             let req = VersionReq::parse(&cargo_req_str)
                 .map_err(|e| eyre!("Failed to parse version req '{}': {}", req_str, e))?;
             if req.matches(&clean_version) {
-                return Ok(url.clone());
+                return Ok(match source {
+                    VersionSource::Url(url) => ResolvedVersionSource {
+                        url: url.clone(),
+                        spaceaware: false,
+                        paginate: None,
+                    },
+                    VersionSource::Structured(details) => ResolvedVersionSource {
+                        url: details.url.clone(),
+                        spaceaware: details.spaceaware,
+                        paginate: details.paginate.clone(),
+                    },
+                });
             }
         }
         Err(DataSourceError::UnsupportedVersion(version.clone()).into())
+    }
+
+    pub fn get_url(&self, version: &Version) -> Result<String> {
+        Ok(self.resolve_version(version)?.url)
     }
 }
 
@@ -452,5 +528,29 @@ version:
             Err(err) => err,
         };
         assert!(err.to_string().contains("valid logstash sources.yml"));
+    }
+
+    #[test]
+    fn test_kibana_structured_version_resolution() {
+        let sources = get_sources();
+        let kibana_sources = sources.get("kibana").unwrap();
+        let alerts = kibana_sources.get("kibana_alerts").unwrap();
+
+        let resolved = alerts
+            .resolve_version(&Version::parse("8.19.0").unwrap())
+            .unwrap();
+
+        assert_eq!(resolved.url, "/api/alerts/_find");
+        assert!(resolved.spaceaware);
+        assert_eq!(resolved.paginate.as_deref(), Some("per_page"));
+    }
+
+    #[test]
+    fn test_kibana_source_file_path_generation() {
+        let sources = get_sources();
+        let kibana_sources = sources.get("kibana").unwrap();
+        let status = kibana_sources.get("kibana_status").unwrap();
+
+        assert_eq!(status.get_file_path("kibana_status"), "kibana_status.json");
     }
 }

--- a/src/processor/diagnostic/data_source.rs
+++ b/src/processor/diagnostic/data_source.rs
@@ -73,7 +73,11 @@ pub trait DataSource {
         let name = Self::name();
         let aliases = Self::aliases();
         let (_, source_conf) = get_source(ctx.product, &name, &aliases)?;
-        Ok(source_conf.extension.as_deref().unwrap_or(".json").to_string())
+        Ok(source_conf
+            .extension
+            .as_deref()
+            .unwrap_or(".json")
+            .to_string())
     }
 
     fn candidate_source_file_paths(ctx: &SourceContext) -> Result<Vec<String>> {
@@ -141,7 +145,6 @@ pub struct ResolvedVersionSource {
     pub paginate: Option<String>,
 }
 
-#[allow(dead_code)] // For future use deserialzing the sources.yml
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Eq)]
 pub struct Source {
     pub extension: Option<String>,

--- a/src/processor/kibana/collector.rs
+++ b/src/processor/kibana/collector.rs
@@ -7,7 +7,6 @@ use crate::{
     data::Product,
     exporter::ArchiveExporter,
     processor::{
-        DataSource,
         DiagnosticManifest,
         api::{ApiResolver, DiagnosticType, KibanaApi},
     },
@@ -295,10 +294,7 @@ impl KibanaCollector {
         .with_identifiers(self.options.identifiers.clone())
         .with_collected_apis(collected_api_names);
 
-        let path = PathBuf::from(DiagnosticManifest::source(
-            crate::processor::PathType::File,
-            None,
-        )?);
+        let path = PathBuf::from(DiagnosticManifest::FILENAME);
         let filename = format!("{}", path.display());
         let content = serde_json::to_string_pretty(&manifest)?;
         self.exporter.save(path, content).await?;

--- a/src/processor/kibana/collector.rs
+++ b/src/processor/kibana/collector.rs
@@ -1,0 +1,406 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+use super::super::collector::{CollectOptions, CollectionResult};
+use crate::{
+    data::Product,
+    exporter::ArchiveExporter,
+    processor::{
+        DataSource,
+        DiagnosticManifest,
+        api::{ApiResolver, DiagnosticType, KibanaApi},
+    },
+    receiver::{KibanaReceiver, Receiver},
+};
+use eyre::{Result, WrapErr, eyre};
+use futures::stream::{self, StreamExt};
+use serde_json::Value;
+use std::{path::PathBuf, str::FromStr, time::Duration};
+
+pub struct KibanaCollector {
+    receiver: Receiver,
+    exporter: ArchiveExporter,
+    options: CollectOptions,
+}
+
+impl KibanaCollector {
+    pub async fn new(
+        receiver: Receiver,
+        exporter: ArchiveExporter,
+        options: CollectOptions,
+    ) -> Result<Self> {
+        let timestamp = chrono::Local::now().format("%Y%m%d-%H%M%S").to_string();
+        let collection_name = options
+            .identifiers
+            .filename
+            .as_ref()
+            .and_then(|name| std::path::Path::new(name).file_stem())
+            .map(|stem| stem.to_string_lossy().to_string())
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| format!("api-diagnostics-{}", timestamp));
+        Ok(Self {
+            receiver,
+            exporter: exporter.with_archive_name(&collection_name)?,
+            options,
+        })
+    }
+
+    pub async fn collect(&self) -> Result<CollectionResult> {
+        let collect_result: Result<CollectionResult> = async {
+            let diag_type = DiagnosticType::from_str(&self.options.r#type)?;
+            let apis = ApiResolver::resolve_kb(
+                &diag_type,
+                self.options.include.as_ref(),
+                self.options.exclude.as_ref(),
+            )?;
+
+            let mut result = CollectionResult {
+                path: self.exporter.to_string(),
+                success: 0,
+                total: apis.len() + 1,
+            };
+
+            result.success += self.save_diagnostic_manifest(&apis).await?;
+
+            let mut api_stream = stream::iter(apis)
+                .map(|api| async move { self.save_api_with_retry(&api).await })
+                .buffer_unordered(5);
+
+            while let Some(res) = api_stream.next().await {
+                result.success += res;
+            }
+
+            Ok(result)
+        }
+        .await;
+
+        let finalize_result = self.exporter.finalize();
+
+        match (collect_result, finalize_result) {
+            (Ok(result), Ok(())) => Ok(result),
+            (Err(err), Ok(())) => Err(err),
+            (Ok(_), Err(finalize_err)) => Err(finalize_err),
+            (Err(err), Err(finalize_err)) => {
+                Err(err).wrap_err(format!("Failed to finalize archive: {}", finalize_err))
+            }
+        }
+    }
+
+    async fn save_api_with_retry(&self, api: &KibanaApi) -> usize {
+        let max_duration = Duration::from_secs(300);
+        let start_time = std::time::Instant::now();
+        let mut attempt = 1;
+        let mut delay = Duration::from_secs(2);
+
+        loop {
+            match self.save_api(api).await {
+                Ok(success) => return success,
+                Err(e) => {
+                    if start_time.elapsed() > max_duration {
+                        log::error!(
+                            "Failed to save {} after {} attempts (5 min timeout): {}",
+                            api.as_str(),
+                            attempt,
+                            e
+                        );
+                        return 0;
+                    }
+                    log::warn!(
+                        "Attempt {} failed for {}: {}. Retrying in {:?}...",
+                        attempt,
+                        api.as_str(),
+                        e,
+                        delay
+                    );
+                    tokio::time::sleep(delay).await;
+                    attempt += 1;
+                    delay = std::cmp::min(delay * 2, Duration::from_secs(60));
+                }
+            }
+        }
+    }
+
+    async fn save_api(&self, api: &KibanaApi) -> Result<usize> {
+        let receiver = match &self.receiver {
+            Receiver::Kibana(receiver) => receiver,
+            _ => return Ok(0),
+        };
+        let source_conf =
+            match crate::processor::diagnostic::data_source::get_source("kibana", api.as_str(), &[])
+            {
+                Ok((_, conf)) => conf,
+                Err(e) => {
+                    log::debug!("Skipping {} collection: {}", api.as_str(), e);
+                    return Ok(0);
+                }
+            };
+
+        let version = receiver.get_version().await?;
+        let resolved = match source_conf.resolve_version(version) {
+            Ok(resolved) => resolved,
+            Err(e) => {
+                log::debug!(
+                    "Skipping {} collection on version {}: {}",
+                    api.as_str(),
+                    version,
+                    e
+                );
+                return Ok(0);
+            }
+        };
+
+        let scopes = if resolved.spaceaware {
+            match receiver.get_spaces().await {
+                Ok(spaces) if !spaces.is_empty() => spaces.clone(),
+                Ok(_) => vec!["default".to_string()],
+                Err(err) => {
+                    log::warn!(
+                        "Failed to resolve Kibana spaces for {}: {}. Falling back to default space.",
+                        api.as_str(),
+                        err
+                    );
+                    vec!["default".to_string()]
+                }
+            }
+        } else {
+            vec![String::new()]
+        };
+
+        let mut saved = 0;
+        for scope in scopes {
+            let space = resolved.spaceaware.then_some(scope.as_str());
+            saved += self
+                .save_endpoint(receiver, api.as_str(), source_conf, &resolved.url, space, resolved.paginate.as_deref())
+                .await?;
+        }
+
+        Ok(saved)
+    }
+
+    async fn save_endpoint(
+        &self,
+        receiver: &KibanaReceiver,
+        api_name: &str,
+        source_conf: &crate::processor::diagnostic::data_source::Source,
+        base_url: &str,
+        space: Option<&str>,
+        paginate_field: Option<&str>,
+    ) -> Result<usize> {
+        let base_file_path = source_conf.get_file_path(api_name);
+        let extension = source_conf.extension.as_deref().unwrap_or(".json");
+
+        if let Some(paginate_field) = paginate_field {
+            return self
+                .save_paginated_endpoint(
+                    receiver,
+                    &base_file_path,
+                    base_url,
+                    space,
+                    extension,
+                    paginate_field,
+                )
+                .await;
+        }
+
+        let request_path = with_space_prefix(base_url, space);
+        let content = receiver.get_raw_by_path(&request_path, extension).await?;
+        self.save_content(&base_file_path, content, space, None).await
+    }
+
+    async fn save_paginated_endpoint(
+        &self,
+        receiver: &KibanaReceiver,
+        base_file_path: &str,
+        base_url: &str,
+        space: Option<&str>,
+        extension: &str,
+        paginate_field: &str,
+    ) -> Result<usize> {
+        const PAGE_SIZE: usize = 100;
+
+        let mut page = 1;
+        let mut total_pages = 1;
+        let mut saved = 0;
+
+        loop {
+            let request_path =
+                with_pagination_query(&with_space_prefix(base_url, space), paginate_field, page, PAGE_SIZE);
+            let content = receiver.get_raw_by_path(&request_path, extension).await?;
+            total_pages = total_pages.max(parse_total_pages(&content, paginate_field, page).unwrap_or(page));
+
+            let page_scope = (total_pages > 1).then_some(page);
+            saved += self
+                .save_content(base_file_path, content, space, page_scope)
+                .await?;
+
+            if page >= total_pages {
+                break;
+            }
+            page += 1;
+        }
+
+        Ok(saved)
+    }
+
+    async fn save_content(
+        &self,
+        base_file_path: &str,
+        content: String,
+        space: Option<&str>,
+        page: Option<usize>,
+    ) -> Result<usize> {
+        let file_path = scoped_output_path(base_file_path, space, page);
+        let filename = format!("{}", file_path.display());
+
+        match self.exporter.save(file_path, content).await {
+            Ok(()) => {
+                log::info!("Saved {filename}");
+                Ok(1)
+            }
+            Err(e) => {
+                log::error!("Failed to save {filename}: {e}");
+                Ok(0)
+            }
+        }
+    }
+
+    async fn save_diagnostic_manifest(&self, apis: &[KibanaApi]) -> Result<usize> {
+        let version = match &self.receiver {
+            Receiver::Kibana(receiver) => receiver.get_version().await?.to_string(),
+            _ => return Err(eyre!("Kibana manifest requires a Kibana receiver")),
+        };
+
+        let collected_api_names: Vec<String> =
+            apis.iter().map(|api| api.as_str().to_string()).collect();
+        let manifest = DiagnosticManifest::new(
+            chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            Some(format!("esdiag-{}", env!("CARGO_PKG_VERSION"))),
+            None,
+            None,
+            Some(self.options.r#type.clone()),
+            Product::Kibana,
+            Some("kibana_diagnostic".to_string()),
+            Some("esdiag".to_string()),
+            Some(version),
+        )
+        .with_identifiers(self.options.identifiers.clone())
+        .with_collected_apis(collected_api_names);
+
+        let path = PathBuf::from(DiagnosticManifest::source(
+            crate::processor::PathType::File,
+            None,
+        )?);
+        let filename = format!("{}", path.display());
+        let content = serde_json::to_string_pretty(&manifest)?;
+        self.exporter.save(path, content).await?;
+        log::info!("Saved {filename}");
+        Ok(1)
+    }
+}
+
+fn with_space_prefix(path: &str, space: Option<&str>) -> String {
+    match space {
+        Some(space) if !space.is_empty() => format!("/s/{space}{path}"),
+        _ => path.to_string(),
+    }
+}
+
+fn with_pagination_query(path: &str, paginate_field: &str, page: usize, page_size: usize) -> String {
+    let mut request_path = path.to_string();
+    let separator = if request_path.contains('?') { '&' } else { '?' };
+    request_path.push(separator);
+    request_path.push_str(&format!("page={page}"));
+
+    if !request_path.contains(&format!("{paginate_field}=")) {
+        request_path.push('&');
+        request_path.push_str(&format!("{paginate_field}={page_size}"));
+    }
+
+    request_path
+}
+
+fn parse_total_pages(content: &str, paginate_field: &str, current_page: usize) -> Option<usize> {
+    let value: Value = serde_json::from_str(content).ok()?;
+    let total = value.get("total")?.as_u64()? as usize;
+    let page = value
+        .get("page")
+        .and_then(Value::as_u64)
+        .map(|value| value as usize)
+        .unwrap_or(current_page);
+    let per_page = lookup_page_size(&value, paginate_field)? as usize;
+    if per_page == 0 {
+        return None;
+    }
+    Some(std::cmp::max(page, total.div_ceil(per_page)))
+}
+
+fn lookup_page_size(value: &Value, paginate_field: &str) -> Option<u64> {
+    value
+        .get(paginate_field)
+        .and_then(Value::as_u64)
+        .or_else(|| value.get("per_page").and_then(Value::as_u64))
+        .or_else(|| value.get("perPage").and_then(Value::as_u64))
+}
+
+fn scoped_output_path(base_file_path: &str, space: Option<&str>, page: Option<usize>) -> PathBuf {
+    let mut path = PathBuf::new();
+    if let Some(space) = space {
+        path.push("spaces");
+        path.push(sanitize_segment(space));
+    }
+    if let Some(page) = page {
+        path.push("pages");
+        path.push(format!("page-{:04}", page));
+    }
+    path.push(base_file_path);
+    path
+}
+
+fn sanitize_segment(segment: &str) -> String {
+    segment.replace(['/', '\\', ':'], "_")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scoped_output_path_preserves_plain_file_layout() {
+        let path = scoped_output_path("alerts/kibana_alerts.json", None, None);
+        assert_eq!(path, PathBuf::from("alerts/kibana_alerts.json"));
+    }
+
+    #[test]
+    fn scoped_output_path_adds_space_and_page_segments() {
+        let path = scoped_output_path("alerts/kibana_alerts.json", Some("default"), Some(2));
+        assert_eq!(
+            path,
+            PathBuf::from("spaces/default/pages/page-0002/alerts/kibana_alerts.json")
+        );
+    }
+
+    #[test]
+    fn pagination_query_appends_page_and_size() {
+        let path = with_pagination_query("/api/alerts/_find?sort=asc", "per_page", 3, 100);
+        assert_eq!(path, "/api/alerts/_find?sort=asc&page=3&per_page=100");
+    }
+
+    #[test]
+    fn pagination_query_supports_page_size_style() {
+        let path = with_pagination_query("/api/endpoint/metadata", "pageSize", 2, 50);
+        assert_eq!(path, "/api/endpoint/metadata?page=2&pageSize=50");
+    }
+
+    #[test]
+    fn parse_total_pages_supports_snake_case_page_size() {
+        let body = r#"{"page":1,"per_page":100,"total":205,"data":[]}"#;
+        assert_eq!(parse_total_pages(body, "per_page", 1), Some(3));
+    }
+
+    #[test]
+    fn parse_total_pages_supports_camel_case_page_size() {
+        let body = r#"{"page":1,"perPage":100,"total":150,"items":[]}"#;
+        assert_eq!(parse_total_pages(body, "perPage", 1), Some(2));
+    }
+}

--- a/src/processor/kibana/collector.rs
+++ b/src/processor/kibana/collector.rs
@@ -11,7 +11,7 @@ use crate::{
         DiagnosticManifest,
         api::{ApiResolver, DiagnosticType, KibanaApi},
     },
-    receiver::{KibanaReceiver, Receiver},
+    receiver::{KibanaReceiver, KibanaRequestError, Receiver},
 };
 use eyre::{Result, WrapErr, eyre};
 use futures::stream::{self, StreamExt};
@@ -97,6 +97,14 @@ impl KibanaCollector {
             match self.save_api(api).await {
                 Ok(success) => return success,
                 Err(e) => {
+                    if !should_retry_kibana_error(&e) {
+                        log::warn!(
+                            "Skipping non-retriable failure for {}: {}",
+                            api.as_str(),
+                            e
+                        );
+                        return 0;
+                    }
                     if start_time.elapsed() > max_duration {
                         log::error!(
                             "Failed to save {} after {} attempts (5 min timeout): {}",
@@ -361,9 +369,17 @@ fn sanitize_segment(segment: &str) -> String {
     segment.replace(['/', '\\', ':'], "_")
 }
 
+fn should_retry_kibana_error(error: &eyre::Report) -> bool {
+    if let Some(request_error) = error.downcast_ref::<KibanaRequestError>() {
+        return request_error.status.as_u16() == 429 || request_error.status.is_server_error();
+    }
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reqwest::StatusCode;
 
     #[test]
     fn scoped_output_path_preserves_plain_file_layout() {
@@ -402,5 +418,29 @@ mod tests {
     fn parse_total_pages_supports_camel_case_page_size() {
         let body = r#"{"page":1,"perPage":100,"total":150,"items":[]}"#;
         assert_eq!(parse_total_pages(body, "perPage", 1), Some(2));
+    }
+
+    #[test]
+    fn retry_policy_skips_non_retriable_client_errors() {
+        let error = eyre::Report::from(KibanaRequestError {
+            status: StatusCode::FORBIDDEN,
+            body: "forbidden".to_string(),
+        });
+        assert!(!should_retry_kibana_error(&error));
+    }
+
+    #[test]
+    fn retry_policy_retries_server_errors_and_rate_limits() {
+        let rate_limit = eyre::Report::from(KibanaRequestError {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            body: "slow down".to_string(),
+        });
+        let server_error = eyre::Report::from(KibanaRequestError {
+            status: StatusCode::BAD_GATEWAY,
+            body: "gateway".to_string(),
+        });
+
+        assert!(should_retry_kibana_error(&rate_limit));
+        assert!(should_retry_kibana_error(&server_error));
     }
 }

--- a/src/processor/kibana/collector.rs
+++ b/src/processor/kibana/collector.rs
@@ -132,7 +132,7 @@ impl KibanaCollector {
     async fn save_api(&self, api: &KibanaApi) -> Result<usize> {
         let receiver = match &self.receiver {
             Receiver::Kibana(receiver) => receiver,
-            _ => return Ok(0),
+            _ => return Err(eyre!("KibanaCollector requires a Kibana receiver")),
         };
         let source_conf =
             match crate::processor::diagnostic::data_source::get_source("kibana", api.as_str(), &[])
@@ -373,7 +373,10 @@ fn should_retry_kibana_error(error: &eyre::Report) -> bool {
     if let Some(request_error) = error.downcast_ref::<KibanaRequestError>() {
         return request_error.status.as_u16() == 429 || request_error.status.is_server_error();
     }
-    true
+    if let Some(request_error) = error.downcast_ref::<reqwest::Error>() {
+        return request_error.is_connect() || request_error.is_timeout();
+    }
+    false
 }
 
 #[cfg(test)]

--- a/src/processor/kibana/mod.rs
+++ b/src/processor/kibana/mod.rs
@@ -2,4 +2,6 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-// TODO: Add Kibana diagnostic processor
+mod collector;
+
+pub use collector::KibanaCollector;

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -11,6 +11,8 @@ pub mod diagnostic;
 mod elastic_cloud_kubernetes;
 /// Processors for Elasticsearch diagnostics
 mod elasticsearch;
+/// Processors for Kibana diagnostics
+mod kibana;
 /// Processors for Managed Kubernetes Infrastructure (MKI) platform diagnostics
 mod kubernetes_platform;
 /// Processors for Logstash diagnostics

--- a/src/receiver/kibana.rs
+++ b/src/receiver/kibana.rs
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::super::processor::{DataSource, DiagnosticManifest, PathType, StreamingDataSource};
+use super::super::processor::{DataSource, DiagnosticManifest, SourceContext, StreamingDataSource};
 use super::{Receive, ReceiveRaw};
 use crate::{client::KibanaClient, data::{KnownHost, Product}};
 use eyre::{Result, eyre};
@@ -151,8 +151,8 @@ impl Receive for KibanaReceiver {
     where
         T: DataSource + DeserializeOwned,
     {
-        let version = self.get_version().await?;
-        let path = T::source(PathType::Url, Some(version))?;
+        let ctx = SourceContext::new("kibana", Some(self.get_version().await?.clone()));
+        let path = T::resolve_source_request_path(&ctx)?;
         let response = self
             .client
             .request(Method::GET, &HashMap::new(), &path, None)
@@ -201,16 +201,10 @@ impl ReceiveRaw for KibanaReceiver {
     where
         T: DataSource,
     {
-        let version = self.get_version().await?;
-        let path = T::source(PathType::Url, Some(version))?;
-
-        let name = T::name();
-        let aliases = T::aliases();
-        let source_conf =
-            crate::processor::diagnostic::data_source::get_source(T::product(), &name, &aliases)?;
-        let extension = source_conf.1.extension.as_deref().unwrap_or(".json");
-
-        self.get_raw_by_path(&path, extension).await
+        let ctx = SourceContext::new("kibana", Some(self.get_version().await?.clone()));
+        let path = T::resolve_source_request_path(&ctx)?;
+        let extension = T::resolve_source_extension(&ctx)?;
+        self.get_raw_by_path(&path, &extension).await
     }
 }
 

--- a/src/receiver/kibana.rs
+++ b/src/receiver/kibana.rs
@@ -39,6 +39,20 @@ struct KibanaSpace {
     id: String,
 }
 
+#[derive(Debug)]
+pub struct KibanaRequestError {
+    pub status: reqwest::StatusCode,
+    pub body: String,
+}
+
+impl std::fmt::Display for KibanaRequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "http {} - {}", self.status, self.body)
+    }
+}
+
+impl std::error::Error for KibanaRequestError {}
+
 impl KibanaReceiver {
     pub fn new(url: Url, client: KibanaClient) -> Self {
         Self {
@@ -57,7 +71,7 @@ impl KibanaReceiver {
         let status = response.status();
         let body = response.text().await?;
         if !status.is_success() {
-            return Err(eyre!("http {} - {}", status, body));
+            return Err(KibanaRequestError { status, body }.into());
         }
         serde_json::from_str(&body).map_err(Into::into)
     }
@@ -82,7 +96,7 @@ impl KibanaReceiver {
                 let status = response.status();
                 let body = response.text().await?;
                 if !status.is_success() {
-                    return Err(eyre!("http {} - {}", status, body));
+                    return Err(KibanaRequestError { status, body }.into());
                 }
                 let spaces: Vec<KibanaSpace> = serde_json::from_str(&body)?;
                 Ok(spaces.into_iter().map(|space| space.id).collect())
@@ -104,7 +118,7 @@ impl KibanaReceiver {
         let status = response.status();
         let body = response.text().await?;
         if !status.is_success() {
-            return Err(eyre!("http {} - {}", status, body));
+            return Err(KibanaRequestError { status, body }.into());
         }
         Ok(body)
     }
@@ -150,7 +164,11 @@ impl Receive for KibanaReceiver {
             serde_json::from_str(&body).map_err(Into::into)
         } else {
             let body_json = serde_json::from_str::<Value>(&body).unwrap_or(Value::String(body));
-            Err(eyre!("http {} - {}", status, body_json))
+            Err(KibanaRequestError {
+                status,
+                body: body_json.to_string(),
+            }
+            .into())
         }
     }
 

--- a/src/receiver/kibana.rs
+++ b/src/receiver/kibana.rs
@@ -1,0 +1,198 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+use super::super::processor::{DataSource, DiagnosticManifest, PathType, StreamingDataSource};
+use super::{Receive, ReceiveRaw};
+use crate::{client::KibanaClient, data::{KnownHost, Product}};
+use eyre::{Result, eyre};
+use futures::stream::BoxStream;
+use reqwest::Method;
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
+use url::Url;
+
+#[derive(Clone)]
+pub struct KibanaReceiver {
+    client: KibanaClient,
+    url: Url,
+    version: Arc<OnceCell<semver::Version>>,
+    spaces: Arc<OnceCell<Vec<String>>>,
+}
+
+#[derive(Deserialize)]
+struct KibanaStatusVersion {
+    number: String,
+}
+
+#[derive(Deserialize)]
+struct KibanaStatusResponse {
+    version: KibanaStatusVersion,
+}
+
+#[derive(Deserialize)]
+struct KibanaSpace {
+    id: String,
+}
+
+impl KibanaReceiver {
+    pub fn new(url: Url, client: KibanaClient) -> Self {
+        Self {
+            client,
+            url,
+            version: Arc::new(OnceCell::new()),
+            spaces: Arc::new(OnceCell::new()),
+        }
+    }
+
+    async fn get_status(&self) -> Result<KibanaStatusResponse> {
+        let response = self
+            .client
+            .request(Method::GET, &HashMap::new(), "/api/status", None)
+            .await?;
+        let status = response.status();
+        let body = response.text().await?;
+        if !status.is_success() {
+            return Err(eyre!("http {} - {}", status, body));
+        }
+        serde_json::from_str(&body).map_err(Into::into)
+    }
+
+    pub async fn get_version(&self) -> Result<&semver::Version> {
+        self.version
+            .get_or_try_init(|| async {
+                let status = self.get_status().await?;
+                semver::Version::parse(&status.version.number)
+                    .map_err(|e| eyre!("Failed to parse Kibana version: {}", e))
+            })
+            .await
+    }
+
+    pub async fn get_spaces(&self) -> Result<&Vec<String>> {
+        self.spaces
+            .get_or_try_init(|| async {
+                let response = self
+                    .client
+                    .request(Method::GET, &HashMap::new(), "/api/spaces/space", None)
+                    .await?;
+                let status = response.status();
+                let body = response.text().await?;
+                if !status.is_success() {
+                    return Err(eyre!("http {} - {}", status, body));
+                }
+                let spaces: Vec<KibanaSpace> = serde_json::from_str(&body)?;
+                Ok(spaces.into_iter().map(|space| space.id).collect())
+            })
+            .await
+    }
+
+    pub async fn get_raw_by_path(&self, path: &str, extension: &str) -> Result<String> {
+        log::debug!("Getting raw Kibana API path: {}", path);
+
+        let mut headers = HashMap::new();
+        if extension == ".txt" {
+            headers.insert("Accept".to_string(), "text/plain".to_string());
+        } else {
+            headers.insert("Accept".to_string(), "application/json".to_string());
+        }
+
+        let response = self.client.request(Method::GET, &headers, path, None).await?;
+        response.text().await.map_err(Into::into)
+    }
+}
+
+impl TryFrom<KnownHost> for KibanaReceiver {
+    type Error = eyre::Report;
+
+    fn try_from(host: KnownHost) -> Result<Self> {
+        let url = host.get_url();
+        let client = KibanaClient::try_from(host)?;
+        Ok(Self::new(url, client))
+    }
+}
+
+impl Receive for KibanaReceiver {
+    async fn collection_date(&self) -> String {
+        chrono::Utc::now().to_rfc3339()
+    }
+
+    async fn is_connected(&self) -> bool {
+        self.client.test_connection().await.is_ok()
+    }
+
+    fn filename(&self) -> Option<String> {
+        None
+    }
+
+    async fn get<T>(&self) -> Result<T>
+    where
+        T: DataSource + DeserializeOwned,
+    {
+        let version = self.get_version().await.ok();
+        let path = T::source(PathType::Url, version)?;
+        let response = self
+            .client
+            .request(Method::GET, &HashMap::new(), &path, None)
+            .await?;
+        let status = response.status();
+        let body = response.text().await?;
+
+        if status.is_success() {
+            serde_json::from_str(&body).map_err(Into::into)
+        } else {
+            let body_json = serde_json::from_str::<Value>(&body).unwrap_or(Value::String(body));
+            Err(eyre!("http {} - {}", status, body_json))
+        }
+    }
+
+    async fn get_stream<T>(&self) -> Result<BoxStream<'static, Result<T::Item>>>
+    where
+        T: StreamingDataSource + DeserializeOwned,
+        T::Item: DeserializeOwned + Send + 'static,
+    {
+        Err(eyre!("Streaming is not yet implemented for Kibana receiver"))
+    }
+
+    async fn try_get_manifest(&self) -> Result<DiagnosticManifest> {
+        let status = self.get_status().await?;
+        Ok(DiagnosticManifest::new(
+            chrono::Utc::now().to_rfc3339(),
+            Some(format!("esdiag-{}", env!("CARGO_PKG_VERSION"))),
+            None,
+            None,
+            Some("compatible".to_string()),
+            Product::Kibana,
+            Some("kibana_diagnostic".to_string()),
+            Some("esdiag".to_string()),
+            Some(status.version.number),
+        ))
+    }
+}
+
+impl ReceiveRaw for KibanaReceiver {
+    async fn get_raw<T>(&self) -> Result<String>
+    where
+        T: DataSource,
+    {
+        let version = self.get_version().await.ok();
+        let path = T::source(PathType::Url, version)?;
+
+        let name = T::name();
+        let aliases = T::aliases();
+        let source_conf =
+            crate::processor::diagnostic::data_source::get_source(T::product(), &name, &aliases)?;
+        let extension = source_conf.1.extension.as_deref().unwrap_or(".json");
+
+        self.get_raw_by_path(&path, extension).await
+    }
+}
+
+impl std::fmt::Display for KibanaReceiver {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Kibana {}", self.url)
+    }
+}

--- a/src/receiver/kibana.rs
+++ b/src/receiver/kibana.rs
@@ -101,7 +101,12 @@ impl KibanaReceiver {
         }
 
         let response = self.client.request(Method::GET, &headers, path, None).await?;
-        response.text().await.map_err(Into::into)
+        let status = response.status();
+        let body = response.text().await?;
+        if !status.is_success() {
+            return Err(eyre!("http {} - {}", status, body));
+        }
+        Ok(body)
     }
 }
 
@@ -132,8 +137,8 @@ impl Receive for KibanaReceiver {
     where
         T: DataSource + DeserializeOwned,
     {
-        let version = self.get_version().await.ok();
-        let path = T::source(PathType::Url, version)?;
+        let version = self.get_version().await?;
+        let path = T::source(PathType::Url, Some(version))?;
         let response = self
             .client
             .request(Method::GET, &HashMap::new(), &path, None)
@@ -178,8 +183,8 @@ impl ReceiveRaw for KibanaReceiver {
     where
         T: DataSource,
     {
-        let version = self.get_version().await.ok();
-        let path = T::source(PathType::Url, version)?;
+        let version = self.get_version().await?;
+        let path = T::source(PathType::Url, Some(version))?;
 
         let name = T::name();
         let aliases = T::aliases();

--- a/src/receiver/mod.rs
+++ b/src/receiver/mod.rs
@@ -12,10 +12,14 @@ mod elastic_cloud_admin;
 mod elasticsearch;
 /// Request API calls from Logstash
 mod logstash;
+/// Request API calls from Kibana
+mod kibana;
 /// Get file from https://upload.elastic.co/
 mod upload_service;
 
 pub use elasticsearch::ElasticsearchReceiver;
+pub use logstash::LogstashReceiver;
+pub use kibana::KibanaReceiver;
 pub use logstash::LogstashReceiver;
 
 use super::{
@@ -84,6 +88,8 @@ pub enum Receiver {
     Elasticsearch(ElasticsearchReceiver),
     /// Request API calls from Logstash
     Logstash(LogstashReceiver),
+    /// Request API calls from Kibana
+    Kibana(KibanaReceiver),
     /// Request API calls from Elastic Cloud admin
     ElasticCloudAdmin(ElasticCloudAdminReceiver),
 }
@@ -100,6 +106,9 @@ impl Receiver {
             )),
             Receiver::Logstash(receiver) => {
                 Ok(SourceContext::new("logstash", Some(receiver.get_version().await?.clone())))
+            }
+            Receiver::Kibana(receiver) => {
+                Ok(SourceContext::new("kibana", Some(receiver.get_version().await?.clone())))
             }
             Receiver::ElasticCloudAdmin(receiver) => Ok(SourceContext::new(
                 "elasticsearch",
@@ -118,6 +127,8 @@ impl Receiver {
             Receiver::Directory(receiver) => receiver.get::<T>().await,
             Receiver::Elasticsearch(receiver) => receiver.get::<T>().await,
             Receiver::Logstash(receiver) => receiver.get::<T>().await,
+            Receiver::Kibana(receiver) => receiver.get::<T>().await,
+            Receiver::Logstash(receiver) => receiver.get::<T>().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.get::<T>().await,
         }
     }
@@ -133,6 +144,8 @@ impl Receiver {
             Receiver::Directory(receiver) => receiver.get_stream::<T>().await,
             Receiver::Elasticsearch(receiver) => receiver.get_stream::<T>().await,
             Receiver::Logstash(receiver) => receiver.get_stream::<T>().await,
+            Receiver::Kibana(receiver) => receiver.get_stream::<T>().await,
+            Receiver::Logstash(receiver) => receiver.get_stream::<T>().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.get_stream::<T>().await,
         }
     }
@@ -144,6 +157,8 @@ impl Receiver {
         match self {
             Receiver::Elasticsearch(receiver) => receiver.get_raw::<T>().await,
             Receiver::Logstash(receiver) => receiver.get_raw::<T>().await,
+            Receiver::Kibana(receiver) => receiver.get_raw::<T>().await,
+            Receiver::Logstash(receiver) => receiver.get_raw::<T>().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.get_raw::<T>().await,
             _ => Err(eyre!("Raw data is not supported for this receiver")),
         }
@@ -153,8 +168,10 @@ impl Receiver {
         match self {
             Receiver::Elasticsearch(receiver) => receiver.get_raw_by_path(path, extension).await,
             Receiver::Logstash(receiver) => receiver.get_raw_by_path(path, extension).await,
+            Receiver::Kibana(receiver) => receiver.get_raw_by_path(path, extension).await,
+            Receiver::Logstash(receiver) => receiver.get_raw_by_path(path, extension).await,
             _ => Err(eyre!(
-                "Raw data by path is only supported for API receivers"
+                "Raw data by path is only supported for Elasticsearch, Kibana, or Logstash receivers"
             )),
         }
     }
@@ -165,6 +182,8 @@ impl Receiver {
             Receiver::ArchiveFile(receiver) => receiver.is_connected().await,
             Receiver::Directory(receiver) => receiver.is_connected().await,
             Receiver::Elasticsearch(receiver) => receiver.is_connected().await,
+            Receiver::Logstash(receiver) => receiver.is_connected().await,
+            Receiver::Kibana(receiver) => receiver.is_connected().await,
             Receiver::Logstash(receiver) => receiver.is_connected().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.is_connected().await,
         }
@@ -192,6 +211,8 @@ impl Receiver {
             Receiver::Directory(receiver) => receiver.collection_date().await,
             Receiver::Elasticsearch(receiver) => receiver.collection_date().await,
             Receiver::Logstash(receiver) => receiver.collection_date().await,
+            Receiver::Kibana(receiver) => receiver.collection_date().await,
+            Receiver::Logstash(receiver) => receiver.collection_date().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.collection_date().await,
         }
     }
@@ -203,6 +224,8 @@ impl Receiver {
             Receiver::Directory(receiver) => receiver.filename(),
             Receiver::Elasticsearch(receiver) => receiver.filename(),
             Receiver::Logstash(receiver) => receiver.filename(),
+            Receiver::Kibana(receiver) => receiver.filename(),
+            Receiver::Logstash(receiver) => receiver.filename(),
             Receiver::ElasticCloudAdmin(receiver) => receiver.filename(),
         }
     }
@@ -213,6 +236,8 @@ impl Receiver {
             | Receiver::ArchiveFile(_)
             | Receiver::Directory(_) => self.try_get_manifest_from_files().await,
             Receiver::Elasticsearch(receiver) => receiver.try_get_manifest().await,
+            Receiver::Logstash(receiver) => receiver.try_get_manifest().await,
+            Receiver::Kibana(receiver) => receiver.try_get_manifest().await,
             Receiver::Logstash(receiver) => receiver.try_get_manifest().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.try_get_manifest().await,
         }?;
@@ -291,6 +316,7 @@ impl TryFrom<Uri> for Receiver {
                     Receiver::Elasticsearch(ElasticsearchReceiver::try_from(host)?)
                 }
                 Product::Logstash => Receiver::Logstash(LogstashReceiver::try_from(host)?),
+                Product::Kibana => Receiver::Kibana(KibanaReceiver::try_from(host)?),
                 _ => return Err(eyre!("Unsupported known-host receiver product: {}", host.app())),
             },
             Uri::ServiceLink(url) => {
@@ -326,6 +352,8 @@ impl std::fmt::Display for Receiver {
             Receiver::ArchiveFile(receiver) => write!(f, "Archive File {receiver}"),
             Receiver::Directory(receiver) => write!(f, "Directory {receiver}"),
             Receiver::Elasticsearch(receiver) => write!(f, "Elasticsearch {receiver}"),
+            Receiver::Logstash(receiver) => write!(f, "Logstash {receiver}"),
+            Receiver::Kibana(receiver) => write!(f, "Kibana {receiver}"),
             Receiver::Logstash(receiver) => write!(f, "Logstash {receiver}"),
             Receiver::ElasticCloudAdmin(receiver) => {
                 write!(f, "ElasticCloudAdmin {receiver}")

--- a/src/receiver/mod.rs
+++ b/src/receiver/mod.rs
@@ -18,8 +18,7 @@ mod kibana;
 mod upload_service;
 
 pub use elasticsearch::ElasticsearchReceiver;
-pub use logstash::LogstashReceiver;
-pub use kibana::KibanaReceiver;
+pub use kibana::{KibanaReceiver, KibanaRequestError};
 pub use logstash::LogstashReceiver;
 
 use super::{
@@ -126,7 +125,6 @@ impl Receiver {
             Receiver::ArchiveFile(receiver) => receiver.get::<T>().await,
             Receiver::Directory(receiver) => receiver.get::<T>().await,
             Receiver::Elasticsearch(receiver) => receiver.get::<T>().await,
-            Receiver::Logstash(receiver) => receiver.get::<T>().await,
             Receiver::Kibana(receiver) => receiver.get::<T>().await,
             Receiver::Logstash(receiver) => receiver.get::<T>().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.get::<T>().await,
@@ -143,7 +141,6 @@ impl Receiver {
             Receiver::ArchiveFile(receiver) => receiver.get_stream::<T>().await,
             Receiver::Directory(receiver) => receiver.get_stream::<T>().await,
             Receiver::Elasticsearch(receiver) => receiver.get_stream::<T>().await,
-            Receiver::Logstash(receiver) => receiver.get_stream::<T>().await,
             Receiver::Kibana(receiver) => receiver.get_stream::<T>().await,
             Receiver::Logstash(receiver) => receiver.get_stream::<T>().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.get_stream::<T>().await,
@@ -156,7 +153,6 @@ impl Receiver {
     {
         match self {
             Receiver::Elasticsearch(receiver) => receiver.get_raw::<T>().await,
-            Receiver::Logstash(receiver) => receiver.get_raw::<T>().await,
             Receiver::Kibana(receiver) => receiver.get_raw::<T>().await,
             Receiver::Logstash(receiver) => receiver.get_raw::<T>().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.get_raw::<T>().await,
@@ -167,7 +163,6 @@ impl Receiver {
     pub async fn get_raw_by_path(&self, path: &str, extension: &str) -> Result<String> {
         match self {
             Receiver::Elasticsearch(receiver) => receiver.get_raw_by_path(path, extension).await,
-            Receiver::Logstash(receiver) => receiver.get_raw_by_path(path, extension).await,
             Receiver::Kibana(receiver) => receiver.get_raw_by_path(path, extension).await,
             Receiver::Logstash(receiver) => receiver.get_raw_by_path(path, extension).await,
             _ => Err(eyre!(
@@ -182,7 +177,6 @@ impl Receiver {
             Receiver::ArchiveFile(receiver) => receiver.is_connected().await,
             Receiver::Directory(receiver) => receiver.is_connected().await,
             Receiver::Elasticsearch(receiver) => receiver.is_connected().await,
-            Receiver::Logstash(receiver) => receiver.is_connected().await,
             Receiver::Kibana(receiver) => receiver.is_connected().await,
             Receiver::Logstash(receiver) => receiver.is_connected().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.is_connected().await,
@@ -210,7 +204,6 @@ impl Receiver {
             Receiver::ArchiveFile(receiver) => receiver.collection_date().await,
             Receiver::Directory(receiver) => receiver.collection_date().await,
             Receiver::Elasticsearch(receiver) => receiver.collection_date().await,
-            Receiver::Logstash(receiver) => receiver.collection_date().await,
             Receiver::Kibana(receiver) => receiver.collection_date().await,
             Receiver::Logstash(receiver) => receiver.collection_date().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.collection_date().await,
@@ -223,7 +216,6 @@ impl Receiver {
             Receiver::ArchiveFile(receiver) => receiver.filename(),
             Receiver::Directory(receiver) => receiver.filename(),
             Receiver::Elasticsearch(receiver) => receiver.filename(),
-            Receiver::Logstash(receiver) => receiver.filename(),
             Receiver::Kibana(receiver) => receiver.filename(),
             Receiver::Logstash(receiver) => receiver.filename(),
             Receiver::ElasticCloudAdmin(receiver) => receiver.filename(),
@@ -236,7 +228,6 @@ impl Receiver {
             | Receiver::ArchiveFile(_)
             | Receiver::Directory(_) => self.try_get_manifest_from_files().await,
             Receiver::Elasticsearch(receiver) => receiver.try_get_manifest().await,
-            Receiver::Logstash(receiver) => receiver.try_get_manifest().await,
             Receiver::Kibana(receiver) => receiver.try_get_manifest().await,
             Receiver::Logstash(receiver) => receiver.try_get_manifest().await,
             Receiver::ElasticCloudAdmin(receiver) => receiver.try_get_manifest().await,
@@ -352,7 +343,6 @@ impl std::fmt::Display for Receiver {
             Receiver::ArchiveFile(receiver) => write!(f, "Archive File {receiver}"),
             Receiver::Directory(receiver) => write!(f, "Directory {receiver}"),
             Receiver::Elasticsearch(receiver) => write!(f, "Elasticsearch {receiver}"),
-            Receiver::Logstash(receiver) => write!(f, "Logstash {receiver}"),
             Receiver::Kibana(receiver) => write!(f, "Kibana {receiver}"),
             Receiver::Logstash(receiver) => write!(f, "Logstash {receiver}"),
             Receiver::ElasticCloudAdmin(receiver) => {

--- a/tests/collection_tests.rs
+++ b/tests/collection_tests.rs
@@ -1,5 +1,11 @@
+use axum::{
+    Json, Router,
+    extract::{Path as AxumPath, Query},
+    routing::get,
+};
 use serde_json::Value;
 use std::collections::BTreeSet;
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -756,6 +762,137 @@ fn assert_has_diagnostic_manifest(
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_collect_kibana_mock_workflow() {
+    async fn status_handler() -> Json<serde_json::Value> {
+        Json(serde_json::json!({
+            "name": "mock-kibana",
+            "version": { "number": "8.19.0" }
+        }))
+    }
+
+    async fn spaces_handler() -> Json<serde_json::Value> {
+        Json(serde_json::json!([
+            { "id": "default" },
+            { "id": "security" }
+        ]))
+    }
+
+    async fn stats_handler() -> Json<serde_json::Value> {
+        Json(serde_json::json!({
+            "name": "mock-kibana",
+            "status": "green"
+        }))
+    }
+
+    async fn alerts_handler(
+        AxumPath(space): AxumPath<String>,
+        Query(params): Query<HashMap<String, String>>,
+    ) -> Json<serde_json::Value> {
+        let page = params
+            .get("page")
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(1);
+        let per_page = params
+            .get("per_page")
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(100);
+        let total = 125;
+        let start = (page - 1) * per_page;
+        let end = total.min(start + per_page);
+        let data: Vec<_> = (start..end)
+            .map(|idx| serde_json::json!({ "id": format!("{space}-{idx}") }))
+            .collect();
+
+        Json(serde_json::json!({
+            "page": page,
+            "per_page": per_page,
+            "total": total,
+            "data": data
+        }))
+    }
+
+    let app = Router::new()
+        .route("/api/status", get(status_handler))
+        .route("/api/spaces/space", get(spaces_handler))
+        .route("/api/stats", get(stats_handler))
+        .route("/s/{space}/api/alerts/_find", get(alerts_handler));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock kibana");
+    let addr = listener.local_addr().expect("listener addr");
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("serve mock kibana");
+    });
+
+    let home = tempdir().expect("temp home");
+    let host_url = format!("http://{addr}");
+
+    let host_output = run_esdiag(
+        &["host", "mock-kibana", "kibana", &host_url],
+        &home,
+        &[],
+    );
+    assert_success(&host_output, "configure mock kibana host");
+
+    let out_dir = home.path().join("collect-out");
+    fs::create_dir_all(&out_dir).expect("create output dir");
+    let collect_output = run_esdiag(
+        &[
+            "collect",
+            "mock-kibana",
+            out_dir.to_str().expect("out dir"),
+            "--type",
+            "minimal",
+            "--include",
+            "kibana_stats,kibana_alerts",
+        ],
+        &home,
+        &[],
+    );
+    assert_success(&collect_output, "collect mock kibana workflow");
+
+    let extracted = extract_diag_zip_to_temp(&out_dir).expect("extract collected archive");
+    assert!(extracted.path.join("diagnostic_manifest.json").exists());
+    assert!(extracted.path.join("kibana_status.json").exists());
+    assert!(extracted.path.join("kibana_spaces.json").exists());
+    assert!(extracted.path.join("kibana_stats.json").exists());
+    assert!(
+        extracted
+            .path
+            .join("spaces/default/pages/page-0001/kibana_alerts.json")
+            .exists()
+    );
+    assert!(
+        extracted
+            .path
+            .join("spaces/default/pages/page-0002/kibana_alerts.json")
+            .exists()
+    );
+    assert!(
+        extracted
+            .path
+            .join("spaces/security/pages/page-0001/kibana_alerts.json")
+            .exists()
+    );
+    assert!(
+        extracted
+            .path
+            .join("spaces/security/pages/page-0002/kibana_alerts.json")
+            .exists()
+    );
+
+    let _ = shutdown_tx.send(());
+    let _ = server.await;
+}
+
 fn run_esdiag(args: &[&str], home: &tempfile::TempDir, extra_env: &[(&str, &str)]) -> Output {
     let home_path = home.path().to_str().expect("home path");
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_esdiag"));
@@ -767,6 +904,135 @@ fn run_esdiag(args: &[&str], home: &tempfile::TempDir, extra_env: &[(&str, &str)
         cmd.env(k, v);
     }
     cmd.output().expect("run esdiag")
+}
+
+fn run_kibana_collect_matrix_case(host_env: &str) {
+    let host = env::var(host_env).unwrap_or_else(|_| {
+        panic!(
+            "Set {} to a known Kibana host before running this ignored test",
+            host_env
+        )
+    });
+    let dir = tempdir().expect("temp dir");
+    let out_dir = dir.path().to_str().expect("output dir");
+
+    let status = Command::new(env!("CARGO_BIN_EXE_esdiag"))
+        .args([
+            "collect",
+            host.as_str(),
+            out_dir,
+            "--type",
+            "minimal",
+            "--include",
+            "kibana_stats",
+        ])
+        .status()
+        .expect("Failed to execute Kibana collect process");
+
+    assert!(status.success());
+
+    let extracted = extract_diag_zip_to_temp(dir.path()).expect("Should have generated a zip");
+    assert!(extracted.path.join("diagnostic_manifest.json").exists());
+    assert!(extracted.path.join("kibana_status.json").exists());
+    assert!(extracted.path.join("kibana_spaces.json").exists());
+    assert!(extracted.path.join("kibana_stats.json").exists());
+}
+
+#[test]
+#[ignore = "requires external localhost Kibana service"]
+fn test_collect_kibana_localhost_no_auth() {
+    let home = tempdir().expect("temp home");
+    let host_output = run_esdiag(
+        &["host", "localhost-kibana", "kibana", "http://localhost:5601"],
+        &home,
+        &[],
+    );
+    assert_success(&host_output, "configure localhost kibana host");
+
+    let out_dir = home.path().join("collect-out");
+    fs::create_dir_all(&out_dir).expect("create output dir");
+    let collect_output = run_esdiag(
+        &[
+            "collect",
+            "localhost-kibana",
+            out_dir.to_str().expect("out dir"),
+            "--type",
+            "minimal",
+            "--include",
+            "kibana_stats",
+        ],
+        &home,
+        &[],
+    );
+    assert_success(&collect_output, "collect localhost kibana");
+
+    let extracted = extract_diag_zip_to_temp(&out_dir).expect("extract collected archive");
+    assert!(extracted.path.join("diagnostic_manifest.json").exists());
+    assert!(extracted.path.join("kibana_status.json").exists());
+    assert!(extracted.path.join("kibana_spaces.json").exists());
+    assert!(extracted.path.join("kibana_stats.json").exists());
+}
+
+#[test]
+#[ignore = "requires external localhost Kibana service"]
+fn test_kibana_localhost_accepts_kibana_pagination_query_shapes() {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("http client");
+
+    let cases = [
+        (
+            "pageSize style",
+            "http://localhost:5601/api/endpoint/metadata?page=1&pageSize=2",
+        ),
+        (
+            "per_page style",
+            "http://localhost:5601/api/detection_engine/rules/_find?sort_field=enabled&sort_order=asc&page=1&per_page=2",
+        ),
+    ];
+
+    for (label, url) in cases {
+        let response = client
+            .get(url)
+            .header("kbn-xsrf", "true")
+            .send()
+            .unwrap_or_else(|err| panic!("{label}: request failed: {err}"));
+        let status = response.status();
+        let body = response.text().expect("response body");
+
+        assert!(
+            !(status.as_u16() == 400
+                && (body.contains("query.pageIndex")
+                    || body.contains("query.page")
+                    || body.contains("definition for this key is missing"))),
+            "{label}: pagination query shape was rejected\nstatus={status}\nbody={body}"
+        );
+    }
+}
+
+#[test]
+#[ignore = "requires external Kibana 6.8.x service"]
+fn test_collect_kibana_6_8_x_compatibility() {
+    run_kibana_collect_matrix_case("ESDIAG_TEST_KIBANA_6_8_HOST");
+}
+
+#[test]
+#[ignore = "requires external Kibana 7.17.x service"]
+fn test_collect_kibana_7_17_x_compatibility() {
+    run_kibana_collect_matrix_case("ESDIAG_TEST_KIBANA_7_17_HOST");
+}
+
+#[test]
+#[ignore = "requires external Kibana 8.19.x service"]
+fn test_collect_kibana_8_19_x_compatibility() {
+    run_kibana_collect_matrix_case("ESDIAG_TEST_KIBANA_8_19_HOST");
+}
+
+#[test]
+#[ignore = "requires external Kibana 9.x service"]
+fn test_collect_kibana_9_x_compatibility() {
+    run_kibana_collect_matrix_case("ESDIAG_TEST_KIBANA_9_HOST");
 }
 
 fn assert_success(output: &Output, label: &str) {

--- a/tests/collection_tests.rs
+++ b/tests/collection_tests.rs
@@ -792,7 +792,8 @@ async fn test_collect_kibana_mock_workflow() {
         let page = params
             .get("page")
             .and_then(|value| value.parse::<usize>().ok())
-            .unwrap_or(1);
+            .unwrap_or(1)
+            .max(1);
         let per_page = params
             .get("per_page")
             .and_then(|value| value.parse::<usize>().ok())

--- a/tests/collection_tests.rs
+++ b/tests/collection_tests.rs
@@ -834,30 +834,40 @@ async fn test_collect_kibana_mock_workflow() {
     });
 
     let home = tempdir().expect("temp home");
+    let home_path = home.path().to_path_buf();
     let host_url = format!("http://{addr}");
 
-    let host_output = run_esdiag(
-        &["host", "mock-kibana", "kibana", &host_url],
-        &home,
-        &[],
-    );
+    let host_args = vec![
+        "host".to_string(),
+        "mock-kibana".to_string(),
+        "kibana".to_string(),
+        host_url.clone(),
+    ];
+    let host_output = tokio::task::spawn_blocking({
+        let home_path = home_path.clone();
+        move || run_esdiag_with_home(host_args, home_path, vec![])
+    })
+    .await
+    .expect("join host command");
     assert_success(&host_output, "configure mock kibana host");
 
     let out_dir = home.path().join("collect-out");
     fs::create_dir_all(&out_dir).expect("create output dir");
-    let collect_output = run_esdiag(
-        &[
-            "collect",
-            "mock-kibana",
-            out_dir.to_str().expect("out dir"),
-            "--type",
-            "minimal",
-            "--include",
-            "kibana_stats,kibana_alerts",
-        ],
-        &home,
-        &[],
-    );
+    let collect_args = vec![
+        "collect".to_string(),
+        "mock-kibana".to_string(),
+        out_dir.to_str().expect("out dir").to_string(),
+        "--type".to_string(),
+        "minimal".to_string(),
+        "--include".to_string(),
+        "kibana_stats,kibana_alerts".to_string(),
+    ];
+    let collect_output = tokio::task::spawn_blocking({
+        let home_path = home_path.clone();
+        move || run_esdiag_with_home(collect_args, home_path, vec![])
+    })
+    .await
+    .expect("join collect command");
     assert_success(&collect_output, "collect mock kibana workflow");
 
     let extracted = extract_diag_zip_to_temp(&out_dir).expect("extract collected archive");
@@ -895,7 +905,22 @@ async fn test_collect_kibana_mock_workflow() {
 }
 
 fn run_esdiag(args: &[&str], home: &tempfile::TempDir, extra_env: &[(&str, &str)]) -> Output {
-    let home_path = home.path().to_str().expect("home path");
+    run_esdiag_with_home(
+        args.iter().map(|arg| (*arg).to_string()).collect(),
+        home.path().to_path_buf(),
+        extra_env
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect(),
+    )
+}
+
+fn run_esdiag_with_home(
+    args: Vec<String>,
+    home_path: PathBuf,
+    extra_env: Vec<(String, String)>,
+) -> Output {
+    let home_path = home_path.to_str().expect("home path");
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_esdiag"));
     cmd.args(args)
         .env("HOME", home_path)


### PR DESCRIPTION
## Summary
- add source-driven Kibana collection support to `esdiag collect`, including a dedicated Kibana receiver and collector
- extend shared `sources.yml` resolution to support multi-product catalogs plus Kibana-specific metadata like `spaceaware` and `paginate`
- add Kibana resolver, mocked workflow coverage, and ignored external compatibility tests including localhost no-auth validation

## Test plan
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo test --workspace`
- [x] `cargo test test_collect_kibana_localhost_no_auth --test collection_tests -- --ignored`
- [x] `cargo test test_kibana_localhost_accepts_kibana_pagination_query_shapes --test collection_tests -- --ignored`

Made with [Cursor](https://cursor.com)