### PR TITLE
ci: fail PR check when openspec/changes/* directories are unarchived

### DIFF
--- a/.github/workflows/openspec-archived.yml
+++ b/.github/workflows/openspec-archived.yml
@@ -1,0 +1,38 @@
+name: OpenSpec Archived
+
+on:
+  pull_request:
+    paths:
+      - "openspec/changes/**"
+
+jobs:
+  check-archived:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fail if openspec/changes/* directories are present in PR
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+
+          new_changes=$(git diff --name-only --diff-filter=A "$base" "$head" \
+            | grep '^openspec/changes/' \
+            | sed 's|^openspec/changes/||' \
+            | cut -d/ -f1 \
+            | sort -u)
+
+          if [ -n "$new_changes" ]; then
+            echo "::error::This PR adds the following openspec/changes/* director(ies) that have not been archived:"
+            echo "$new_changes" | while read -r dir; do
+              echo "  - openspec/changes/$dir"
+            done
+            echo ""
+            echo "Run 'openspec archive' to move them to openspec/archive/ before merging."
+            exit 1
+          fi
+
+          echo "No unarchived openspec/changes directories found."


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/openspec-archived.yml` triggered on PRs that touch `openspec/changes/**`
- Diffs the PR base vs head for added files under `openspec/changes/` and extracts unique top-level directories
- Fails with a clear error listing the offending directories and instructing the author to run `openspec archive`
- Passes automatically once the directories are no longer present in `openspec/changes/` (i.e. after archiving)

## Test plan

- [ ] Open a PR that adds a new directory under `openspec/changes/` — check should fail
- [ ] Run `openspec archive` and push — check should pass
- [ ] Open a PR that only touches files outside `openspec/changes/` — workflow does not trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)