### PR TITLE
fix: skip receiver auth retry loops

### DIFF
--- a/src/processor/elasticsearch/collector.rs
+++ b/src/processor/elasticsearch/collector.rs
@@ -12,7 +12,11 @@ use super::{
     NodesStats, PendingTasks, Repositories, SearchableSnapshotsCacheStats,
     SearchableSnapshotsStats, SlmPolicies, Snapshots, Tasks,
 };
-use crate::{data::Product, exporter::ArchiveExporter, receiver::Receiver};
+use crate::{
+    data::Product,
+    exporter::ArchiveExporter,
+    receiver::{ElasticsearchRequestError, Receiver},
+};
 use eyre::{Result, WrapErr};
 use std::path::PathBuf;
 
@@ -120,6 +124,14 @@ impl ElasticsearchCollector {
             match self.save_api(api).await {
                 Ok(success) => return success,
                 Err(e) => {
+                    if !should_retry_elasticsearch_error(&e) {
+                        tracing::warn!(
+                            "Skipping non-retriable authentication failure for {}: {}",
+                            api.as_str(),
+                            e
+                        );
+                        return attempt;
+                    }
                     if start_time.elapsed() > max_duration {
                         tracing::error!(
                             "Failed to save {} after {} attempts (5 min timeout): {}",
@@ -127,7 +139,7 @@ impl ElasticsearchCollector {
                             attempt,
                             e
                         );
-                        return 0;
+                        return attempt;
                     }
                     tracing::warn!(
                         "Attempt {} failed for {}: {}. Retrying in {:?}...",
@@ -290,5 +302,45 @@ impl ElasticsearchCollector {
         self.exporter.save(path, content).await?;
         tracing::info!("Saved {filename}");
         Ok(1)
+    }
+}
+
+fn should_retry_elasticsearch_error(error: &eyre::Report) -> bool {
+    if let Some(request_error) = error.downcast_ref::<ElasticsearchRequestError>() {
+        return request_error.status.as_u16() != 401 && request_error.status.as_u16() != 403;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use elasticsearch::http::StatusCode;
+
+    #[test]
+    fn retry_policy_skips_authentication_errors() {
+        let unauthorized = eyre::Report::from(ElasticsearchRequestError {
+            status: StatusCode::UNAUTHORIZED,
+            body: "unauthorized".to_string(),
+        });
+        let forbidden = eyre::Report::from(ElasticsearchRequestError {
+            status: StatusCode::FORBIDDEN,
+            body: "forbidden".to_string(),
+        });
+
+        assert!(!should_retry_elasticsearch_error(&unauthorized));
+        assert!(!should_retry_elasticsearch_error(&forbidden));
+    }
+
+    #[test]
+    fn retry_policy_retries_non_auth_failures() {
+        let rate_limited = eyre::Report::from(ElasticsearchRequestError {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            body: "slow down".to_string(),
+        });
+        let transport = eyre::eyre!("connection reset");
+
+        assert!(should_retry_elasticsearch_error(&rate_limited));
+        assert!(should_retry_elasticsearch_error(&transport));
     }
 }

--- a/src/processor/elasticsearch/collector.rs
+++ b/src/processor/elasticsearch/collector.rs
@@ -130,7 +130,7 @@ impl ElasticsearchCollector {
                             api.as_str(),
                             e
                         );
-                        return attempt;
+                        return 0;
                     }
                     if start_time.elapsed() > max_duration {
                         tracing::error!(
@@ -139,7 +139,7 @@ impl ElasticsearchCollector {
                             attempt,
                             e
                         );
-                        return attempt;
+                        return 0;
                     }
                     tracing::warn!(
                         "Attempt {} failed for {}: {}. Retrying in {:?}...",

--- a/src/processor/logstash/collector.rs
+++ b/src/processor/logstash/collector.rs
@@ -122,7 +122,7 @@ impl LogstashCollector {
                             api.as_str(),
                             e
                         );
-                        return attempt;
+                        return 0;
                     }
                     if start_time.elapsed() > max_duration {
                         tracing::error!(

--- a/src/processor/logstash/collector.rs
+++ b/src/processor/logstash/collector.rs
@@ -11,7 +11,7 @@ use crate::{
         api::{ApiResolver, ApiWeight, DiagnosticType, LogstashApi},
         collector::{CollectOptions, CollectionResult},
     },
-    receiver::Receiver,
+    receiver::{LogstashRequestError, Receiver},
 };
 use eyre::{Result, WrapErr};
 use futures::stream::{self, StreamExt};
@@ -116,6 +116,14 @@ impl LogstashCollector {
             match self.save_api(api).await {
                 Ok(success) => return success,
                 Err(e) => {
+                    if !should_retry_logstash_error(&e) {
+                        tracing::warn!(
+                            "Skipping non-retriable authentication failure for {}: {}",
+                            api.as_str(),
+                            e
+                        );
+                        return attempt;
+                    }
                     if start_time.elapsed() > max_duration {
                         tracing::error!(
                             "Failed to save {} after {} attempts (5 min timeout): {}",
@@ -280,5 +288,46 @@ impl LogstashCollector {
         self.exporter.save(path, content).await?;
         tracing::info!("Saved {filename}");
         Ok(1)
+    }
+}
+
+fn should_retry_logstash_error(error: &eyre::Report) -> bool {
+    if let Some(request_error) = error.downcast_ref::<LogstashRequestError>() {
+        return request_error.status != reqwest::StatusCode::UNAUTHORIZED
+            && request_error.status != reqwest::StatusCode::FORBIDDEN;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::StatusCode;
+
+    #[test]
+    fn retry_policy_skips_authentication_errors() {
+        let unauthorized = eyre::Report::from(LogstashRequestError {
+            status: StatusCode::UNAUTHORIZED,
+            body: "unauthorized".to_string(),
+        });
+        let forbidden = eyre::Report::from(LogstashRequestError {
+            status: StatusCode::FORBIDDEN,
+            body: "forbidden".to_string(),
+        });
+
+        assert!(!should_retry_logstash_error(&unauthorized));
+        assert!(!should_retry_logstash_error(&forbidden));
+    }
+
+    #[test]
+    fn retry_policy_retries_non_auth_failures() {
+        let rate_limited = eyre::Report::from(LogstashRequestError {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            body: "slow down".to_string(),
+        });
+        let transport = eyre::eyre!("connection reset");
+
+        assert!(should_retry_logstash_error(&rate_limited));
+        assert!(should_retry_logstash_error(&transport));
     }
 }

--- a/src/receiver/elasticsearch.rs
+++ b/src/receiver/elasticsearch.rs
@@ -18,6 +18,20 @@ use url::Url;
 use std::sync::Arc;
 use tokio::sync::OnceCell;
 
+#[derive(Debug)]
+pub struct ElasticsearchRequestError {
+    pub status: http::StatusCode,
+    pub body: String,
+}
+
+impl std::fmt::Display for ElasticsearchRequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "http {} - {}", self.status, self.body)
+    }
+}
+
+impl std::error::Error for ElasticsearchRequestError {}
+
 #[derive(Clone)]
 pub struct ElasticsearchReceiver {
     client: Elasticsearch,
@@ -26,6 +40,12 @@ pub struct ElasticsearchReceiver {
 }
 
 impl ElasticsearchReceiver {
+    fn format_error_body(body: &str) -> String {
+        serde_json::from_str::<Value>(body)
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| body.to_string())
+    }
+
     pub fn new(url: Url) -> Result<Self> {
         let client = Elasticsearch::default();
         Ok(Self {
@@ -50,8 +70,16 @@ impl ElasticsearchReceiver {
                         None,
                     )
                     .await?;
-                let bytes = response.bytes().await?;
-                let cluster: Value = serde_json::from_slice(&bytes)?;
+                let status = response.status_code();
+                let body = response.text().await?;
+                if !status.is_success() {
+                    return Err(ElasticsearchRequestError {
+                        status,
+                        body: Self::format_error_body(&body),
+                    }
+                    .into());
+                }
+                let cluster: Value = serde_json::from_str(&body)?;
                 let version_str = cluster
                     .get("version")
                     .and_then(|version| version.get("number").and_then(|number| number.as_str()))
@@ -85,8 +113,17 @@ impl ElasticsearchReceiver {
                 None,
             )
             .await?;
+        let status = response.status_code();
+        let body = response.text().await?;
+        if !status.is_success() {
+            return Err(ElasticsearchRequestError {
+                status,
+                body: Self::format_error_body(&body),
+            }
+            .into());
+        }
 
-        response.text().await.map_err(Into::into)
+        Ok(body)
     }
 }
 
@@ -167,13 +204,14 @@ impl Receive for ElasticsearchReceiver {
         match response.status_code() {
             http::StatusCode::OK => response.json::<T>().await.map_err(Into::into),
             status => {
-                let body: Value = response.json::<Value>().await?;
-                tracing::debug!("Failed to get API response: {}", body);
-                let reason = body
-                    .get("error")
-                    .and_then(|e| e.get("reason").and_then(|r| r.as_str()))
-                    .unwrap_or("Unknown");
-                Err(eyre!("http {} - {}", status, reason))
+                let body = response.text().await?;
+                let formatted_body = Self::format_error_body(&body);
+                tracing::debug!("Failed to get API response: {}", formatted_body);
+                Err(ElasticsearchRequestError {
+                    status,
+                    body: formatted_body,
+                }
+                .into())
             }
         }
     }

--- a/src/receiver/logstash.rs
+++ b/src/receiver/logstash.rs
@@ -23,7 +23,27 @@ pub struct LogstashReceiver {
     version: Arc<OnceCell<semver::Version>>,
 }
 
+#[derive(Debug)]
+pub struct LogstashRequestError {
+    pub status: reqwest::StatusCode,
+    pub body: String,
+}
+
+impl std::fmt::Display for LogstashRequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "http {} - {}", self.status, self.body)
+    }
+}
+
+impl std::error::Error for LogstashRequestError {}
+
 impl LogstashReceiver {
+    fn format_error_body(body: &str) -> String {
+        serde_json::from_str::<Value>(body)
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| body.to_string())
+    }
+
     pub async fn get_version(&self) -> Result<&semver::Version> {
         self.version
             .get_or_try_init(|| async {
@@ -32,7 +52,16 @@ impl LogstashReceiver {
                     .client
                     .request(Method::GET, &HashMap::new(), "/", None)
                     .await?;
-                let body: Value = response.json().await?;
+                let status = response.status();
+                let body = response.text().await?;
+                if !status.is_success() {
+                    return Err(LogstashRequestError {
+                        status,
+                        body: Self::format_error_body(&body),
+                    }
+                    .into());
+                }
+                let body: Value = serde_json::from_str(&body)?;
                 let version_str = body
                     .get("version")
                     .and_then(|version| version.as_str())
@@ -56,8 +85,17 @@ impl LogstashReceiver {
             .client
             .request(Method::GET, &headers, path, None)
             .await?;
+        let status = response.status();
+        let body = response.text().await?;
+        if !status.is_success() {
+            return Err(LogstashRequestError {
+                status,
+                body: Self::format_error_body(&body),
+            }
+            .into());
+        }
 
-        response.text().await.map_err(Into::into)
+        Ok(body)
     }
 }
 
@@ -106,8 +144,13 @@ impl Receive for LogstashReceiver {
             reqwest::StatusCode::OK => response.json::<T>().await.map_err(Into::into),
             status => {
                 let body = response.text().await.unwrap_or_default();
-                tracing::debug!("Failed to get Logstash API response: {}", body);
-                Err(eyre!("http {} - {}", status, body))
+                let formatted_body = Self::format_error_body(&body);
+                tracing::debug!("Failed to get Logstash API response: {}", formatted_body);
+                Err(LogstashRequestError {
+                    status,
+                    body: formatted_body,
+                }
+                .into())
             }
         }
     }

--- a/src/receiver/mod.rs
+++ b/src/receiver/mod.rs
@@ -17,9 +17,9 @@ mod logstash;
 /// Get file from https://upload.elastic.co/
 mod upload_service;
 
-pub use elasticsearch::ElasticsearchReceiver;
+pub use elasticsearch::{ElasticsearchReceiver, ElasticsearchRequestError};
 pub use kibana::{KibanaReceiver, KibanaRequestError};
-pub use logstash::LogstashReceiver;
+pub use logstash::{LogstashReceiver, LogstashRequestError};
 
 use super::{
     data::{KnownHost, Product, Uri},


### PR DESCRIPTION
## Summary
- stop retrying unrecoverable 401/403 receiver failures during collection for Elasticsearch and Logstash
- surface typed receiver request errors so collectors can distinguish authentication failures from transient transport issues
- add retry-policy tests to keep the non-retriable auth behavior covered

## Test plan
- [x] `cargo fmt`
- [x] `cargo test retry_policy_`

Resolves #301 

Made with [Cursor](https://cursor.com)