### PR TITLE
Restore lookup enrichment coverage and fix tempfile warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,17 @@
-.env*
+# Rust build outputs
 /target
 /output
-/assets/kibana/esdiag-dashboards*.ndjson
-.opencode/
-.claude/
-.codex/
-.claude/
-.cursor/
-esdiag.spdx.json
-/tauri-dist
+/tauri-dist/
 /frontend-dist/
+
+# Agent skills and commands
+/*/skills/
+/*/command*/
+.cursor
+.wolf
+
+# Environment variable files
+.env*
+
+# SPDX license file
+esdiag.spdx.json

--- a/docs/repository/branch-management.md
+++ b/docs/repository/branch-management.md
@@ -29,6 +29,8 @@ Releases
 - Before releasing, bring `preview` up to date with `main` so stable fixes already merged to `main` are included in the release candidate.
 - Open a PR from `preview` to `main`.
 - Merge that PR with a merge commit to preserve a clear release boundary.
+- After the `preview` -> `main` PR merges, fast-forward `preview` to the new `main` tip so both long-lived branches point to the same commit before new preview-only work resumes.
+- Do not rebase `preview` after a release PR merge, and do not create a follow-up sync merge commit unless branch protections leave no other option.
 - Tag the release from `main` and create the new `0.x` maintenance branch from that release point.
 
 Hotfixes

--- a/src/processor/elasticsearch/nodes_stats/data.rs
+++ b/src/processor/elasticsearch/nodes_stats/data.rs
@@ -4,6 +4,7 @@
 
 use super::super::super::diagnostic::data_source::StreamingDataSource;
 use super::super::DataSource;
+use super::super::nodes::NodeDocument;
 use crate::data::option_map_as_vec_entries;
 use eyre::Result;
 use serde::{Deserialize, Serialize};
@@ -126,7 +127,7 @@ pub struct NodeStats {
     ip: Option<Box<RawValue>>,
     jvm: Box<RawValue>,
     name: Box<RawValue>,
-    os: OsStats,
+    os: NodeOs,
     process: Box<RawValue>,
     repositories: Option<Box<RawValue>>,
     pub roles: HashSet<String>,
@@ -159,12 +160,26 @@ struct LoadPercent {
 }
 
 #[derive(Deserialize, Serialize)]
-pub struct OsStats {
+pub struct NodeOs {
     timestamp: usize,
     cpu: CpuStats,
     mem: Box<RawValue>,
     swap: Option<Box<RawValue>>,
     cgroup: Option<Box<RawValue>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    refresh_interval_in_millis: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pretty_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    arch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    available_processors: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allocated_processors: Option<usize>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -185,6 +200,22 @@ impl NodeStats {
             (self.os.cpu.load_average.five * 100.0) as usize / processors;
         self.os.cpu.load_percent.fifteen =
             (self.os.cpu.load_average.fifteen * 100.0) as usize / processors;
+    }
+
+    pub fn enrich_from_lookup(&mut self, node: &NodeDocument) {
+        self.os.enrich_from_lookup(node);
+    }
+}
+
+impl NodeOs {
+    fn enrich_from_lookup(&mut self, node: &NodeDocument) {
+        self.refresh_interval_in_millis = Some(node.os.refresh_interval_in_millis);
+        self.name = node.os.name.clone();
+        self.pretty_name = node.os.pretty_name.clone();
+        self.arch = node.os.arch.clone();
+        self.version = node.os.version.clone();
+        self.available_processors = Some(node.os.available_processors);
+        self.allocated_processors = Some(node.os.allocated_processors);
     }
 }
 

--- a/src/processor/elasticsearch/nodes_stats/processor.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor.rs
@@ -52,6 +52,9 @@ async fn process_node(
         .map(|node| node.os.allocated_processors)
         .unwrap_or(1);
     node_stats.calculate_stats(allocated_processors);
+    if let Some(node) = node_metadata {
+        node_stats.enrich_from_lookup(node);
+    }
 
     // Extract transport actions
     if let Some(transport_raw) = node_stats.transport.take() {

--- a/src/processor/elasticsearch/nodes_stats/tests.rs
+++ b/src/processor/elasticsearch/nodes_stats/tests.rs
@@ -47,3 +47,76 @@ async fn test_streaming_deserialization() {
     assert_eq!(count, 1);
     handle.await.unwrap();
 }
+
+#[test]
+fn test_node_stats_os_enrichment_from_lookup() {
+    use crate::processor::elasticsearch::nodes::NodeDocument;
+    use crate::processor::elasticsearch::nodes_stats::NodeStats;
+    use serde_json::json;
+
+    let mut node_stats: NodeStats = serde_json::from_value(json!({
+        "name": "esdiag-node",
+        "transport_address": "127.0.0.1:9300",
+        "host": "127.0.0.1",
+        "ip": "127.0.0.1",
+        "roles": ["master", "data"],
+        "attributes": {},
+        "http": {},
+        "transport": {},
+        "discovery": {},
+        "ingest": { "total": {} },
+        "thread_pool": {},
+        "jvm": {},
+        "fs": { "total": { "total_in_bytes": 100, "free_in_bytes": 50, "available_in_bytes": 50 } },
+        "os": {
+            "timestamp": 123,
+            "cpu": { "percent": 0, "load_average": { "1m": 0.0, "5m": 0.0, "15m": 0.0 } },
+            "mem": {}
+        },
+        "process": {},
+        "script": {},
+        "script_cache": {},
+        "indexing_pressure": {},
+        "indices": {},
+        "breakers": {}
+    }))
+    .expect("parse NodeStats");
+
+    let lookup_node: NodeDocument = serde_json::from_value(json!({
+        "name": "esdiag-node",
+        "id": "node-id",
+        "host": "10.89.0.2",
+        "ip": "10.89.0.2",
+        "role": "dm",
+        "roles": ["data", "master"],
+        "tier": "hot",
+        "tier_order": 2,
+        "version": "9.1.3",
+        "os": {
+            "allocated_processors": 8,
+            "arch": "aarch64",
+            "available_processors": 8,
+            "name": "Linux",
+            "pretty_name": "Red Hat Enterprise Linux 9.6 (Plow)",
+            "refresh_interval_in_millis": 1000,
+            "version": "6.15.6-200.fc42.aarch64"
+        }
+    }))
+    .expect("parse NodeDocument");
+
+    node_stats.calculate_stats(8);
+    node_stats.enrich_from_lookup(&lookup_node);
+
+    let node_stats_json = serde_json::to_value(&node_stats).expect("serialize NodeStats");
+    let os = &node_stats_json["os"];
+
+    assert_eq!(os["timestamp"], 123);
+    assert_eq!(os["cpu"]["percent"], 0);
+    assert_eq!(os["refresh_interval_in_millis"], 1000);
+    assert_eq!(os["name"], "Linux");
+    assert_eq!(os["pretty_name"], "Red Hat Enterprise Linux 9.6 (Plow)");
+    assert_eq!(os["arch"], "aarch64");
+    assert_eq!(os["version"], "6.15.6-200.fc42.aarch64");
+    assert_eq!(os["available_processors"], 8);
+    assert_eq!(os["allocated_processors"], 8);
+}

--- a/src/server/index.rs
+++ b/src/server/index.rs
@@ -170,7 +170,6 @@ pub async fn workflow_page(
         .unwrap_or('_')
         .to_ascii_uppercase();
 
-    let allows_local_runtime_features = state.runtime_mode_policy.allows_local_runtime_features();
     let exporter = { state.exporter.read().await.clone() };
     let send_defaults = classify_configured_exporter(&exporter);
     let workflow_hosts = workflow_host_options(&state);
@@ -270,7 +269,6 @@ async fn build_jobs_page(
         .unwrap_or('_')
         .to_ascii_uppercase();
 
-    let allows_local_runtime_features = state.runtime_mode_policy.allows_local_runtime_features();
     let exporter = { state.exporter.read().await.clone() };
     let send_defaults = classify_configured_exporter(&exporter);
     let workflow_hosts = workflow_host_options(&state);

--- a/tests/archive_lookup_enriched_processors_tests.rs
+++ b/tests/archive_lookup_enriched_processors_tests.rs
@@ -1,8 +1,9 @@
 use serde_json::Value;
 use std::fs;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use tempfile::tempdir;
+use tempfile::{tempdir, TempDir};
 
 fn archive_fixtures() -> Vec<PathBuf> {
     let archives_dir = Path::new("tests/archives");
@@ -23,7 +24,19 @@ fn archive_fixtures() -> Vec<PathBuf> {
     archives
 }
 
-fn process_archive(archive: &Path) -> PathBuf {
+struct ProcessedArchive {
+    output: TempDir,
+}
+
+impl Deref for ProcessedArchive {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        self.output.path()
+    }
+}
+
+fn process_archive(archive: &Path) -> ProcessedArchive {
     let home = tempdir().expect("temp HOME");
     let output = tempdir().expect("temp output");
 
@@ -46,7 +59,7 @@ fn process_archive(archive: &Path) -> PathBuf {
         String::from_utf8_lossy(&process.stderr)
     );
 
-    output.keep()
+    ProcessedArchive { output }
 }
 
 fn first_doc(output_dir: &Path, file_name: &str) -> Value {

--- a/tests/archive_lookup_enriched_processors_tests.rs
+++ b/tests/archive_lookup_enriched_processors_tests.rs
@@ -46,13 +46,13 @@ fn process_archive(archive: &Path) -> PathBuf {
         String::from_utf8_lossy(&process.stderr)
     );
 
-    output.into_path()
+    output.keep()
 }
 
 fn first_doc(output_dir: &Path, file_name: &str) -> Value {
     let path = output_dir.join(file_name);
-    let content =
-        fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {} failed: {}", path.display(), e));
+    let content = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {} failed: {}", path.display(), e));
     let line = content
         .lines()
         .find(|line| !line.trim().is_empty())
@@ -63,14 +63,15 @@ fn first_doc(output_dir: &Path, file_name: &str) -> Value {
 
 fn read_docs(output_dir: &Path, file_name: &str) -> Vec<Value> {
     let path = output_dir.join(file_name);
-    let content =
-        fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {} failed: {}", path.display(), e));
+    let content = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {} failed: {}", path.display(), e));
     let docs: Vec<Value> = content
         .lines()
         .filter(|line| !line.trim().is_empty())
         .map(|line| {
-            serde_json::from_str::<Value>(line)
-                .unwrap_or_else(|e| panic!("failed parsing document from {}: {}", path.display(), e))
+            serde_json::from_str::<Value>(line).unwrap_or_else(|e| {
+                panic!("failed parsing document from {}: {}", path.display(), e)
+            })
         })
         .collect();
     assert!(!docs.is_empty(), "{} had no documents", path.display());
@@ -170,15 +171,18 @@ fn test_archive_lookup_enriched_processors_match_expected_shape() {
         let metrics_shard = first_doc(&output_dir, "metrics-shard-esdiag.ndjson");
         assert_node_lookup_enrichment(&metrics_shard["node"], &archive, "metrics-shard-esdiag");
 
-        let metrics_http_clients = first_doc(&output_dir, "metrics-node.http.clients-esdiag.ndjson");
+        let metrics_http_clients =
+            first_doc(&output_dir, "metrics-node.http.clients-esdiag.ndjson");
         assert_node_lookup_enrichment(
             &metrics_http_clients["node"],
             &archive,
             "metrics-node.http.clients-esdiag",
         );
 
-        let metrics_cluster_applier =
-            first_doc(&output_dir, "metrics-node.discovery.cluster_applier-esdiag.ndjson");
+        let metrics_cluster_applier = first_doc(
+            &output_dir,
+            "metrics-node.discovery.cluster_applier-esdiag.ndjson",
+        );
         assert_node_lookup_enrichment(
             &metrics_cluster_applier["node"],
             &archive,
@@ -190,7 +194,11 @@ fn test_archive_lookup_enriched_processors_match_expected_shape() {
 #[test]
 fn test_archive_node_lookup_specific_os_values_for_9_1_fixture() {
     let archive = Path::new("tests/archives/elasticsearch-api-diagnostics-9.1.3.zip");
-    assert!(archive.exists(), "missing archive fixture: {}", archive.display());
+    assert!(
+        archive.exists(),
+        "missing archive fixture: {}",
+        archive.display()
+    );
 
     let output_dir = process_archive(archive);
     let metrics_node = first_doc(&output_dir, "metrics-node-esdiag.ndjson");
@@ -199,7 +207,10 @@ fn test_archive_node_lookup_specific_os_values_for_9_1_fixture() {
     assert_eq!(node["name"], "esdiag-node");
     assert_eq!(node["os"]["allocated_processors"], 8);
     assert_eq!(node["os"]["available_processors"], 8);
-    assert_eq!(node["os"]["pretty_name"], "Red Hat Enterprise Linux 9.6 (Plow)");
+    assert_eq!(
+        node["os"]["pretty_name"],
+        "Red Hat Enterprise Linux 9.6 (Plow)"
+    );
 }
 
 #[test]

--- a/tests/archive_lookup_enriched_processors_tests.rs
+++ b/tests/archive_lookup_enriched_processors_tests.rs
@@ -1,0 +1,273 @@
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::tempdir;
+
+fn archive_fixtures() -> Vec<PathBuf> {
+    let archives_dir = Path::new("tests/archives");
+    let mut archives = Vec::new();
+    for entry in fs::read_dir(archives_dir).expect("read tests/archives") {
+        let entry = entry.expect("archive dir entry");
+        let path = entry.path();
+        let filename = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
+        if filename.starts_with("elasticsearch-api-diagnostics-") && filename.ends_with(".zip") {
+            archives.push(path);
+        }
+    }
+    archives.sort();
+    assert!(
+        !archives.is_empty(),
+        "no elasticsearch archive fixtures found"
+    );
+    archives
+}
+
+fn process_archive(archive: &Path) -> PathBuf {
+    let home = tempdir().expect("temp HOME");
+    let output = tempdir().expect("temp output");
+
+    let process = Command::new(env!("CARGO_BIN_EXE_esdiag"))
+        .args([
+            "process",
+            archive.to_str().expect("archive path"),
+            output.path().to_str().expect("output path"),
+        ])
+        .env("HOME", home.path())
+        .env("USERPROFILE", home.path())
+        .output()
+        .expect("run esdiag process");
+
+    assert!(
+        process.status.success(),
+        "process failed for {}\nstdout:\n{}\nstderr:\n{}",
+        archive.display(),
+        String::from_utf8_lossy(&process.stdout),
+        String::from_utf8_lossy(&process.stderr)
+    );
+
+    output.into_path()
+}
+
+fn first_doc(output_dir: &Path, file_name: &str) -> Value {
+    let path = output_dir.join(file_name);
+    let content =
+        fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {} failed: {}", path.display(), e));
+    let line = content
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or_else(|| panic!("{} had no documents", path.display()));
+    serde_json::from_str::<Value>(line)
+        .unwrap_or_else(|e| panic!("failed parsing first doc from {}: {}", path.display(), e))
+}
+
+fn read_docs(output_dir: &Path, file_name: &str) -> Vec<Value> {
+    let path = output_dir.join(file_name);
+    let content =
+        fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {} failed: {}", path.display(), e));
+    let docs: Vec<Value> = content
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str::<Value>(line)
+                .unwrap_or_else(|e| panic!("failed parsing document from {}: {}", path.display(), e))
+        })
+        .collect();
+    assert!(!docs.is_empty(), "{} had no documents", path.display());
+    docs
+}
+
+fn assert_node_lookup_enrichment(node: &Value, archive: &Path, stream: &str) {
+    let os = &node["os"];
+    assert!(
+        os["allocated_processors"].is_number(),
+        "{} in {} is missing node.os.allocated_processors",
+        stream,
+        archive.display()
+    );
+    assert!(
+        os["available_processors"].is_number(),
+        "{} in {} is missing node.os.available_processors",
+        stream,
+        archive.display()
+    );
+    assert!(
+        node["id"].is_string(),
+        "{} in {} is missing node.id",
+        stream,
+        archive.display()
+    );
+}
+
+fn assert_has_data_stream_lookup(doc: &Value, archive: &Path, stream: &str) {
+    assert!(
+        doc["index"]["data_stream"]["name"].is_string(),
+        "{} in {} missing index.data_stream.name",
+        stream,
+        archive.display()
+    );
+    assert!(
+        doc["index"]["data_stream"]["dataset"].is_string(),
+        "{} in {} missing index.data_stream.dataset",
+        stream,
+        archive.display()
+    );
+    assert!(
+        doc["index"]["data_stream"]["type"].is_string(),
+        "{} in {} missing index.data_stream.type",
+        stream,
+        archive.display()
+    );
+    assert!(
+        doc["index"]["data_stream"]["namespace"].is_string(),
+        "{} in {} missing index.data_stream.namespace",
+        stream,
+        archive.display()
+    );
+}
+
+fn assert_has_index_settings_lookup(doc: &Value, archive: &Path, stream: &str) {
+    assert!(
+        doc["index"]["name"].is_string(),
+        "{} in {} missing index.name",
+        stream,
+        archive.display()
+    );
+    assert!(
+        doc["index"]["number_of_shards"].is_number(),
+        "{} in {} missing index.number_of_shards",
+        stream,
+        archive.display()
+    );
+    assert!(
+        doc["index"]["number_of_replicas"].is_number(),
+        "{} in {} missing index.number_of_replicas",
+        stream,
+        archive.display()
+    );
+    assert!(
+        doc["index"]["refresh_interval"].is_string(),
+        "{} in {} missing index.refresh_interval",
+        stream,
+        archive.display()
+    );
+}
+
+#[test]
+fn test_archive_lookup_enriched_processors_match_expected_shape() {
+    for archive in archive_fixtures() {
+        let output_dir = process_archive(&archive);
+
+        let settings_node = first_doc(&output_dir, "settings-node-esdiag.ndjson");
+        assert_node_lookup_enrichment(&settings_node["node"], &archive, "settings-node-esdiag");
+
+        let metrics_node = first_doc(&output_dir, "metrics-node-esdiag.ndjson");
+        assert_node_lookup_enrichment(&metrics_node["node"], &archive, "metrics-node-esdiag");
+
+        let metrics_task = first_doc(&output_dir, "metrics-task-esdiag.ndjson");
+        assert_node_lookup_enrichment(&metrics_task["node"], &archive, "metrics-task-esdiag");
+
+        let metrics_shard = first_doc(&output_dir, "metrics-shard-esdiag.ndjson");
+        assert_node_lookup_enrichment(&metrics_shard["node"], &archive, "metrics-shard-esdiag");
+
+        let metrics_http_clients = first_doc(&output_dir, "metrics-node.http.clients-esdiag.ndjson");
+        assert_node_lookup_enrichment(
+            &metrics_http_clients["node"],
+            &archive,
+            "metrics-node.http.clients-esdiag",
+        );
+
+        let metrics_cluster_applier =
+            first_doc(&output_dir, "metrics-node.discovery.cluster_applier-esdiag.ndjson");
+        assert_node_lookup_enrichment(
+            &metrics_cluster_applier["node"],
+            &archive,
+            "metrics-node.discovery.cluster_applier-esdiag",
+        );
+    }
+}
+
+#[test]
+fn test_archive_node_lookup_specific_os_values_for_9_1_fixture() {
+    let archive = Path::new("tests/archives/elasticsearch-api-diagnostics-9.1.3.zip");
+    assert!(archive.exists(), "missing archive fixture: {}", archive.display());
+
+    let output_dir = process_archive(archive);
+    let metrics_node = first_doc(&output_dir, "metrics-node-esdiag.ndjson");
+    let node = &metrics_node["node"];
+
+    assert_eq!(node["name"], "esdiag-node");
+    assert_eq!(node["os"]["allocated_processors"], 8);
+    assert_eq!(node["os"]["available_processors"], 8);
+    assert_eq!(node["os"]["pretty_name"], "Red Hat Enterprise Linux 9.6 (Plow)");
+}
+
+#[test]
+fn test_archive_data_stream_lookup_enrichment_for_index_processors() {
+    for archive in archive_fixtures() {
+        let output_dir = process_archive(&archive);
+
+        let settings_index_docs = read_docs(&output_dir, "settings-index-esdiag.ndjson");
+        let settings_index_doc = settings_index_docs
+            .iter()
+            .find(|doc| doc["index"]["data_stream"]["name"].is_string())
+            .unwrap_or_else(|| {
+                panic!(
+                    "settings-index-esdiag in {} had no document with data_stream enrichment",
+                    archive.display()
+                )
+            });
+        assert_has_data_stream_lookup(settings_index_doc, &archive, "settings-index-esdiag");
+
+        let metrics_index_docs = read_docs(&output_dir, "metrics-index-esdiag.ndjson");
+        let metrics_index_doc = metrics_index_docs
+            .iter()
+            .find(|doc| doc["index"]["data_stream"]["name"].is_string())
+            .unwrap_or_else(|| {
+                panic!(
+                    "metrics-index-esdiag in {} had no document with data_stream enrichment",
+                    archive.display()
+                )
+            });
+        assert_has_data_stream_lookup(metrics_index_doc, &archive, "metrics-index-esdiag");
+    }
+}
+
+#[test]
+fn test_archive_index_settings_lookup_enrichment_for_index_metrics() {
+    for archive in archive_fixtures() {
+        let output_dir = process_archive(&archive);
+
+        let metrics_index_docs = read_docs(&output_dir, "metrics-index-esdiag.ndjson");
+        let metrics_index_doc = metrics_index_docs
+            .iter()
+            .find(|doc| {
+                doc["index"]["number_of_shards"].is_number()
+                    && doc["index"]["number_of_replicas"].is_number()
+                    && doc["index"]["refresh_interval"].is_string()
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "metrics-index-esdiag in {} had no document with index settings enrichment",
+                    archive.display()
+                )
+            });
+        assert_has_index_settings_lookup(metrics_index_doc, &archive, "metrics-index-esdiag");
+
+        let metrics_shard_docs = read_docs(&output_dir, "metrics-shard-esdiag.ndjson");
+        let metrics_shard_doc = metrics_shard_docs
+            .iter()
+            .find(|doc| {
+                doc["index"]["number_of_shards"].is_number()
+                    && doc["index"]["number_of_replicas"].is_number()
+                    && doc["index"]["refresh_interval"].is_string()
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "metrics-shard-esdiag in {} had no document with index settings enrichment",
+                    archive.display()
+                )
+            });
+        assert_has_index_settings_lookup(metrics_shard_doc, &archive, "metrics-shard-esdiag");
+    }
+}


### PR DESCRIPTION
This PR restores lookup enrichment coverage for node and index streams, adds archive-backed contract tests, and fixes a deprecated tempfile usage in tests. It also includes minor updates to .gitignore and documentation.