### PR TITLE
fix: node stats parsing

### DIFF
--- a/example.env
+++ b/example.env
@@ -74,7 +74,7 @@ export ESDIAG_IMAGE_TAG="esdiag:latest"
 ################## docker/podman compose #########################
 # These variables are only referenced by the `docker/docker-compose.yml` file
 
-export ELASTIC_VERSION="9.3.0"
+export ELASTIC_VERSION="9.3.3"
 # Will be overwritten if `--insecure` is passed to `esdiag-control up`
 export ELASTIC_SECURITY_ENABLED=true
 # The `esdiag-control up` command will update these passwords and

--- a/src/processor/elasticsearch/nodes_stats/data.rs
+++ b/src/processor/elasticsearch/nodes_stats/data.rs
@@ -185,7 +185,7 @@ pub struct NodeOs {
 #[derive(Deserialize, Serialize)]
 pub struct CpuStats {
     percent: usize,
-    load_average: LoadAverage,
+    load_average: Option<LoadAverage>,
     #[serde(skip_deserializing)]
     load_percent: LoadPercent,
 }
@@ -195,11 +195,11 @@ impl NodeStats {
         self.fs.total.used_in_bytes = self.fs.total.total_in_bytes - self.fs.total.free_in_bytes;
         self.fs.total.used_percent =
             (self.fs.total.used_in_bytes * 100) / self.fs.total.total_in_bytes;
-        self.os.cpu.load_percent.one = (self.os.cpu.load_average.one * 100.0) as usize / processors;
-        self.os.cpu.load_percent.five =
-            (self.os.cpu.load_average.five * 100.0) as usize / processors;
-        self.os.cpu.load_percent.fifteen =
-            (self.os.cpu.load_average.fifteen * 100.0) as usize / processors;
+        if let Some(load_average) = &self.os.cpu.load_average {
+            self.os.cpu.load_percent.one = (load_average.one * 100.0) as usize / processors;
+            self.os.cpu.load_percent.five = (load_average.five * 100.0) as usize / processors;
+            self.os.cpu.load_percent.fifteen = (load_average.fifteen * 100.0) as usize / processors;
+        }
     }
 
     pub fn enrich_from_lookup(&mut self, node: &NodeDocument) {


### PR DESCRIPTION
## Summary
- make Elasticsearch node stats load_average optional, Windows does not report them
- bump the example Elastic stack version

## Testing
- Not run (PR creation only).