### PR TITLE
perf: speed up keystore tests

### DIFF
--- a/src/data/keystore.rs
+++ b/src/data/keystore.rs
@@ -29,6 +29,11 @@ use std::{
 const KDF_ROUNDS: u32 = 100_000;
 #[cfg(debug_assertions)]
 const KDF_ROUNDS: u32 = 1_000;
+#[cfg(not(debug_assertions))]
+const MIN_KDF_ROUNDS: u32 = 100_000;
+#[cfg(debug_assertions)]
+const MIN_KDF_ROUNDS: u32 = 1_000;
+const MAX_KDF_ROUNDS: u32 = 1_000_000;
 const LEGACY_KDF_ROUNDS: u32 = 100_000;
 const KDF_ALGORITHM: &str = "pbkdf2-sha256";
 const KEY_SIZE: usize = 32;
@@ -399,6 +404,20 @@ fn validate_kdf_params(params: &KdfParams) -> Result<()> {
     }
     if params.rounds == 0 {
         return Err(eyre!("KDF rounds must be greater than zero"));
+    }
+    if params.rounds < MIN_KDF_ROUNDS {
+        return Err(eyre!(
+            "KDF rounds {} are below the minimum supported value {}",
+            params.rounds,
+            MIN_KDF_ROUNDS
+        ));
+    }
+    if params.rounds > MAX_KDF_ROUNDS {
+        return Err(eyre!(
+            "KDF rounds {} exceed the maximum supported value {}",
+            params.rounds,
+            MAX_KDF_ROUNDS
+        ));
     }
     Ok(())
 }
@@ -1235,6 +1254,21 @@ ciphertext: ""
 
         assert_eq!(keystore.kdf.algorithm, KDF_ALGORITHM);
         assert_eq!(keystore.kdf.rounds, LEGACY_KDF_ROUNDS);
+    }
+
+    #[test]
+    fn kdf_params_reject_unsupported_round_counts() {
+        let too_low = KdfParams {
+            algorithm: KDF_ALGORITHM.to_string(),
+            rounds: MIN_KDF_ROUNDS - 1,
+        };
+        assert!(validate_kdf_params(&too_low).is_err());
+
+        let too_high = KdfParams {
+            algorithm: KDF_ALGORITHM.to_string(),
+            rounds: MAX_KDF_ROUNDS + 1,
+        };
+        assert!(validate_kdf_params(&too_high).is_err());
     }
 
     #[test]

--- a/src/data/keystore.rs
+++ b/src/data/keystore.rs
@@ -29,9 +29,11 @@ use std::{
 const KDF_ROUNDS: u32 = 100_000;
 #[cfg(debug_assertions)]
 const KDF_ROUNDS: u32 = 1_000;
+#[cfg(not(debug_assertions))]
+const MIN_KDF_ROUNDS: u32 = 100_000;
+#[cfg(debug_assertions)]
 const MIN_KDF_ROUNDS: u32 = 1_000;
 const MAX_KDF_ROUNDS: u32 = 1_000_000;
-const DEFAULT_KDF_ROUNDS: u32 = 100_000;
 const KDF_ALGORITHM: &str = "pbkdf2-sha256";
 const KEY_SIZE: usize = 32;
 const SALT_SIZE: usize = 16;
@@ -173,7 +175,7 @@ impl Default for KdfParams {
     fn default() -> Self {
         Self {
             algorithm: KDF_ALGORITHM.to_string(),
-            rounds: DEFAULT_KDF_ROUNDS,
+            rounds: KDF_ROUNDS,
         }
     }
 }
@@ -183,7 +185,7 @@ fn default_kdf_algorithm() -> String {
 }
 
 fn default_kdf_rounds() -> u32 {
-    DEFAULT_KDF_ROUNDS
+    KDF_ROUNDS
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -394,10 +396,7 @@ fn unlock_context_material() -> Result<String> {
 
 fn validate_kdf_params(params: &KdfParams) -> Result<()> {
     if params.algorithm != KDF_ALGORITHM {
-        return Err(eyre!(
-            "Unsupported KDF algorithm '{}'",
-            params.algorithm
-        ));
+        return Err(eyre!("Unsupported KDF algorithm '{}'", params.algorithm));
     }
     if params.rounds == 0 {
         return Err(eyre!("KDF rounds must be greater than zero"));
@@ -1238,7 +1237,7 @@ mod tests {
     }
 
     #[test]
-    fn encrypted_envelopes_default_missing_kdf_to_default_rounds() {
+    fn encrypted_envelopes_default_missing_kdf_to_current_rounds() {
         let keystore: EncryptedKeystore = serde_yaml::from_str(
             r#"
 version: 1
@@ -1250,7 +1249,7 @@ ciphertext: ""
         .expect("keystore envelope with defaulted KDF params");
 
         assert_eq!(keystore.kdf.algorithm, KDF_ALGORITHM);
-        assert_eq!(keystore.kdf.rounds, DEFAULT_KDF_ROUNDS);
+        assert_eq!(keystore.kdf.rounds, KDF_ROUNDS);
     }
 
     #[test]

--- a/src/data/keystore.rs
+++ b/src/data/keystore.rs
@@ -900,7 +900,7 @@ pub fn list_secret_names(keystore_password: &str) -> Result<Vec<String>> {
     Ok(names)
 }
 
-pub fn list_secret_entries(keystore_password: &str) -> Result<Vec<(String, SecretEntry)>> {
+pub(crate) fn list_secret_entries(keystore_password: &str) -> Result<Vec<(String, SecretEntry)>> {
     let store = read_store(keystore_password)?;
     Ok(store.secrets.into_iter().collect())
 }

--- a/src/data/keystore.rs
+++ b/src/data/keystore.rs
@@ -38,6 +38,7 @@ const KDF_ALGORITHM: &str = "pbkdf2-sha256";
 const KEY_SIZE: usize = 32;
 const SALT_SIZE: usize = 16;
 const NONCE_SIZE: usize = 12;
+const ENCRYPTED_ENVELOPE_VERSION: u8 = 2;
 const KEYSTORE_FILE: &str = "secrets.yml";
 const UNLOCK_FILE: &str = "keystore.unlock";
 const DEFAULT_UNLOCK_TTL_SECS: u64 = 24 * 60 * 60;
@@ -436,7 +437,7 @@ fn encrypt_unlock_lease(data: &UnlockLeaseData) -> Result<EncryptedUnlockLease> 
         .encrypt(Nonce::from_slice(&nonce), plaintext.as_bytes())
         .map_err(|_| eyre!("Failed to encrypt unlock lease"))?;
     Ok(EncryptedUnlockLease {
-        version: 1,
+        version: ENCRYPTED_ENVELOPE_VERSION,
         kdf,
         salt: base64::engine::general_purpose::STANDARD.encode(salt),
         nonce: base64::engine::general_purpose::STANDARD.encode(nonce),
@@ -445,7 +446,7 @@ fn encrypt_unlock_lease(data: &UnlockLeaseData) -> Result<EncryptedUnlockLease> 
 }
 
 fn decrypt_unlock_lease(encrypted: EncryptedUnlockLease) -> Result<UnlockLeaseData> {
-    if encrypted.version != 1 {
+    if !matches!(encrypted.version, 1 | ENCRYPTED_ENVELOPE_VERSION) {
         return Err(eyre!(
             "Unsupported unlock lease version {}",
             encrypted.version
@@ -917,7 +918,7 @@ fn read_store(keystore_password: &str) -> Result<KeystoreData> {
     let file = File::open(path)?;
     let reader = BufReader::new(file);
     let encrypted: EncryptedKeystore = serde_yaml::from_reader(reader)?;
-    if encrypted.version != 1 {
+    if !matches!(encrypted.version, 1 | ENCRYPTED_ENVELOPE_VERSION) {
         return Err(eyre!("Unsupported keystore version {}", encrypted.version));
     }
 
@@ -960,7 +961,7 @@ fn write_store(store: &KeystoreData, keystore_password: &str) -> Result<()> {
         .map_err(|_| eyre!("Failed to encrypt keystore"))?;
 
     let envelope = EncryptedKeystore {
-        version: 1,
+        version: ENCRYPTED_ENVELOPE_VERSION,
         kdf,
         salt: base64::engine::general_purpose::STANDARD.encode(salt),
         nonce: base64::engine::general_purpose::STANDARD.encode(nonce),
@@ -1228,11 +1229,13 @@ mod tests {
         let keystore_file = File::open(keystore_path).expect("open keystore");
         let keystore: EncryptedKeystore =
             serde_yaml::from_reader(BufReader::new(keystore_file)).expect("keystore envelope");
+        assert_eq!(keystore.version, ENCRYPTED_ENVELOPE_VERSION);
         assert_eq!(keystore.kdf, KdfParams::current());
 
         let unlock_file = File::open(unlock_path).expect("open unlock lease");
         let unlock: EncryptedUnlockLease =
             serde_yaml::from_reader(BufReader::new(unlock_file)).expect("unlock envelope");
+        assert_eq!(unlock.version, ENCRYPTED_ENVELOPE_VERSION);
         assert_eq!(unlock.kdf, KdfParams::current());
     }
 

--- a/src/data/keystore.rs
+++ b/src/data/keystore.rs
@@ -25,7 +25,12 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+#[cfg(not(debug_assertions))]
 const KDF_ROUNDS: u32 = 100_000;
+#[cfg(debug_assertions)]
+const KDF_ROUNDS: u32 = 1_000;
+const LEGACY_KDF_ROUNDS: u32 = 100_000;
+const KDF_ALGORITHM: &str = "pbkdf2-sha256";
 const KEY_SIZE: usize = 32;
 const SALT_SIZE: usize = 16;
 const NONCE_SIZE: usize = 12;
@@ -121,6 +126,8 @@ impl Default for KeystoreData {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct EncryptedKeystore {
     version: u8,
+    #[serde(default)]
+    kdf: KdfParams,
     salt: String,
     nonce: String,
     ciphertext: String,
@@ -136,9 +143,45 @@ struct UnlockLeaseData {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct EncryptedUnlockLease {
     version: u8,
+    #[serde(default)]
+    kdf: KdfParams,
     salt: String,
     nonce: String,
     ciphertext: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct KdfParams {
+    #[serde(default = "default_kdf_algorithm")]
+    algorithm: String,
+    #[serde(default = "legacy_kdf_rounds")]
+    rounds: u32,
+}
+
+impl KdfParams {
+    fn current() -> Self {
+        Self {
+            algorithm: KDF_ALGORITHM.to_string(),
+            rounds: KDF_ROUNDS,
+        }
+    }
+}
+
+impl Default for KdfParams {
+    fn default() -> Self {
+        Self {
+            algorithm: KDF_ALGORITHM.to_string(),
+            rounds: LEGACY_KDF_ROUNDS,
+        }
+    }
+}
+
+fn default_kdf_algorithm() -> String {
+    KDF_ALGORITHM.to_string()
+}
+
+fn legacy_kdf_rounds() -> u32 {
+    LEGACY_KDF_ROUNDS
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -347,16 +390,31 @@ fn unlock_context_material() -> Result<String> {
     ))
 }
 
-fn derive_context_key(context: &str, salt: &[u8]) -> [u8; KEY_SIZE] {
+fn validate_kdf_params(params: &KdfParams) -> Result<()> {
+    if params.algorithm != KDF_ALGORITHM {
+        return Err(eyre!(
+            "Unsupported KDF algorithm '{}'",
+            params.algorithm
+        ));
+    }
+    if params.rounds == 0 {
+        return Err(eyre!("KDF rounds must be greater than zero"));
+    }
+    Ok(())
+}
+
+fn derive_context_key(context: &str, salt: &[u8], params: &KdfParams) -> Result<[u8; KEY_SIZE]> {
+    validate_kdf_params(params)?;
     let mut key = [0_u8; KEY_SIZE];
-    pbkdf2_hmac::<Sha256>(context.as_bytes(), salt, KDF_ROUNDS, &mut key);
-    key
+    pbkdf2_hmac::<Sha256>(context.as_bytes(), salt, params.rounds, &mut key);
+    Ok(key)
 }
 
 fn encrypt_unlock_lease(data: &UnlockLeaseData) -> Result<EncryptedUnlockLease> {
     let salt = rand::random::<[u8; SALT_SIZE]>();
     let nonce = rand::random::<[u8; NONCE_SIZE]>();
-    let key = derive_context_key(&unlock_context_material()?, &salt);
+    let kdf = KdfParams::current();
+    let key = derive_context_key(&unlock_context_material()?, &salt, &kdf)?;
     let plaintext = serde_yaml::to_string(data)?;
     let cipher = Aes256GcmSiv::new_from_slice(&key)?;
     let ciphertext = cipher
@@ -364,6 +422,7 @@ fn encrypt_unlock_lease(data: &UnlockLeaseData) -> Result<EncryptedUnlockLease> 
         .map_err(|_| eyre!("Failed to encrypt unlock lease"))?;
     Ok(EncryptedUnlockLease {
         version: 1,
+        kdf,
         salt: base64::engine::general_purpose::STANDARD.encode(salt),
         nonce: base64::engine::general_purpose::STANDARD.encode(nonce),
         ciphertext: base64::engine::general_purpose::STANDARD.encode(ciphertext),
@@ -394,7 +453,7 @@ fn decrypt_unlock_lease(encrypted: EncryptedUnlockLease) -> Result<UnlockLeaseDa
             NONCE_SIZE
         ));
     }
-    let key = derive_context_key(&unlock_context_material()?, &salt);
+    let key = derive_context_key(&unlock_context_material()?, &salt, &encrypted.kdf)?;
     let cipher = Aes256GcmSiv::new_from_slice(&key)?;
     let plaintext = cipher
         .decrypt(Nonce::from_slice(&nonce), ciphertext.as_ref())
@@ -825,6 +884,11 @@ pub fn list_secret_names(keystore_password: &str) -> Result<Vec<String>> {
     Ok(names)
 }
 
+pub fn list_secret_entries(keystore_password: &str) -> Result<Vec<(String, SecretEntry)>> {
+    let store = read_store(keystore_password)?;
+    Ok(store.secrets.into_iter().collect())
+}
+
 pub fn keystore_exists() -> Result<bool> {
     Ok(get_keystore_path()?.is_file())
 }
@@ -860,7 +924,7 @@ fn read_store(keystore_password: &str) -> Result<KeystoreData> {
         ));
     }
 
-    let key = derive_key(keystore_password, &salt);
+    let key = derive_key(keystore_password, &salt, &encrypted.kdf)?;
     let cipher = Aes256GcmSiv::new_from_slice(&key)?;
     let plaintext = cipher
         .decrypt(Nonce::from_slice(&nonce), ciphertext.as_ref())
@@ -871,7 +935,8 @@ fn read_store(keystore_password: &str) -> Result<KeystoreData> {
 fn write_store(store: &KeystoreData, keystore_password: &str) -> Result<()> {
     let salt = rand::random::<[u8; SALT_SIZE]>();
     let nonce = rand::random::<[u8; NONCE_SIZE]>();
-    let key = derive_key(keystore_password, &salt);
+    let kdf = KdfParams::current();
+    let key = derive_key(keystore_password, &salt, &kdf)?;
     let plaintext = serde_yaml::to_string(store)?;
 
     let cipher = Aes256GcmSiv::new_from_slice(&key)?;
@@ -881,6 +946,7 @@ fn write_store(store: &KeystoreData, keystore_password: &str) -> Result<()> {
 
     let envelope = EncryptedKeystore {
         version: 1,
+        kdf,
         salt: base64::engine::general_purpose::STANDARD.encode(salt),
         nonce: base64::engine::general_purpose::STANDARD.encode(nonce),
         ciphertext: base64::engine::general_purpose::STANDARD.encode(ciphertext),
@@ -891,10 +957,11 @@ fn write_store(store: &KeystoreData, keystore_password: &str) -> Result<()> {
     Ok(())
 }
 
-fn derive_key(password: &str, salt: &[u8]) -> [u8; KEY_SIZE] {
+fn derive_key(password: &str, salt: &[u8], params: &KdfParams) -> Result<[u8; KEY_SIZE]> {
+    validate_kdf_params(params)?;
     let mut key = [0_u8; KEY_SIZE];
-    pbkdf2_hmac::<Sha256>(password.as_bytes(), salt, KDF_ROUNDS, &mut key);
-    key
+    pbkdf2_hmac::<Sha256>(password.as_bytes(), salt, params.rounds, &mut key);
+    Ok(key)
 }
 
 #[cfg(test)]
@@ -1133,6 +1200,41 @@ mod tests {
 
         let status = get_unlock_status().expect("unlock status");
         assert_eq!(status.expires_at_epoch, Some(i64::MAX));
+    }
+
+    #[test]
+    fn encrypted_envelopes_persist_current_kdf_params() {
+        let _guard = test_env_lock().lock().expect("env lock");
+        let (_tmp, keystore_path, unlock_path) = setup_env();
+
+        create_keystore("pw").expect("create keystore");
+        write_unlock_lease("pw", Duration::from_secs(300)).expect("write unlock lease");
+
+        let keystore_file = File::open(keystore_path).expect("open keystore");
+        let keystore: EncryptedKeystore =
+            serde_yaml::from_reader(BufReader::new(keystore_file)).expect("keystore envelope");
+        assert_eq!(keystore.kdf, KdfParams::current());
+
+        let unlock_file = File::open(unlock_path).expect("open unlock lease");
+        let unlock: EncryptedUnlockLease =
+            serde_yaml::from_reader(BufReader::new(unlock_file)).expect("unlock envelope");
+        assert_eq!(unlock.kdf, KdfParams::current());
+    }
+
+    #[test]
+    fn encrypted_envelopes_default_missing_kdf_to_legacy_rounds() {
+        let keystore: EncryptedKeystore = serde_yaml::from_str(
+            r#"
+version: 1
+salt: ""
+nonce: ""
+ciphertext: ""
+"#,
+        )
+        .expect("legacy keystore envelope");
+
+        assert_eq!(keystore.kdf.algorithm, KDF_ALGORITHM);
+        assert_eq!(keystore.kdf.rounds, LEGACY_KDF_ROUNDS);
     }
 
     #[test]

--- a/src/data/keystore.rs
+++ b/src/data/keystore.rs
@@ -29,9 +29,6 @@ use std::{
 const KDF_ROUNDS: u32 = 100_000;
 #[cfg(debug_assertions)]
 const KDF_ROUNDS: u32 = 1_000;
-#[cfg(not(debug_assertions))]
-const MIN_KDF_ROUNDS: u32 = 100_000;
-#[cfg(debug_assertions)]
 const MIN_KDF_ROUNDS: u32 = 1_000;
 const MAX_KDF_ROUNDS: u32 = 1_000_000;
 const LEGACY_KDF_ROUNDS: u32 = 100_000;
@@ -407,7 +404,7 @@ fn validate_kdf_params(params: &KdfParams) -> Result<()> {
     }
     if params.rounds < MIN_KDF_ROUNDS {
         return Err(eyre!(
-            "KDF rounds {} are below the minimum supported value {}",
+            "KDF rounds {} are below the minimum readable value {}",
             params.rounds,
             MIN_KDF_ROUNDS
         ));

--- a/src/data/keystore.rs
+++ b/src/data/keystore.rs
@@ -31,7 +31,7 @@ const KDF_ROUNDS: u32 = 100_000;
 const KDF_ROUNDS: u32 = 1_000;
 const MIN_KDF_ROUNDS: u32 = 1_000;
 const MAX_KDF_ROUNDS: u32 = 1_000_000;
-const LEGACY_KDF_ROUNDS: u32 = 100_000;
+const DEFAULT_KDF_ROUNDS: u32 = 100_000;
 const KDF_ALGORITHM: &str = "pbkdf2-sha256";
 const KEY_SIZE: usize = 32;
 const SALT_SIZE: usize = 16;
@@ -156,7 +156,7 @@ struct EncryptedUnlockLease {
 struct KdfParams {
     #[serde(default = "default_kdf_algorithm")]
     algorithm: String,
-    #[serde(default = "legacy_kdf_rounds")]
+    #[serde(default = "default_kdf_rounds")]
     rounds: u32,
 }
 
@@ -173,7 +173,7 @@ impl Default for KdfParams {
     fn default() -> Self {
         Self {
             algorithm: KDF_ALGORITHM.to_string(),
-            rounds: LEGACY_KDF_ROUNDS,
+            rounds: DEFAULT_KDF_ROUNDS,
         }
     }
 }
@@ -182,8 +182,8 @@ fn default_kdf_algorithm() -> String {
     KDF_ALGORITHM.to_string()
 }
 
-fn legacy_kdf_rounds() -> u32 {
-    LEGACY_KDF_ROUNDS
+fn default_kdf_rounds() -> u32 {
+    DEFAULT_KDF_ROUNDS
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1238,7 +1238,7 @@ mod tests {
     }
 
     #[test]
-    fn encrypted_envelopes_default_missing_kdf_to_legacy_rounds() {
+    fn encrypted_envelopes_default_missing_kdf_to_default_rounds() {
         let keystore: EncryptedKeystore = serde_yaml::from_str(
             r#"
 version: 1
@@ -1247,10 +1247,10 @@ nonce: ""
 ciphertext: ""
 "#,
         )
-        .expect("legacy keystore envelope");
+        .expect("keystore envelope with defaulted KDF params");
 
         assert_eq!(keystore.kdf.algorithm, KDF_ALGORITHM);
-        assert_eq!(keystore.kdf.rounds, LEGACY_KDF_ROUNDS);
+        assert_eq!(keystore.kdf.rounds, DEFAULT_KDF_ROUNDS);
     }
 
     #[test]

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -24,11 +24,12 @@ pub use keystore::{
     BasicSecret, SecretAuth, SecretEntry, UnlockLease, UnlockStatus, add_secret, authenticate,
     clear_unlock_lease, create_keystore, default_unlock_ttl, get_keystore_password,
     get_keystore_path, get_password_for_secret_commands, get_password_from_unlock_file, get_secret,
-    get_unlock_path, get_unlock_status, keystore_exists, list_secret_entries, list_secret_names,
-    parse_unlock_ttl, read_unlock_lease, remove_secret, resolve_secret_auth, rotate_keystore_password,
-    update_secret, upsert_secret_auth, validate_existing_keystore_password,
-    with_scoped_keystore_password, write_unlock_lease,
+    get_unlock_path, get_unlock_status, keystore_exists, list_secret_names, parse_unlock_ttl,
+    read_unlock_lease, remove_secret, resolve_secret_auth, rotate_keystore_password, update_secret,
+    upsert_secret_auth, validate_existing_keystore_password, with_scoped_keystore_password,
+    write_unlock_lease,
 };
+pub(crate) use keystore::list_secret_entries;
 pub use known_host::{ElasticCloud, HostRole, KnownHost, KnownHostBuilder, KnownHostCliUpdate};
 #[cfg(test)]
 pub(crate) use known_host::write_hosts_yml_for_tests;

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -24,10 +24,10 @@ pub use keystore::{
     BasicSecret, SecretAuth, SecretEntry, UnlockLease, UnlockStatus, add_secret, authenticate,
     clear_unlock_lease, create_keystore, default_unlock_ttl, get_keystore_password,
     get_keystore_path, get_password_for_secret_commands, get_password_from_unlock_file, get_secret,
-    get_unlock_path, get_unlock_status, keystore_exists, list_secret_names, parse_unlock_ttl,
-    read_unlock_lease, remove_secret, resolve_secret_auth, rotate_keystore_password, update_secret,
-    upsert_secret_auth, validate_existing_keystore_password, with_scoped_keystore_password,
-    write_unlock_lease,
+    get_unlock_path, get_unlock_status, keystore_exists, list_secret_entries, list_secret_names,
+    parse_unlock_ttl, read_unlock_lease, remove_secret, resolve_secret_auth, rotate_keystore_password,
+    update_secret, upsert_secret_auth, validate_existing_keystore_password,
+    with_scoped_keystore_password, write_unlock_lease,
 };
 pub use known_host::{ElasticCloud, HostRole, KnownHost, KnownHostBuilder, KnownHostCliUpdate};
 #[cfg(test)]

--- a/src/server/hosts.rs
+++ b/src/server/hosts.rs
@@ -872,10 +872,12 @@ fn read_secret_rows(
     let mut secret_ids = Vec::with_capacity(entries.len());
 
     for (secret_id, entry) in entries {
-        let (auth_type, username) = match entry.resolve_auth() {
-            Some(SecretAuth::ApiKey { .. }) => ("ApiKey", String::new()),
-            Some(SecretAuth::Basic { username, .. }) => ("Basic", username),
-            None => ("Unknown", String::new()),
+        let (auth_type, username) = if entry.apikey.is_some() {
+            ("ApiKey", String::new())
+        } else if let Some(basic) = entry.basic.as_ref() {
+            ("Basic", basic.username.clone())
+        } else {
+            ("Unknown", String::new())
         };
         secret_ids.push(secret_id.clone());
         rows.push(template::SecretTableRow {

--- a/src/server/hosts.rs
+++ b/src/server/hosts.rs
@@ -881,7 +881,7 @@ fn read_secret_rows(
         };
         secret_ids.push(secret_id.clone());
         rows.push(template::SecretTableRow {
-            secret_id: secret_id.clone(),
+            secret_id,
             auth_type: auth_type.to_string(),
             username,
         });

--- a/src/server/hosts.rs
+++ b/src/server/hosts.rs
@@ -1,7 +1,7 @@
 use super::{ServerState, get_theme_dark, template};
 use crate::data::{
     HostRole, KnownHost, KnownHostBuilder, Product, SecretAuth, Settings, keystore_exists,
-    list_secret_names, remove_secret, resolve_secret_auth, upsert_secret_auth,
+    list_secret_entries, remove_secret, resolve_secret_auth, upsert_secret_auth,
 };
 use askama::Template;
 use axum::{
@@ -867,16 +867,17 @@ fn host_has_plaintext_auth(host: &KnownHost) -> bool {
 fn read_secret_rows(
     keystore_password: &str,
 ) -> Result<(Vec<template::SecretTableRow>, Vec<String>), String> {
-    let secret_ids = list_secret_names(keystore_password).map_err(to_message)?;
-    let mut rows = Vec::new();
+    let entries = list_secret_entries(keystore_password).map_err(to_message)?;
+    let mut rows = Vec::with_capacity(entries.len());
+    let mut secret_ids = Vec::with_capacity(entries.len());
 
-    for secret_id in &secret_ids {
-        let auth = resolve_secret_auth(secret_id, keystore_password).map_err(to_message)?;
-        let (auth_type, username) = match auth {
+    for (secret_id, entry) in entries {
+        let (auth_type, username) = match entry.resolve_auth() {
             Some(SecretAuth::ApiKey { .. }) => ("ApiKey", String::new()),
             Some(SecretAuth::Basic { username, .. }) => ("Basic", username),
             None => ("Unknown", String::new()),
         };
+        secret_ids.push(secret_id.clone());
         rows.push(template::SecretTableRow {
             secret_id: secret_id.clone(),
             auth_type: auth_type.to_string(),


### PR DESCRIPTION
## Summary
- Store KDF metadata in keystore and unlock lease envelopes so files carry the rounds used to derive their keys.
- Use lower default KDF rounds in debug builds while preserving 100k rounds for release builds and legacy files.
- Avoid repeated keystore decrypts when rendering secret rows in the hosts UI.

## Test plan
- cargo test --lib data::keystore
- cargo test --lib server::hosts
- cargo test


Made with [Cursor](https://cursor.com)