### PR TITLE
fix: extend long-running collection request timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ published release notes, maintenance branches, and tagged history.
 
 ### Changed
 
+- Increased the long-running collection request timeout so large Elasticsearch API payloads can finish returning.
 - Moved the Tauri desktop app root under `desktop/` while keeping root-level `cargo tauri build` and desktop packaging workflows working.
 - Refined workflow card controls.
 - Polished workflow bundle delivery.

--- a/src/processor/api.rs
+++ b/src/processor/api.rs
@@ -76,7 +76,7 @@ impl ElasticsearchApi {
             ElasticsearchApi::PendingTasks => ApiWeight::Light,
             ElasticsearchApi::Repositories => ApiWeight::Light,
             ElasticsearchApi::SearchableSnapshotsCacheStats => ApiWeight::Light,
-            ElasticsearchApi::SearchableSnapshotsStats => ApiWeight::Light,
+            ElasticsearchApi::SearchableSnapshotsStats => ApiWeight::Heavy,
             ElasticsearchApi::Snapshots => ApiWeight::Heavy,
             ElasticsearchApi::SlmPolicies => ApiWeight::Light,
             ElasticsearchApi::Tasks => ApiWeight::Heavy,

--- a/src/receiver/elastic_cloud_admin.rs
+++ b/src/receiver/elastic_cloud_admin.rs
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use super::super::processor::{DataSource, DiagnosticManifest, ElasticsearchCluster, ManifestBuilder, SourceContext};
-use super::{Receive, ReceiveRaw};
+use super::{LONG_RUNNING_REQUEST_TIMEOUT, Receive, ReceiveRaw};
 use crate::data::{Auth, KnownHost};
 use eyre::{Result, eyre};
 use reqwest::header::{ACCEPT, ACCEPT_ENCODING, AUTHORIZATION};
@@ -17,7 +17,6 @@ use std::time::Duration;
 use tokio::sync::OnceCell;
 
 const ELASTIC_CLOUD_ADMIN_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-const ELASTIC_CLOUD_ADMIN_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Debug)]
 pub struct ElasticCloudAdminRequestError {
@@ -69,7 +68,9 @@ impl ElasticCloudAdminReceiver {
         let client = ClientBuilder::new()
             .default_headers(default_headers)
             .connect_timeout(ELASTIC_CLOUD_ADMIN_CONNECT_TIMEOUT)
-            .timeout(ELASTIC_CLOUD_ADMIN_REQUEST_TIMEOUT)
+            // Cloud Admin collection proxies Elasticsearch APIs that can spend
+            // minutes building large payloads before response headers arrive.
+            .timeout(LONG_RUNNING_REQUEST_TIMEOUT)
             .build()?;
         Ok(Self {
             client,

--- a/src/receiver/mod.rs
+++ b/src/receiver/mod.rs
@@ -31,7 +31,10 @@ use directory::DirectoryReceiver;
 use eyre::{Result, eyre};
 use futures::stream::BoxStream;
 use serde::de::DeserializeOwned;
+use std::time::Duration;
 use upload_service::UploadServiceDownloader;
+
+pub(crate) const LONG_RUNNING_REQUEST_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
 #[allow(async_fn_in_trait)]
 pub trait Receive {


### PR DESCRIPTION
## Summary
- replace the Cloud Admin-specific request timeout name with a shared long-running collection timeout
- raise the request timeout used by Cloud Admin collection from 15 seconds to 5 minutes
- treat searchable snapshots stats as a heavy Elasticsearch collection API

## Tests
- cargo test receiver::elastic_cloud_admin::tests
- cargo test processor::api::tests::test_es_resolve_minimal_dependencies
- cargo check
- git diff --check