### PR TITLE
feat(receiver): normalize malformed IPs in scrubbed diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ published release notes, maintenance branches, and tagged history.
 - Added `esdiag local` to provision and manage a local Elastic Stack through a Rust-owned lifecycle, with core as the default and an explicit full-container override.
 - Added optional Elastic Upload Service forwarding to `esdiag-lite.sh` for newly collected and existing ZIP archives.
 - Added `esdiag-lite.ps1` for version-aware Elasticsearch diagnostic collection on Windows PowerShell.
+- Added receiver-stage normalization for malformed IPv4 values in scrubbed diagnostics, with `--scrubbed` CLI flag and upload checkbox (#330).
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ zip = { version = "8.6.0", default-features = false, features = [
     "deflate-flate2",
 ] }
 yaml_serde = "0.10.4"
+tempfile = "3.27.0"
 
 [dev-dependencies]
 portpicker = "0.1.1"
@@ -82,7 +83,6 @@ tokio = { version = "1.52", features = [
     "sync",
     "io-util",
 ] }
-tempfile = "3.27.0"
 
 [build-dependencies]
 flate2 = { version = "1.1", default-features = false, features = ["rust_backend"] }

--- a/docs/scrubbed-diagnostics.md
+++ b/docs/scrubbed-diagnostics.md
@@ -1,0 +1,138 @@
+---
+type: Reference
+title: Scrubbed Diagnostic Normalization
+description: Reference for how esdiag normalizes malformed IPv4 values in scrubbed diagnostics, and how to control it.
+tags: [receiver, scrubbed, normalization]
+---
+
+# Scrubbed diagnostic normalization
+
+esdiag can repair deterministic malformed IPv4 values in scrubbed Elasticsearch API diagnostics before processors run. This keeps node address fields ingest-safe and improves node summary joins without changing processor logic.
+
+## When normalization runs
+
+Normalization runs in the **receiver read path** for archive and directory inputs (`process` CLI and upload UI). Processors always receive either original or already-normalized JSON.
+
+| Channel | Control | Default when unset |
+|---------|---------|-------------------|
+| CLI `process` | `--scrubbed true\|false` | Auto: enabled when the input path contains `scrubbed` as a standalone token (zip **or** extracted directory) |
+| Upload UI | `scrubbed` multipart field (checkbox) | Auto: enabled when the **uploaded** filename contains `scrubbed` as a standalone token (not the temp staging path) |
+| Service link | _(no checkbox yet)_ | Auto: enabled when the **filename** field contains `scrubbed` as a standalone token |
+
+Precedence is **channel-local**:
+
+- CLI `--scrubbed true` forces normalization even if the filename does not contain a `scrubbed` token.
+- CLI `--scrubbed false` disables normalization even for `*scrubbed*.zip` inputs.
+- Upload checkbox values `true`, `1`, or `on` enable scrub mode; any other explicit value disables it. If the checkbox field is present but unreadable, scrub mode defaults to enabled.
+
+CLI and UI are independent execution channels; one does not override the other.
+
+## Supported files and fields
+
+Normalization applies to address fields in **all diagnostic `.json` files** except `diagnostic_manifest.json` and `version.json` (including `nodes.json`, `nodes_stats.json`, `tasks.json`, `master.json`, `shards.json`, etc.).
+
+Only explicit address fields are rewritten:
+
+- Pure IP semantics (`ip` mapping and keyword mirrors): `ip`, `host`, `publish_host`, `bind_host`
+- IP with optional port: `transport_address`, `publish_address`, `bound_address`, `local_address`, `remote_address`, `x_forwarded_for`
+- HTTP client IDs under `http.clients[].id` when the value is a malformed dotted-quad
+
+All other `.json` diagnostic files are scanned (except `diagnostic_manifest.json` and `version.json`).
+
+## Normalization rules
+
+- Malformed IPv4 octets use deterministic modulo: `octet % 255`.
+- Valid IPv4 values (all octets `<= 255`) pass through unchanged.
+- For `ip:port` fields, only the IP component is normalized; the port is preserved.
+- For pure IP fields (`ip`, `host`), normalized output is IP-only (no port suffix).
+
+Scrubbed 19-character lowercase hex node names are humanized during node lookup processing (for example `aaaabbbbccccddddee0` → `hot-dee0`).
+
+## Customer diagnostics policy
+
+**Never commit customer scrubbed API bundles to this repository.**
+
+Automated tests build synthetic malformed IPs at runtime from the esdiag golden archive (`tests/archives/elasticsearch-api-diagnostics-9.3.3.zip`). See `tests/scrubbed_normalization_tests.rs` and the `synthetic_vectors` test module in `src/receiver/archive/scrub.rs` for canonical test constants.
+
+## Deterministic verification (CI)
+
+```bash
+cargo test --lib scrub
+cargo test --test scrubbed_normalization_tests
+cargo test --test scrub_debug_log_tests
+cargo clippy --workspace --all-targets
+npx openspec validate normalize-malformed-scrubbed-ips
+```
+
+The integration test transforms the golden archive in a temp directory (malformed IP substitution), runs `process` → directory export, and asserts normalized node metrics — no committed scrubbed zip or helper scripts required.
+
+## Dev ingest verification (environment-gated)
+
+Optional before merge when you have a live Elasticsearch output target (`ESDIAG_OUTPUT_URL` in a `KEY=value` env file). Use a **local** archive whose filename contains `scrubbed`, or pass `--scrubbed true` explicitly. Do not commit customer bundles.
+
+```bash
+cargo build --release
+set -a && source /path/to/.env && set +a
+
+esdiag process /path/to/local-archive.zip --scrubbed true --debug
+
+jq '.diagnostic | {doc_errors: .docs.errors, created: .docs.created, node_metrics: .processor.stats["metrics-node-esdiag"]}' \
+  ~/.esdiag/last_run/report.json
+```
+
+Pass criteria:
+
+1. `esdiag process` exits 0.
+2. `diagnostic.docs.errors` is zero in `~/.esdiag/last_run/report.json`.
+3. `diagnostic.processor.stats["metrics-node-esdiag"].docs` is non-zero when the archive includes node stats.
+
+Recorded run: `openspec/changes/archive/2026-06-04-normalize-malformed-scrubbed-ips/validation-code-gates.md` (§3 Live ingest)
+
+## Memory regression spot-check
+
+Compare RSS for the same archive with scrub mode off vs on. Target: **≤ 20% RSS increase** with scrub enabled.
+
+Linux:
+
+```bash
+/usr/bin/time -v ./target/release/esdiag process tests/archives/elasticsearch-api-diagnostics-9.3.3.zip --scrubbed false -o /tmp/esdiag-out-base
+/usr/bin/time -v ./target/release/esdiag process tests/archives/elasticsearch-api-diagnostics-9.3.3.zip --scrubbed true -o /tmp/esdiag-out-scrub
+```
+
+macOS:
+
+```bash
+/usr/bin/time -l ./target/release/esdiag process tests/archives/elasticsearch-api-diagnostics-9.3.3.zip --scrubbed false -o /tmp/esdiag-out-base
+/usr/bin/time -l ./target/release/esdiag process tests/archives/elasticsearch-api-diagnostics-9.3.3.zip --scrubbed true -o /tmp/esdiag-out-scrub
+```
+
+Use the `Maximum resident set size` line from each run.
+
+## Troubleshooting
+
+| Symptom | Likely cause | What to check |
+|---------|--------------|---------------|
+| Node metrics missing in Kibana | Time picker excludes collection date | Metric docs use manifest collection date for `@timestamp`, not ingest time |
+| Scrub normalization did not run | Auto mode off or directory path without scrub wiring (fixed in feature branch) | Use `./target/release/esdiag` from this branch; pass `--scrubbed true`; prefer `*.zip` or ensure extracted folder name contains `scrubbed` |
+| Valid IPs changed unexpectedly | Scrub mode forced on non-scrubbed bundle | Re-run with `--scrubbed false` |
+| Partial node summary fields | Node lookup miss | Debug logs show `Node lookup not found`; fallback summary patch should still populate `node.id` and tier fields |
+
+Enable debug logging to see per-file normalization:
+
+```bash
+esdiag process scrubbed-api-diagnostics.zip --scrubbed true --debug
+```
+
+Look for lines like `Unscrubbed N address fields in .../nodes.json`.
+
+## Test matrix
+
+| Gate | Scope | Command |
+|------|-------|---------|
+| Deterministic unit tests | Scrub helpers, receiver wiring, upload parsing, node rename | `cargo test --lib scrub` |
+| Deterministic integration | In-process `process` → directory export; per-node IP mapping across NDJSON streams; archive **and** directory paths; scrub disabled regression | `cargo test --test scrubbed_normalization_tests` |
+| Debug log assertions | Scrub mode context + per-file unscrubbed counts | `cargo test --test scrub_debug_log_tests` |
+| Workspace lint | Changed Rust sources | `cargo clippy --workspace --all-targets` |
+| OpenSpec | Change artifacts | `npx openspec validate normalize-malformed-scrubbed-ips` |
+| Environment-gated ingest | Live Elasticsearch target | Manual `esdiag process --debug` + `report.json` checks (see above) |
+| Environment-gated full suite | Known-host / container dependent tests | `cargo test --workspace` (classify pre-existing failures) |

--- a/docs/scrubbed-diagnostics.md
+++ b/docs/scrubbed-diagnostics.md
@@ -23,7 +23,7 @@ Precedence is **channel-local**:
 
 - CLI `--scrubbed true` forces normalization even if the filename does not contain a `scrubbed` token.
 - CLI `--scrubbed false` disables normalization even for `*scrubbed*.zip` inputs.
-- Upload checkbox values `true`, `1`, or `on` enable scrub mode; any other explicit value disables it. If the checkbox field is present but unreadable, scrub mode defaults to enabled.
+- Checking the upload checkbox explicitly enables scrub mode. When unchecked, the field is omitted and the uploaded filename controls auto-detection. API clients may send other explicit values to disable scrub mode. If the checkbox field is present but unreadable, scrub mode defaults to enabled.
 
 CLI and UI are independent execution channels; one does not override the other.
 

--- a/openspec/changes/archive/2026-06-04-normalize-malformed-scrubbed-ips/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-04-normalize-malformed-scrubbed-ips/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-11

--- a/openspec/changes/archive/2026-06-04-normalize-malformed-scrubbed-ips/design.md
+++ b/openspec/changes/archive/2026-06-04-normalize-malformed-scrubbed-ips/design.md
@@ -1,0 +1,145 @@
+## Context
+
+Scrubbed diagnostic archives can contain deterministic but malformed IPv4 values and anonymized node names that break node-level readability and cross-source joins. In practice, this causes partial dashboards (especially node summary views) even when ingest technically succeeds.
+
+esdiag already has a receiver -> processor -> exporter architecture, and this change fits best as a receiver-stage normalization pass so processors can remain focused on business logic rather than scrub-specific repair logic.
+
+Constraints and decisions from proposal review:
+- receiver-first handling only (no ingest retry fallback path)
+- scrub mode auto-detect by filename/path containing `scrubbed`
+- explicit control in each execution channel (CLI flag in CLI path, checkbox in UI path)
+- UI/CLI are treated as either/or channels rather than cross-overriding controls
+- normalization only on explicit address fields (no free-text global rewrite)
+- non-scrubbed bundles must not be mangled
+- scrubbed node names are 19-char lowercase hex and should be humanized using last 4 chars
+
+## Goals / Non-Goals
+
+**Goals:**
+- Detect scrubbed archives early in receiver flow and normalize before processor parsing.
+- Normalize malformed IPv4-like values deterministically using octet `% 255`.
+- Preserve document usability and processor joins by standardizing node address/name surfaces.
+- Humanize scrubbed node names using existing rename logic shape with last-4 suffix behavior.
+- Guarantee non-mangling of non-scrubbed diagnostics through fixture-based tests.
+- Keep memory overhead bounded with a target of <= 20% RSS increase vs non-scrubbed processing.
+
+**Non-Goals:**
+- No ingest-pipeline retry/fallback mechanism for malformed IP failures.
+- No global free-text replacement outside explicit address/name fields.
+- No external dependencies or sidecar preprocessing service.
+- No change to core processor state-machine design.
+
+## Decisions
+
+### 0) Test Strategy Must Match esdiag Test Topology
+
+esdiag testing is intentionally mixed:
+- deterministic unit/in-process tests (always runnable in CI/dev)
+- environment-dependent integration tests (known-host aliases, local/remote services, containers)
+
+Therefore this change uses layered verification instead of a single "all workspace tests must pass everywhere" gate.
+
+Required per-phase gates:
+- `cargo clippy --workspace --all-targets`
+- targeted deterministic tests for touched modules (receiver/server/processor units)
+- `openspec validate normalize-malformed-scrubbed-ips`
+
+Environment-gated checks (required before merge, but not required on every local iteration):
+- full `cargo test --workspace` with documented baseline for existing env-dependent failures
+- live ingest validation against Elasticsearch dev target using `esdiag process --debug`
+- post-run artifact checks in `~/.esdiag/last_run`
+
+### 1) Receiver-Stage Scrub Normalization
+
+Implement a scrub-aware normalization layer in receiver archive readers (`archive/file` and `archive/bytes`) that transforms selected file payloads before processor consumption.
+
+Rationale:
+- Centralized behavior for all downstream processors.
+- Avoids duplicated repair logic across `nodes`, `nodes_stats`, `tasks`, and other processors.
+- Preserves existing type-state processor flow with minimal architectural disruption.
+
+Alternative considered:
+- Processor-side normalization only. Rejected because it fragments behavior across modules and is easy to miss when data is represented as `serde_json::Value`.
+
+### 2) Activation Model and Precedence
+
+Activation modes:
+- CLI channel:
+  - implicit `auto`: when `--scrubbed` is not provided, enable only if input archive filename/path contains `scrubbed`
+  - explicit override: `--scrubbed true` forces scrub normalization
+  - explicit override: `--scrubbed false` forces no scrub normalization
+- UI channel:
+  - checkbox controls scrub behavior for upload path
+  - auto-detect fallback applies when checkbox is unset
+
+Precedence:
+- resolve precedence within channel only
+- no cross-channel precedence is required because execution is either CLI or UI
+
+Surface:
+- CLI flag `--scrubbed BOOL` (for `process` and server ingest path wiring)
+- Upload UI checkbox mapped to same mode enum
+
+Rationale:
+- Safe default for known scrubbed archives plus explicit operator control for edge cases.
+
+### 3) Explicit Field Allowlist
+
+Normalization SHALL apply only to explicit address fields:
+- `ip`, `host`
+- `transport_address`, `publish_address`, `bound_address`
+- known nested transport/http address fields (`local_address`, `remote_address`, `x_forwarded_for`)
+
+Rationale:
+- Reduces accidental mutation risk and supports non-mangling guarantee.
+
+Alternative considered:
+- Rewrite any string matching malformed IPv4 pattern. Rejected as too risky for semantic text fields.
+
+### 4) Deterministic IPv4 Rewrite
+
+Malformed dotted-quad octets are normalized via `octet % 255` per octet.
+
+For `ip:port` fields:
+- normalize IP component only
+- preserve original port component
+
+For fields typed as pure IP semantics (`ip`, `host`):
+- store normalized IP only (no port suffix)
+
+Rationale:
+- Stateless, deterministic, low-compute transformation requested in proposal discussion.
+
+### 5) Node Name Humanization Rule
+
+For scrubbed node names matching 19-char lowercase hex (example: `c4e8f2a16b3d4f099e7`):
+- use existing tier rename logic shape
+- replace numeric segment with original scrubbed name last 4 chars
+
+Example behavior:
+- source: `c4e8f2a16b3d4f099e7`, tier `hot`
+- output style: `hot-99e7`
+
+Rationale:
+- Operator-readable labels while retaining deterministic traceability.
+
+### 6) Type-State and Trait Boundaries
+
+No processor lifecycle changes required. Existing transitions remain:
+- `Processor<Ready> -> Processor<Processing> -> Processor<Completed|Failed>`
+
+Receiver boundary updates:
+- Introduce scrub-mode decision and transformation inside receiver archive read path.
+- Keep `Receiver` trait contract intact by returning normalized bytes/content transparently.
+- Follow existing logging pattern (`log::debug!`) and emit one debug line for each file read that is unscrubbed.
+
+## Risks / Trade-offs
+
+- **[False positive auto-detect on filename]** -> Mitigation: manual override always wins (`on`/`off`).
+- **[Unexpected field mutation]** -> Mitigation: strict allowlist + golden non-mangling fixtures.
+- **[Join regressions across node datasets]** -> Mitigation: add integration assertions for node ID/name/address consistency in `nodes` + `nodes_stats`.
+- **[Memory overhead from transformation]** -> Mitigation: streaming/targeted transforms and RSS budget gate (<=20% increase).
+- **[Inconsistent memory measurement across developer platforms]** -> Mitigation: document and use `/usr/bin/time -l` on macOS and `/usr/bin/time -v` on Linux in validation workflow.
+- **[False-negative quality signal from environment-dependent tests]** -> Mitigation: classify tests into deterministic vs environment-gated; require deterministic gates every phase and run env-gated matrix before merge.
+- **[Octet modulo collisions]** -> Mitigation: acceptable by design for scrubbed mode; deterministic output and logging for traceability.
+

--- a/openspec/changes/archive/2026-06-04-normalize-malformed-scrubbed-ips/proposal.md
+++ b/openspec/changes/archive/2026-06-04-normalize-malformed-scrubbed-ips/proposal.md
@@ -1,0 +1,74 @@
+## Why
+
+Scrubbed diagnostics can replace real node addresses with deterministic but invalid IPv4 values (for example `432.359.345.528`). These values break `ip` field handling and can cause partial ingest or missing node visualizations even when the diagnostic is otherwise processable.
+
+esdiag needs a deterministic, low-overhead, and auditable normalization strategy so malformed scrubbed IPs do not block node-level analytics.
+
+## What Changes
+
+- Add a **scrubbed archive receiver stage** in the read path: when `Receiver` detects a scrubbed diagnostic bundle, it normalizes malformed IP-like values before handing data to processors.
+- Add dual activation controls for scrub handling:
+  - auto mode when archive filename/path contains `scrubbed`
+  - explicit activation control in each execution channel:
+    - CLI channel uses `--scrubbed BOOL`
+    - UI upload channel uses scrub checkbox
+- Keep processors unchanged as consumers of normalized input (no per-processor normalization logic by default).
+- Add a canonical malformed-IPv4 normalization path in esdiag using octet transformation (`octet % 255`) with stable, deterministic output.
+- Apply normalization to all known node-related address surfaces (`ip`, `host`, `transport_address`, `publish_address`, `bound_address`, and nested transport/http address fields) while preserving non-address semantics.
+- Do not add an ingest-fallback retry path; normalization is handled in the receiver path before processor execution.
+- Add diagnostics/telemetry for normalization events (count, source field, sample values redacted) so support can trace why values changed.
+- Add a strict fallback behavior: if a value still cannot be normalized safely, route to non-fatal handling (drop field or tag document) rather than failing entire node ingestion.
+- Add tests and fixtures covering malformed scrubbed bundles and validating that node summary dashboards populate after ingest.
+- Add non-mangling safety tests to prove normal diagnostics are unchanged and only targeted malformed scrubbed IP fields are transformed.
+- Add node-name correction planning in node lookup rename defaults:
+  - detect scrubbed node names that match 19-character lowercase hex
+  - preserve readability by keeping the last 4 chars of the original scrubbed name in the renamed output
+  - use existing rename logic shape, but replace the numeric segment with the original scrubbed name's last 4 chars
+- Add a dev ingest verification workflow that runs real `esdiag process` ingestion and hard-fails on bulk/index mapping conflicts.
+  - conflict indicators are recorded and evaluated in debug mode output/artifacts
+
+## Capabilities
+
+### New Capabilities
+- `scrubbed-archive-receiver`: Receiver-level scrubbed archive detection and pre-processor normalization pass.
+- `malformed-ip-normalization`: Deterministic normalization and validation of malformed scrubbed IPv4 values across node-centric diagnostic payloads.
+- `scrubbed-mode-controls`: Auto-detect plus explicit controls per channel (CLI flag or UI checkbox).
+- `normalization-observability`: Structured counters/tags for when and where normalization was applied.
+- `node-name-humanization`: Deterministic tier-based rename with retained scrubbed suffix (last 4 chars) for operator readability.
+- `dev-ingest-validation`: Development workflow tests that ingest into Elasticsearch and assert clean bulk results with no mapping conflicts.
+
+### Modified Capabilities
+- None currently (no existing OpenSpec capabilities are defined yet in this repository).
+
+## Impact
+
+- **Affected code paths**
+  - `src/receiver/mod.rs`
+  - `src/receiver/archive/file.rs`
+  - `src/receiver/archive/bytes.rs`
+  - `src/processor/elasticsearch/nodes/data.rs`
+  - `src/processor/elasticsearch/nodes/lookup.rs` (rename default updates for scrubbed names)
+  - `src/processor/elasticsearch/nodes_stats/data.rs`
+  - `src/processor/elasticsearch/nodes_stats/processor.rs`
+  - `src/receiver/scrub.rs`
+  - `src/server/file_upload.rs` (checkbox path)
+  - `src/main.rs` / CLI argument surface (flag path)
+- **Data/Schema**
+  - Potential updates to mappings/pipelines for `metrics-node-esdiag` and related node datasets.
+  - Additional optional metadata fields/tags for normalization observability.
+- **Operational**
+  - Receiver-first strategy is the default and only normalization path.
+  - No ingest-pipeline fallback dependency is planned for this change.
+
+### Ryan Questions / Decision Points For Review
+
+- **Default strategy:** Confirm receiver-first as the only path. no fallback, this will be handled by receiver
+- **Detection contract:** Confirm default auto-detect as filename/path contains `scrubbed`, with manual checkbox/flag override. yes
+- **Override precedence:** CLI and UI are separate execution channels (either/or); no cross-channel precedence required.
+- **Non-mangling guarantee:** Which fixtures become hard gates to prove untouched behavior for non-scrubbed inputs? IPs are still valid IPs
+- **Safety boundary:** Should normalization run only on explicitly recognized IP fields, or on any string that parses as malformed IPv4?  explicetly only
+- **Collision tolerance:** Is `octet % 255` acceptable given potential collisions, or do we need an additional deterministic tie-breaker to reduce collision risk? if we are deterministcally determining IP, how would that even happen? so i think we are safe there
+- **Failure mode:** If normalization still yields unusable output for a field, should esdiag drop the field, tag and keep document, or route to a dead-letter stream? cluster will handle that
+- **Performance target:** What overhead budget is acceptable for per-document normalization in large diagnostics?  memory usage is a bigger concern, optimze,a 20% memory usage RSS on the scrubbed one compared to the unscrubbed
+- **Governance:** Do we require an opt-out/opt-in switch for environments that need original scrubbed values preserved?  NA, not needed
+- **Auditability:** What minimum telemetry is required for support (counts only vs per-field counters vs sampled examples)? no telemetry needed, just debug logging per unscrubbed file read

--- a/openspec/changes/archive/2026-06-04-normalize-malformed-scrubbed-ips/specs/malformed-ip-normalization/spec.md
+++ b/openspec/changes/archive/2026-06-04-normalize-malformed-scrubbed-ips/specs/malformed-ip-normalization/spec.md
@@ -1,0 +1,167 @@
+## ADDED Requirements
+
+### Requirement: Receiver applies scrub normalization before processors
+The system SHALL normalize scrubbed archive payloads in the receiver read path before any processor consumes file content.
+
+#### Scenario: Scrubbed archive in process flow
+- **WHEN** an archive input is classified as scrubbed
+- **THEN** receiver returns normalized content to processors
+- **AND** processors execute without requiring scrub-specific mutation logic
+
+#### Scenario: Non-scrubbed archive in process flow
+- **WHEN** an archive input is classified as non-scrubbed
+- **THEN** receiver returns original content unchanged
+
+### Requirement: Normalization is bounded to supported files
+The system SHALL apply receiver-stage normalization only to supported JSON/text diagnostic files that contain node address and node identity surfaces.
+
+#### Scenario: Supported file
+- **WHEN** receiver reads a supported file (for example `nodes.json` or `nodes_stats.json`)
+- **THEN** receiver applies scrub normalization rules before returning content
+
+#### Scenario: Unsupported file
+- **WHEN** receiver reads an unsupported file type
+- **THEN** receiver SHALL pass content through unchanged
+
+### Requirement: Scrub mode supports auto and manual controls
+The system SHALL support implicit auto mode plus explicit control in both CLI and upload channels.
+
+#### Scenario: Auto mode detection
+- **WHEN** `--scrubbed` is not provided and archive filename/path contains `scrubbed`
+- **THEN** scrub normalization SHALL be enabled
+
+#### Scenario: Auto mode no match
+- **WHEN** `--scrubbed` is not provided and archive filename/path does not contain `scrubbed`
+- **THEN** scrub normalization SHALL remain disabled
+
+### Requirement: Manual override precedence
+The system SHALL apply manual selection precedence within the active execution channel.
+
+#### Scenario: Manual on overrides auto no-match
+- **WHEN** `--scrubbed true` is provided
+- **THEN** normalization SHALL run regardless of filename/path
+
+#### Scenario: Manual off overrides auto match
+- **WHEN** `--scrubbed false` is provided and filename/path contains `scrubbed`
+- **THEN** normalization SHALL NOT run
+
+### Requirement: CLI and UI are independent execution channels
+The system SHALL treat CLI process flow and UI upload flow as either/or channels without cross-channel override behavior.
+
+#### Scenario: CLI channel
+- **WHEN** operator uses CLI process flow
+- **THEN** scrub behavior SHALL be controlled by `--scrubbed BOOL` or implicit auto mode
+
+#### Scenario: UI channel
+- **WHEN** operator uses upload UI flow
+- **THEN** scrub behavior SHALL be controlled by checkbox or auto mode within UI flow
+
+### Requirement: Deterministic malformed IPv4 normalization
+The system SHALL normalize malformed scrubbed IPv4 octets using deterministic per-octet modulo transformation (`octet % 255`).
+
+#### Scenario: Invalid scrubbed IPv4 value
+- **WHEN** a scrubbed address value contains octets outside valid IPv4 range
+- **THEN** each octet SHALL be rewritten via modulo 255
+- **AND** the rewritten value SHALL be deterministic for the same input
+
+### Requirement: Field-allowlist safety boundary
+The system SHALL apply malformed IP normalization only to explicitly supported address fields.
+
+#### Scenario: Allowed address field
+- **WHEN** a malformed IPv4 value appears in an allowed address field
+- **THEN** normalization SHALL be applied
+
+#### Scenario: Non-address field
+- **WHEN** a malformed IPv4-like string appears in a non-address field
+- **THEN** normalization SHALL NOT be applied
+
+### Requirement: Port and pure-IP semantics
+The system SHALL preserve port components for address fields that allow ports and SHALL store pure IP values for fields with pure IP semantics.
+
+#### Scenario: Address with port in transport field
+- **WHEN** an allowed transport field contains `ip:port`
+- **THEN** IP component SHALL be normalized
+- **AND** original port SHALL be preserved
+
+#### Scenario: Pure IP field
+- **WHEN** a pure IP field (`ip` or `host`) contains `ip:port` shaped scrubbed data
+- **THEN** output SHALL contain normalized IP without port
+
+### Requirement: Scrubbed node name detection
+The system SHALL detect scrubbed node-name inputs matching 19-character lowercase hex format.
+
+#### Scenario: 19-char lowercase hex name
+- **WHEN** node name is a 19-character lowercase hexadecimal string
+- **THEN** system SHALL classify it as scrubbed-name format
+
+#### Scenario: Non-matching name
+- **WHEN** node name does not match 19-character lowercase hexadecimal format
+- **THEN** system SHALL treat it as non-scrubbed for this rename rule
+
+### Requirement: Last-4 readable rename default
+The system SHALL use existing tier rename logic shape but replace numeric segment with last 4 characters of original scrubbed node name.
+
+#### Scenario: Scrubbed name with tier
+- **WHEN** a scrubbed 19-character lowercase hexadecimal node name is processed for tier `hot`
+- **THEN** output name SHALL use tier prefix `hot` and suffix equal to the last four characters of the source name (for example, `…99e7` → `hot-99e7`)
+
+#### Scenario: Non-scrubbed existing behavior
+- **WHEN** node name uses existing `instance-...` pattern
+- **THEN** current rename behavior SHALL remain unchanged
+
+### Requirement: Normalization emits debug logs per file
+The system SHALL emit debug logs for scrub normalization decisions and transformations.
+
+#### Scenario: Normalization enabled
+- **WHEN** scrub normalization runs for an archive
+- **THEN** logs SHALL include mode source and transformed field counts
+
+#### Scenario: File-level normalization logging
+- **WHEN** receiver reads a file that is unscrubbed/normalized
+- **THEN** system SHALL emit a debug log line for that file read and transformation action
+
+#### Scenario: Manual override
+- **WHEN** manual scrub mode overrides auto detection
+- **THEN** logs SHALL record effective mode and override source
+
+### Requirement: Non-mangling verification logs
+The system SHALL log verification outcomes for non-scrubbed pass-through behavior in test and validation flows.
+
+#### Scenario: Non-scrubbed fixture validation
+- **WHEN** validation runs against non-scrubbed fixtures
+- **THEN** logs SHALL indicate unchanged pass-through result
+
+### Requirement: Development workflow SHALL validate live ingest cleanliness
+The development workflow SHALL include a test path that runs `esdiag process --debug` against an Elasticsearch target and verifies that ingest completes without bulk/index mapping conflicts.
+
+#### Scenario: Clean ingest run
+- **WHEN** a scrubbed diagnostic fixture is processed to a live Elasticsearch dev target
+- **THEN** bulk ingest SHALL complete with no conflict/rejection entries
+
+#### Scenario: Conflict detection gate
+- **WHEN** any bulk rejection, mapping conflict, or parse/index conflict occurs during ingest
+- **THEN** the development validation step SHALL fail
+
+### Requirement: Development workflow SHALL include artifact checks
+The development workflow SHALL inspect esdiag run artifacts to confirm clean ingest outcomes.
+
+#### Scenario: Last-run artifact verification
+- **WHEN** development ingest validation runs in debug mode
+- **THEN** it SHALL check `~/.esdiag/last_run` outputs for bulk errors and failed responses
+- **AND** it SHALL fail if conflict indicators are present
+
+#### Scenario: Node dataset sanity verification
+- **WHEN** development ingest validation runs successfully
+- **THEN** it SHALL verify node-related datasets are present (for example `metrics-node-esdiag`) and non-empty
+
+### Requirement: Validation gates SHALL follow esdiag test tiers
+The feature validation plan SHALL use deterministic gates for each implementation phase and treat environment-dependent integration tests as separately classified checks.
+
+#### Scenario: Deterministic phase gate
+- **WHEN** a phase changes receiver/server/processor logic
+- **THEN** `cargo clippy --workspace --all-targets` and targeted deterministic tests SHALL pass before phase signoff
+
+#### Scenario: Environment-dependent workspace tests
+- **WHEN** `cargo test --workspace` includes tests requiring preconfigured hosts, local services, or container runtime
+- **THEN** results SHALL be classified as environment-gated baseline vs new regression
+- **AND** only new regressions introduced by this feature SHALL fail phase signoff

--- a/openspec/changes/archive/2026-06-04-normalize-malformed-scrubbed-ips/tasks.md
+++ b/openspec/changes/archive/2026-06-04-normalize-malformed-scrubbed-ips/tasks.md
@@ -1,0 +1,62 @@
+## 1. Receiver Scrub Mode Plumbing
+
+- [x] 1.1 Add scrub mode decision model (implicit auto + explicit boolean override) and wire it through receiver construction path.
+- [x] 1.2 Add CLI flag `--scrubbed BOOL` in `process` flow and propagate to receiver.
+- [x] 1.3 Add upload-path checkbox mapping to scrub mode in server file upload flow.
+- [x] 1.4 Implement precedence rules within each channel (CLI or UI) with no cross-channel override dependency.
+- [x] 1.5 Add validation tests for channel-specific mode resolution (CLI-only and UI-only flows).
+- [x] 1.6 Ensure CLI behavior is fully operable in headless workflows via `--scrubbed true|false`.
+- [x] 1.7 Run `cargo clippy --workspace --all-targets` and fix warnings for changed files.
+- [x] 1.8 Run targeted deterministic tests for touched modules (receiver/server/main CLI parsing) and record results.
+- [x] 1.9 Run `openspec validate normalize-malformed-scrubbed-ips`.
+
+## 2. Receiver-Stage Normalization Engine
+
+- [x] 2.1 Implement scrubbed archive auto-detection using filename/path contains `scrubbed` when mode is `auto`.
+- [x] 2.2 Implement deterministic malformed IPv4 normalization (`octet % 255`) helpers.
+- [x] 2.3 Implement allowlist-only field traversal for address normalization in supported JSON files.
+- [x] 2.4 Implement `ip`/`host` pure-IP behavior and `ip:port` normalization with port preservation in transport fields.
+- [x] 2.5 Integrate normalization into archive read path (`archive/file` and `archive/bytes`) before processor consumption.
+- [x] 2.6 Run `cargo clippy --workspace --all-targets` and fix warnings for changed files.
+- [x] 2.7 Run targeted deterministic normalization tests and receiver integration tests.
+- [x] 2.8 Run `openspec validate normalize-malformed-scrubbed-ips`.
+
+## 3. Node Name Humanization
+
+- [x] 3.1 Update node rename logic in `nodes/lookup` to detect 19-char lowercase hex scrubbed names.
+- [x] 3.2 Implement default rename using existing shape but replace numeric segment with source last 4 chars.
+- [x] 3.3 Preserve existing `instance-...` rename behavior unchanged.
+- [x] 3.4 Add tests for fictional 19-char hex scrubbed names producing last-4 suffix behavior.
+- [x] 3.5 Run `cargo clippy --workspace --all-targets` and fix warnings for changed files.
+- [x] 3.6 Run targeted deterministic rename tests and lookup integration tests.
+- [x] 3.7 Run `openspec validate normalize-malformed-scrubbed-ips`.
+
+## 4. Non-Mangling and Integration Validation
+
+- [x] 4.1 Add golden fixtures for non-scrubbed archives and assert unchanged pass-through.
+- [x] 4.2 Add scrubbed fixtures with malformed IPs and assert normalized values on allowed fields only.
+- [x] 4.3 Add integration assertion that node summary-relevant documents include expected node fields post-normalization.
+- [x] 4.4 Add memory regression check for scrubbed processing and verify <=20% RSS increase vs non-scrubbed baseline.
+- [x] 4.5 Add debug logging assertions that each unscrubbed file read emits a debug log line and mode context (`tests/scrub_debug_log_tests.rs`).
+- [x] 4.6 Document dev ingest validation workflow: manual `esdiag process --debug` into Elasticsearch and `~/.esdiag/last_run` checks for zero bulk conflicts.
+- [x] 4.7 Add dataset sanity assertions in dev ingest validation (non-empty `metrics-node-esdiag` and related node datasets).
+- [x] 4.8 Document memory measurement commands in validation docs: `/usr/bin/time -l` on macOS and `/usr/bin/time -v` on Linux.
+- [x] 4.9 Run `cargo clippy --workspace --all-targets`.
+- [x] 4.10 Run deterministic suite + targeted integration tests for this feature.
+- [x] 4.11 Run `cargo test --workspace` and classify failures as:
+  - expected environment-gated (known-host/local service/container dependent), or
+  - regression introduced by this change.
+- [x] 4.12 Fail the stage on any new regression; do not fail solely on pre-existing environment-gated failures.
+- [x] 4.13 Run `openspec validate normalize-malformed-scrubbed-ips`.
+
+## 5. Rollout and Documentation
+
+- [x] 5.1 Document `--scrubbed BOOL` and UI checkbox behavior, including precedence.
+- [x] 5.2 Document either/or channel model (CLI flow vs UI flow) and channel-specific control rules.
+- [x] 5.3 Document supported normalized fields and non-goals (no global free-text rewrite).
+- [x] 5.4 Document dev ingest verification workflow in debug mode and pass/fail criteria for clean ingest.
+- [x] 5.5 Document platform-specific memory measurement commands for regression checks.
+- [x] 5.6 Add troubleshooting notes for scrub detection and per-file debug logs.
+- [x] 5.7 Document the test matrix explicitly (deterministic gates vs environment-gated integration checks).
+- [x] 5.8 Run `cargo clippy --workspace --all-targets`.
+- [x] 5.9 Run deterministic test gates and final `openspec validate normalize-malformed-scrubbed-ips`.

--- a/openspec/changes/archive/2026-06-04-normalize-malformed-scrubbed-ips/validation-code-gates.md
+++ b/openspec/changes/archive/2026-06-04-normalize-malformed-scrubbed-ips/validation-code-gates.md
@@ -1,0 +1,174 @@
+# Code validation gates — normalize-malformed-scrubbed-ips
+
+**Date:** 2026-06-02 (refreshed for final PR state)  
+**Host:** WSL2 (Linux)  
+**Branch:** `asa/normalize-malformed-ips-openspec`  
+**Repo:** `/home/asa/repos/test-esdiag/esdiag`  
+**Env file:** `/home/asa/repos/ya-esdiag/esdiag/.env` (`ESDIAG_OUTPUT_URL=http://localhost:9201`)
+
+---
+
+## 1. One-time setup
+
+| Step | Result |
+|------|--------|
+| `cargo build --release` | **Pass** (1m 54s) |
+| `jq` | Present (`/usr/bin/jq`) — apt install skipped |
+| `time` | Present (shell builtin / `/usr/bin/time`) — apt install skipped |
+| ES reachability | **Pass** — `curl http://localhost:9201` → **401** (host up; auth required) |
+| Pre-commit credential scan | **Pass** — `git diff --cached \| grep …` → clean |
+
+---
+
+## 2. Deterministic gates (CI-safe)
+
+### Commands
+
+| Command | Result |
+|---------|--------|
+| `cargo test --lib scrub` | **15 passed**, 0 failed |
+| `cargo test --test scrubbed_normalization_tests` | **6 passed**, 0 failed |
+| `cargo test --test scrub_debug_log_tests` | **1 passed**, 0 failed |
+| `cargo clippy --workspace --all-targets` | **Pass** (exit 0); 1 pre-existing `type_complexity` warning in `src/server/mod.rs:298`; 1 non-blocking `collapsible_if` in `tests/scrub_normalization_assertions.rs` |
+| `npx openspec validate normalize-malformed-scrubbed-ips` | **Pass** — change is valid |
+
+**Total deterministic scrub gates:** **22 tests** (15 unit + 6 integration + 1 debug-log).
+
+### Unit test coverage (`cargo test --lib scrub`)
+
+| Area | Tests |
+|------|-------|
+| Scrub engine (`receiver/archive/scrub.rs`) | Valid IPv4 pass-through; allowlisted fields only; `publish_host` / `bind_host`; `tasks.json`; other diagnostic JSON files; excluded manifest/version |
+| Archive receiver (`receiver/archive/file.rs`) | Scrubbed zip normalizes `nodes.json`; non-scrubbed golden archive unchanged |
+| Scrub mode resolution (`receiver/mod.rs`) | Auto (filename contains `scrubbed`); explicit true; explicit false |
+| Upload checkbox parsing (`server/file_upload.rs`) | Truthy (`true`, `1`, `on`); falsy values |
+| Node rename (`nodes/lookup.rs`) | 19-char lowercase hex → tier + last-4 suffix |
+
+### Integration test coverage (`cargo test --test scrubbed_normalization_tests`)
+
+Synthetic malformed IPs are injected at runtime from the golden archive (`tests/archives/elasticsearch-api-diagnostics-9.1.3.zip`); **no committed customer scrubbed bundle**.
+
+| Test | What it proves |
+|------|----------------|
+| `archive_export_normalizes_ips_with_stable_node_mapping` | Zip input + explicit scrub → directory export; **two-node** fixture; per-`node.id` IP mapping across **10 NDJSON streams** |
+| `directory_export_normalizes_ips_with_stable_node_mapping` | **Extracted folder** input + explicit scrub → same mapping assertions |
+| `directory_auto_detect_enables_scrub_when_path_contains_scrubbed` | Folder path containing `scrubbed` enables normalization without `--scrubbed true` |
+| `directory_with_scrub_disabled_preserves_malformed_ips` | `--scrubbed false` regression — malformed IPs pass through |
+| `processes_non_scrubbed_golden_archive_without_error` | Golden archive with scrub off — no mangling |
+| `distinct_malformed_ips_normalize_to_distinct_valid_ips` (assertions module) | Modulo transform produces distinct valid IPv4 per node index |
+
+Shared assertions (`tests/scrub_normalization_assertions.rs`) verify:
+
+- `node.host`, `node.ip`, `node.transport_address` on every applicable export line
+- `node.settings.network.publish_host` on `settings-node-esdiag.ndjson` when value is a dotted quad
+- Each `node.id` maps to **exactly one** normalized IP across streams (≥2 nodes, distinct expected IPs)
+
+### Implementation scope validated by tests
+
+| Surface | Covered |
+|---------|---------|
+| Input types | Archive (zip) **and** directory (extracted folder) |
+| Scrub activation | CLI explicit flag, path auto-detect, upload filename hint (unit-tested); directory auto-detect (integration) |
+| JSON files | All `*.json` except `diagnostic_manifest.json` and `version.json` |
+| Address fields | `ip`, `host`, `publish_host`, `bind_host`, `transport_address`, `publish_address`, `bound_address`, `local_address`, `remote_address`, `x_forwarded_for`, malformed `http.clients[].id` |
+| Non-goals | No rewrite of hyphenated K8s hostnames (`ip-10-36-…`); no global free-text replace |
+
+Operator reference: `docs/scrubbed-diagnostics.md`.
+
+---
+
+## 3. Live ingest (env-gated, manual)
+
+Deterministic coverage (no live ES): `cargo test --test scrubbed_normalization_tests` — builds synthetic malformed-IP zip from golden archive at runtime, exports to a temp directory, and asserts cross-stream node IP mapping.
+
+Optional live Elasticsearch check (recorded 2026-06-02):
+
+```bash
+cd /home/asa/repos/test-esdiag/esdiag
+cargo build --release
+set -a && source /home/asa/repos/ya-esdiag/esdiag/.env && set +a
+
+# Use ./target/release/esdiag from this branch (not a global install without --scrubbed).
+# Enable scrub via --scrubbed true OR a filename/path containing "scrubbed" (auto mode).
+./target/release/esdiag process /path/to/local-archive.zip --scrubbed true --debug
+
+jq '.diagnostic | {doc_errors: .docs.errors, created: .docs.created, node_metrics: .processor.stats["metrics-node-esdiag"]}' \
+  ~/.esdiag/last_run/report.json
+```
+
+Recorded run used a **local synthetic zip** (not committed; same golden→malformed transform as the integration test). Scrub was enabled via **auto-detect** (filename contained `scrubbed`); `--scrubbed true` would work without that.
+
+**Result: PASS**
+
+| Check | Outcome |
+|-------|---------|
+| `esdiag process` exit code | **0** |
+| Bulk error artifact (`~/.esdiag/last_run/bulk_errors.ndjson`) | **empty / absent** |
+| Scrub mode | **Enabled** (auto-detect from filename on recorded run) |
+| `nodes.json` normalization | **5** address fields |
+| `nodes_stats.json` normalization | **133** address fields (stream) |
+| `diagnostic.docs.errors` | **0** |
+| `metrics-node-esdiag` docs | **371** |
+| Total documents created | **375** |
+| Process runtime | **0.141 s** |
+| Diagnostic ID | `esdiag-cluster@2025-09-18~2784` |
+| Cluster / version | `esdiag-cluster` / 9.1.3 |
+| esdiag version | `0.15.0-SNAPSHOT` |
+
+Debug log excerpts:
+
+```
+Unscrubbed 5 address fields in api-diagnostics-20250918-001807/nodes.json
+Unscrubbed 133 address fields in stream file api-diagnostics-20250918-001807/nodes_stats.json
+Processor: metrics-node-esdiag  parsed: true  371 docs  0 errors
+Created 375 documents for Elasticsearch diagnostic: esdiag-cluster@2025-09-18~2784
+```
+
+Full log: `/tmp/esdiag-live-ingest-validation-20260602.log`
+
+Notes:
+
+- Missing APIs in the minimal synthetic fixture produce expected `File not found in archive` warnings; they do not fail ingest.
+- No committed scrubbed zip or shell helpers in this change.
+- **Recommended before merge (not yet recorded here):** one manual run against a **local customer scrubbed API zip** with `--scrubbed true`, then spot-check exports for zero malformed octets in `node.ip`, `node.host`, `transport_address`, and `settings.network.publish_host`.
+
+---
+
+## 4. Memory spot-check (WSL / Linux)
+
+Directory output (`-o /tmp/...`), golden archive `tests/archives/elasticsearch-api-diagnostics-9.1.3.zip`:
+
+```bash
+/usr/bin/time -v ./target/release/esdiag process \
+  tests/archives/elasticsearch-api-diagnostics-9.1.3.zip \
+  --scrubbed false -o /tmp/esdiag-out-base 2>&1 | tee /tmp/esdiag-mem-base.txt
+
+/usr/bin/time -v ./target/release/esdiag process \
+  tests/archives/elasticsearch-api-diagnostics-9.1.3.zip \
+  --scrubbed true -o /tmp/esdiag-out-scrub 2>&1 | tee /tmp/esdiag-mem-scrub.txt
+```
+
+| Run | Maximum resident set size |
+|-----|---------------------------|
+| Baseline (`--scrubbed false`) | **125,556 kB** (~123 MiB) |
+| Scrub enabled (`--scrubbed true`) | **124,188 kB** (~121 MiB) |
+
+**Ratio:** scrub / baseline = **98.9%** (target ≤ **120%**) → **PASS**
+
+Logs: `/tmp/esdiag-mem-base.txt`, `/tmp/esdiag-mem-scrub.txt`
+
+Note: Golden archive has no malformed scrubbed IPs; scrub path adds negligible RSS on that fixture. Heavier normalization work is exercised by `scrubbed_normalization_tests` (runtime synthetic zip from golden, two-node mapping).
+
+---
+
+## Summary
+
+| Gate category | Status |
+|---------------|--------|
+| Setup + ES reachability | **Pass** |
+| Deterministic tests (22) + clippy + openspec | **Pass** |
+| Live synthetic ingest | **Pass** |
+| Memory RSS ≤ 120% baseline | **Pass** (98.9%) |
+| Live customer scrubbed bundle smoke | **Recommended, not recorded** |
+
+**Not in scope for this run:** `cargo test --workspace` / `collection_tests` (requires local `elasticsearch-local` collect setup — classify pre-existing env-gated failures separately).

--- a/openspec/specs/malformed-ip-normalization/spec.md
+++ b/openspec/specs/malformed-ip-normalization/spec.md
@@ -1,0 +1,172 @@
+# malformed-ip-normalization Specification
+
+## Purpose
+Define how esdiag detects scrubbed diagnostic inputs and normalizes deterministic malformed IPv4-like values before processors consume diagnostic JSON, preserving ingest compatibility while keeping normalization bounded to known address fields.
+
+## Requirements
+### Requirement: Receiver applies scrub normalization before processors
+The system SHALL normalize scrubbed archive payloads in the receiver read path before any processor consumes file content.
+
+#### Scenario: Scrubbed archive in process flow
+- **WHEN** an archive input is classified as scrubbed
+- **THEN** receiver returns normalized content to processors
+- **AND** processors execute without requiring scrub-specific mutation logic
+
+#### Scenario: Non-scrubbed archive in process flow
+- **WHEN** an archive input is classified as non-scrubbed
+- **THEN** receiver returns original content unchanged
+
+### Requirement: Normalization is bounded to supported files
+The system SHALL apply receiver-stage normalization only to supported JSON/text diagnostic files that contain node address and node identity surfaces.
+
+#### Scenario: Supported file
+- **WHEN** receiver reads a supported file (for example `nodes.json` or `nodes_stats.json`)
+- **THEN** receiver applies scrub normalization rules before returning content
+
+#### Scenario: Unsupported file
+- **WHEN** receiver reads an unsupported file type
+- **THEN** receiver SHALL pass content through unchanged
+
+### Requirement: Scrub mode supports auto and manual controls
+The system SHALL support implicit auto mode plus explicit control in both CLI and upload channels.
+
+#### Scenario: Auto mode detection
+- **WHEN** `--scrubbed` is not provided and archive filename/path contains `scrubbed` as a standalone token
+- **THEN** scrub normalization SHALL be enabled
+
+#### Scenario: Auto mode no match
+- **WHEN** `--scrubbed` is not provided and archive filename/path does not contain `scrubbed` as a standalone token
+- **THEN** scrub normalization SHALL remain disabled
+
+### Requirement: Manual override precedence
+The system SHALL apply manual selection precedence within the active execution channel.
+
+#### Scenario: Manual on overrides auto no-match
+- **WHEN** `--scrubbed true` is provided
+- **THEN** normalization SHALL run regardless of filename/path
+
+#### Scenario: Manual off overrides auto match
+- **WHEN** `--scrubbed false` is provided and filename/path contains `scrubbed` as a standalone token
+- **THEN** normalization SHALL NOT run
+
+### Requirement: CLI and UI are independent execution channels
+The system SHALL treat CLI process flow and UI upload flow as either/or channels without cross-channel override behavior.
+
+#### Scenario: CLI channel
+- **WHEN** operator uses CLI process flow
+- **THEN** scrub behavior SHALL be controlled by `--scrubbed BOOL` or implicit auto mode
+
+#### Scenario: UI channel
+- **WHEN** operator uses upload UI flow
+- **THEN** scrub behavior SHALL be controlled by checkbox or auto mode within UI flow
+
+### Requirement: Deterministic malformed IPv4 normalization
+The system SHALL normalize malformed scrubbed IPv4 octets using deterministic per-octet modulo transformation (`octet % 255`).
+
+#### Scenario: Invalid scrubbed IPv4 value
+- **WHEN** a scrubbed address value contains octets outside valid IPv4 range
+- **THEN** each octet SHALL be rewritten via modulo 255
+- **AND** the rewritten value SHALL be deterministic for the same input
+
+### Requirement: Field-allowlist safety boundary
+The system SHALL apply malformed IP normalization only to explicitly supported address fields.
+
+#### Scenario: Allowed address field
+- **WHEN** a malformed IPv4 value appears in an allowed address field
+- **THEN** normalization SHALL be applied
+
+#### Scenario: Non-address field
+- **WHEN** a malformed IPv4-like string appears in a non-address field
+- **THEN** normalization SHALL NOT be applied
+
+### Requirement: Port and pure-IP semantics
+The system SHALL preserve port components for address fields that allow ports and SHALL store pure IP values for fields with pure IP semantics.
+
+#### Scenario: Address with port in transport field
+- **WHEN** an allowed transport field contains `ip:port`
+- **THEN** IP component SHALL be normalized
+- **AND** original port SHALL be preserved
+
+#### Scenario: Pure IP field
+- **WHEN** a pure IP field (`ip` or `host`) contains `ip:port` shaped scrubbed data
+- **THEN** output SHALL contain normalized IP without port
+
+### Requirement: Scrubbed node name detection
+The system SHALL detect scrubbed node-name inputs matching 19-character lowercase hex format.
+
+#### Scenario: 19-char lowercase hex name
+- **WHEN** node name is a 19-character lowercase hexadecimal string
+- **THEN** system SHALL classify it as scrubbed-name format
+
+#### Scenario: Non-matching name
+- **WHEN** node name does not match 19-character lowercase hexadecimal format
+- **THEN** system SHALL treat it as non-scrubbed for this rename rule
+
+### Requirement: Last-4 readable rename default
+The system SHALL use existing tier rename logic shape but replace numeric segment with last 4 characters of original scrubbed node name.
+
+#### Scenario: Scrubbed name with tier
+- **WHEN** a scrubbed 19-character lowercase hexadecimal node name is processed for tier `hot`
+- **THEN** output name SHALL use tier prefix `hot` and suffix equal to the last four characters of the source name (for example, `…99e7` → `hot-99e7`)
+
+#### Scenario: Non-scrubbed existing behavior
+- **WHEN** node name uses existing `instance-...` pattern
+- **THEN** current rename behavior SHALL remain unchanged
+
+### Requirement: Normalization emits debug logs per file
+The system SHALL emit debug logs for scrub normalization decisions and transformations.
+
+#### Scenario: Normalization enabled
+- **WHEN** scrub normalization runs for an archive
+- **THEN** logs SHALL include mode source and transformed field counts
+
+#### Scenario: File-level normalization logging
+- **WHEN** receiver reads a file that is unscrubbed/normalized
+- **THEN** system SHALL emit a debug log line for that file read and transformation action
+
+#### Scenario: Manual override
+- **WHEN** manual scrub mode overrides auto detection
+- **THEN** logs SHALL record effective mode and override source
+
+### Requirement: Non-mangling verification logs
+The system SHALL log verification outcomes for non-scrubbed pass-through behavior in test and validation flows.
+
+#### Scenario: Non-scrubbed fixture validation
+- **WHEN** validation runs against non-scrubbed fixtures
+- **THEN** logs SHALL indicate unchanged pass-through result
+
+### Requirement: Development workflow SHALL validate live ingest cleanliness
+The development workflow SHALL include a test path that runs `esdiag process --debug` against an Elasticsearch target and verifies that ingest completes without bulk/index mapping conflicts.
+
+#### Scenario: Clean ingest run
+- **WHEN** a scrubbed diagnostic fixture is processed to a live Elasticsearch dev target
+- **THEN** bulk ingest SHALL complete with no conflict/rejection entries
+
+#### Scenario: Conflict detection gate
+- **WHEN** any bulk rejection, mapping conflict, or parse/index conflict occurs during ingest
+- **THEN** the development validation step SHALL fail
+
+### Requirement: Development workflow SHALL include artifact checks
+The development workflow SHALL inspect esdiag run artifacts to confirm clean ingest outcomes.
+
+#### Scenario: Last-run artifact verification
+- **WHEN** development ingest validation runs in debug mode
+- **THEN** it SHALL check `~/.esdiag/last_run` outputs for bulk errors and failed responses
+- **AND** it SHALL fail if conflict indicators are present
+
+#### Scenario: Node dataset sanity verification
+- **WHEN** development ingest validation runs successfully
+- **THEN** it SHALL verify node-related datasets are present (for example `metrics-node-esdiag`) and non-empty
+
+### Requirement: Validation gates SHALL follow esdiag test tiers
+The feature validation plan SHALL use deterministic gates for each implementation phase and treat environment-dependent integration tests as separately classified checks.
+
+#### Scenario: Deterministic phase gate
+- **WHEN** a phase changes receiver/server/processor logic
+- **THEN** `cargo clippy --workspace --all-targets` and targeted deterministic tests SHALL pass before phase signoff
+
+#### Scenario: Environment-dependent workspace tests
+- **WHEN** `cargo test --workspace` includes tests requiring preconfigured hosts, local services, or container runtime
+- **THEN** results SHALL be classified as environment-gated baseline vs new regression
+- **AND** only new regressions introduced by this feature SHALL fail phase signoff
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,6 +224,9 @@ enum Commands {
         /// The file must match the active product or the command fails before processing.
         #[arg(long)]
         sources: Option<String>,
+        /// Force scrubbed archive mode on/off; when omitted auto-detects by filename containing 'scrubbed'
+        #[arg(long)]
+        scrubbed: Option<bool>,
         /// Save the effective invocation as a named job before continuing execution
         #[cfg(feature = "keystore")]
         #[arg(long = "save-job", value_name = "NAME")]
@@ -1446,6 +1449,7 @@ async fn run(cli: Cli, format: OutputFormat) -> Result<CommandResult> {
                 opportunity,
                 user,
                 sources,
+                scrubbed,
                 #[cfg(feature = "keystore")]
                 save_job,
             } => {
@@ -1474,27 +1478,27 @@ async fn run(cli: Cli, format: OutputFormat) -> Result<CommandResult> {
 
                 tracing::info!("input: {}", input_uri);
 
-                let receiver = Receiver::try_from(input_uri.clone())?;
+                let receiver = Receiver::try_from_with_scrub(input_uri.clone(), scrubbed, None)?;
                 if let Some(sources) = sources {
                     let application = detect_sources_application_for_process(&input_uri, &receiver).await?;
                     esdiag::processor::init_sources(sources_application_key(application)?, sources)?;
                 }
                 let identifiers = Identifiers::new(account, case, receiver.filename(), opportunity, user);
                 let mut context = esdiag::job::context::ExecutionContext::default();
-                let job_input = match &input_uri {
-                    Uri::File(_) | Uri::Directory(_) => esdiag::job::model::Input::Load { uri: input_uri.clone() },
-                    _ => {
-                        let binding = esdiag::job::model::BindingKey::try_new("cli-process-input")?;
-                        let application = match &input_uri {
-                            Uri::KnownHost(host) | Uri::ElasticCloudAdmin(host) | Uri::ElasticGovCloudAdmin(host) => {
-                                host.app()
-                            }
-                            _ => None,
-                        };
-                        context.inputs.bind_receiver(binding.clone(), receiver, application);
-                        esdiag::job::model::Input::LoadBinding { binding }
-                    }
+                let binding = esdiag::job::model::BindingKey::try_new("cli-process-input")?;
+                let application = match &input_uri {
+                    Uri::KnownHost(host) | Uri::ElasticCloudAdmin(host) | Uri::ElasticGovCloudAdmin(host) => host.app(),
+                    _ => None,
                 };
+                match &input_uri {
+                    Uri::File(path) => {
+                        context
+                            .inputs
+                            .bind_bundle(binding.clone(), receiver, path.clone(), application);
+                    }
+                    _ => context.inputs.bind_receiver(binding.clone(), receiver, application),
+                };
+                let job_input = esdiag::job::model::Input::LoadBinding { binding };
                 let export_target = match (&output, &output_uri) {
                     (Some(name), Uri::KnownHost(_)) => {
                         esdiag::job::model::ExportTarget::KnownHost { name: name.clone() }
@@ -4062,6 +4066,23 @@ mod tests {
         match cli.command.expect("command") {
             Commands::Process { save_job, .. } => {
                 assert_eq!(save_job.as_deref(), Some("process-prod"));
+            }
+            _ => panic!("expected process command"),
+        }
+    }
+
+    #[test]
+    fn process_cli_parses_scrubbed_bool_override() {
+        let cli = Cli::parse_from([
+            "esdiag",
+            "process",
+            "local-diagnostics-scrubbed.zip",
+            "--scrubbed",
+            "true",
+        ]);
+        match cli.command.expect("command") {
+            Commands::Process { scrubbed, .. } => {
+                assert_eq!(scrubbed, Some(true));
             }
             _ => panic!("expected process command"),
         }

--- a/src/processor/elasticsearch/mod.rs
+++ b/src/processor/elasticsearch/mod.rs
@@ -51,6 +51,7 @@ pub use metadata::ElasticsearchMetadata;
 use tokio::sync::mpsc;
 pub use {
     licenses::{License, Licenses},
+    nodes::Nodes,
     version::{Cluster, ClusterMetadata, Version},
 };
 
@@ -82,7 +83,7 @@ use {
     indices_settings::{IndexSettings, IndicesSettings},
     indices_stats::IndicesStats,
     mapping_stats::{MappingStats, MappingSummary},
-    nodes::{NodeDocument, Nodes},
+    nodes::NodeDocument,
     nodes_stats::NodesStats,
     pending_tasks::PendingTasks,
     searchable_snapshots_cache_stats::{SearchableSnapshotsCacheStats, SharedCacheStats},

--- a/src/processor/elasticsearch/nodes/lookup.rs
+++ b/src/processor/elasticsearch/nodes/lookup.rs
@@ -147,9 +147,19 @@ fn get_tier_node_name(node_name: String, tier: &str) -> String {
         // Renames `instance-0000000001` into `tier-00001`
         let number = number.trim_start_matches("000000");
         format!("{}-{}", tier, number)
+    } else if is_scrubbed_hex_node_name(&node_name) {
+        let suffix = &node_name[node_name.len() - 4..];
+        format!("{tier}-{suffix}")
     } else {
         node_name
     }
+}
+
+fn is_scrubbed_hex_node_name(node_name: &str) -> bool {
+    node_name.len() == 19
+        && node_name
+            .chars()
+            .all(|ch| ch.is_ascii_hexdigit() && !ch.is_ascii_uppercase())
 }
 
 /// Collects single-character abbreviations for roles into a string.
@@ -181,5 +191,20 @@ fn get_roles_abbreviation(role_list: &HashSet<String>) -> String {
             roles.sort_unstable();
             roles.iter().collect()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_tier_node_name;
+
+    #[test]
+    fn preserves_existing_instance_rename_behavior() {
+        assert_eq!(get_tier_node_name("instance-0000000001".to_string(), "hot"), "hot-0001");
+    }
+
+    #[test]
+    fn humanizes_scrubbed_hex_name_with_last_four_chars() {
+        assert_eq!(get_tier_node_name("aaaabbbbccccddddee0".to_string(), "hot"), "hot-dee0");
     }
 }

--- a/src/processor/elasticsearch/nodes_stats/data.rs
+++ b/src/processor/elasticsearch/nodes_stats/data.rs
@@ -191,6 +191,10 @@ pub struct CpuStats {
 }
 
 impl NodeStats {
+    pub fn node_name(&self) -> Option<&str> {
+        if self.name.is_empty() { None } else { Some(&self.name) }
+    }
+
     pub fn calculate_stats(&mut self, processors: usize) {
         self.fs.total.used_in_bytes = self.fs.total.total_in_bytes - self.fs.total.free_in_bytes;
         self.fs.total.used_percent = (self.fs.total.used_in_bytes * 100) / self.fs.total.total_in_bytes;

--- a/src/processor/elasticsearch/nodes_stats/processor.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor.rs
@@ -41,7 +41,19 @@ async fn process_node(node_id: String, mut node_stats: super::data::NodeStats, c
     let lookup_node = &ctx.lookups.node;
     let lookup_shared_cache = &ctx.lookups.shared_cache;
 
-    let node_metadata = lookup_node.by_id(&node_id);
+    let node_metadata = lookup_node.by_id(&node_id).or_else(|| {
+        node_stats.node_name().and_then(|node_name| {
+            let by_name = lookup_node.by_name(node_name);
+            if by_name.is_some() {
+                tracing::debug!(
+                    "Resolved node lookup by name fallback: node_id={} node_name={}",
+                    node_id,
+                    node_name
+                );
+            }
+            by_name
+        })
+    });
     let allocated_processors = node_metadata.map(|node| node.os.allocated_processors).unwrap_or(1);
     node_stats.calculate_stats(allocated_processors);
     if let Some(node) = node_metadata {

--- a/src/receiver/archive.rs
+++ b/src/receiver/archive.rs
@@ -17,14 +17,17 @@ use zip::ZipArchive;
 
 mod bytes;
 mod file;
+mod scrub;
 
 pub use bytes::*;
 pub use file::*;
+pub use scrub::{normalize_supported_content, normalize_supported_reader_to_temp, supports_json_normalization};
 
 pub async fn get_stream_from_archive<R, T>(
     archive: Arc<RwLock<ZipArchive<R>>>,
     subdir: Option<PathBuf>,
     ctx: SourceContext,
+    scrubbed: bool,
 ) -> Result<BoxStream<'static, Result<T::Item>>>
 where
     R: Read + Seek + Send + Sync + 'static,
@@ -54,9 +57,29 @@ where
         tracing::debug!("Streaming from archive: {}", filename);
         let stream_result = match archive_guard.by_name(&filename) {
             Ok(file) => {
-                let reader = BufReader::new(file);
-                let mut deserializer = serde_json::Deserializer::from_reader(reader);
-                T::deserialize_stream(&mut deserializer, tx.clone()).map_err(|e| eyre::eyre!(e.to_string()))
+                if scrubbed && supports_json_normalization(&filename) {
+                    let reader = BufReader::new(file);
+                    match normalize_supported_reader_to_temp(&filename, reader) {
+                        Ok(mut transformed) => {
+                            tracing::debug!(
+                                "Unscrubbed {} address fields in stream file {}",
+                                transformed.transformed_fields,
+                                filename
+                            );
+                            let reader = BufReader::new(transformed.file.as_file_mut());
+                            let mut deserializer = serde_json::Deserializer::from_reader(reader);
+                            T::deserialize_stream(&mut deserializer, tx.clone()).map_err(|e| eyre::eyre!(e.to_string()))
+                        }
+                        Err(e) => Err(e),
+                    }
+                } else {
+                    if scrubbed {
+                        tracing::debug!("Scrubbed mode stream read {} (no normalization rules)", filename);
+                    }
+                    let reader = BufReader::new(file);
+                    let mut deserializer = serde_json::Deserializer::from_reader(reader);
+                    T::deserialize_stream(&mut deserializer, tx.clone()).map_err(|e| eyre::eyre!(e.to_string()))
+                }
             }
             Err(e) => Err(eyre::eyre!(e)),
         };

--- a/src/receiver/archive/bytes.rs
+++ b/src/receiver/archive/bytes.rs
@@ -2,10 +2,12 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::resolve_archive_path;
+use super::{
+    normalize_supported_content, normalize_supported_reader_to_temp, resolve_archive_path, supports_json_normalization,
+};
 use crate::{
     processor::{DataSource, SourceContext, StreamingDataSource},
-    receiver::{MissingSource, Receive, ReceiveMultiple},
+    receiver::{MissingSource, Receive, ReceiveMultiple, ReceiveRaw},
 };
 use bytes::Bytes;
 use eyre::{Result, WrapErr, eyre};
@@ -28,6 +30,7 @@ pub struct ArchiveBytesReceiver {
     archive: ArchivePointer,
     subdir: Option<PathBuf>,
     source_product: Arc<OnceLock<&'static str>>,
+    scrubbed: bool,
 }
 
 /// A receiver for the Elastic Uploader service (https://upload.elastic.co).
@@ -58,24 +61,48 @@ impl Receive for ArchiveBytesReceiver {
         for source_path in source_paths {
             match resolve_archive_path(self.subdir.as_ref(), &mut *archive, &source_path) {
                 Ok(filename) => {
-                    tracing::debug!("Reading {}", filename);
+                    if self.scrubbed {
+                        tracing::debug!("Reading {} (scrubbed mode)", filename);
+                    } else {
+                        tracing::debug!("Reading {}", filename);
+                    }
                     let file = match archive.by_name(&filename) {
                         Ok(file) => file,
                         Err(_) => return Err(eyre!("Failed to read file {filename} from archive")),
                     };
-                    let mut contents = String::new();
-                    BufReader::new(file).read_to_string(&mut contents)?;
-                    if contents.trim().is_empty() {
-                        last_resolve_error = Some(
-                            MissingSource::Empty {
-                                path: filename.to_string(),
-                            }
-                            .into(),
+                    let parsed = if self.scrubbed && supports_json_normalization(&filename) {
+                        let reader = BufReader::new(file);
+                        let mut transformed = normalize_supported_reader_to_temp(&filename, reader)?;
+                        tracing::debug!(
+                            "Unscrubbed {} address fields in {}",
+                            transformed.transformed_fields,
+                            filename
                         );
-                        continue;
-                    }
-                    let data: T = serde_json::from_str(&contents)
-                        .wrap_err_with(|| format!("Failed to parse {filename} for {}", T::name()))?;
+                        let reader = BufReader::new(transformed.file.as_file_mut());
+                        serde_json::from_reader(reader)
+                    } else {
+                        if self.scrubbed {
+                            tracing::debug!("Scrubbed mode read {} (no normalization rules)", filename);
+                        }
+                        let reader = BufReader::new(file);
+                        serde_json::from_reader(reader)
+                    };
+                    let data: T = match parsed {
+                        Ok(data) => data,
+                        Err(error) if error.is_eof() => {
+                            last_resolve_error = Some(
+                                MissingSource::Empty {
+                                    path: filename.to_string(),
+                                }
+                                .into(),
+                            );
+                            continue;
+                        }
+                        Err(error) => {
+                            return Err(error)
+                                .wrap_err_with(|| format!("Failed to parse {filename} for {}", T::name()));
+                        }
+                    };
                     return Ok(data);
                 }
                 Err(e) => {
@@ -97,8 +124,70 @@ impl Receive for ArchiveBytesReceiver {
         T::Item: DeserializeOwned + Send + 'static,
     {
         let ctx = self.source_context()?;
-        super::get_stream_from_archive::<BufReader<Cursor<Bytes>>, T>(self.archive.clone(), self.subdir.clone(), ctx)
-            .await
+        super::get_stream_from_archive::<BufReader<Cursor<Bytes>>, T>(
+            self.archive.clone(),
+            self.subdir.clone(),
+            ctx,
+            self.scrubbed,
+        )
+        .await
+    }
+}
+
+impl ReceiveRaw for ArchiveBytesReceiver {
+    async fn get_raw<T>(&self) -> Result<String>
+    where
+        T: DataSource,
+    {
+        let mut archive = self.archive.write().await;
+        let ctx = self.source_context()?;
+        let source_paths = T::candidate_source_file_paths(&ctx)?;
+        let mut last_resolve_error = None;
+
+        for source_path in source_paths {
+            match resolve_archive_path(self.subdir.as_ref(), &mut *archive, &source_path) {
+                Ok(filename) => {
+                    if self.scrubbed {
+                        tracing::debug!("Reading {} (scrubbed mode)", filename);
+                    } else {
+                        tracing::debug!("Reading {}", filename);
+                    }
+
+                    let file = match archive.by_name(&filename) {
+                        Ok(file) => file,
+                        Err(_) => return Err(eyre!("Failed to read file {filename} from archive")),
+                    };
+                    let mut reader = BufReader::new(file);
+                    let mut data = String::new();
+                    reader.read_to_string(&mut data)?;
+
+                    if self.scrubbed {
+                        let transformed = normalize_supported_content(&filename, data)?;
+                        if transformed.supported {
+                            tracing::debug!(
+                                "Unscrubbed {} address fields in {}",
+                                transformed.transformed_fields,
+                                filename
+                            );
+                        } else {
+                            tracing::debug!("Scrubbed mode read {} (no normalization rules)", filename);
+                        }
+                        return Ok(transformed.content);
+                    }
+
+                    return Ok(data);
+                }
+                Err(e) => {
+                    last_resolve_error = Some(e);
+                    continue;
+                }
+            }
+        }
+
+        match last_resolve_error {
+            Some(e) => Err(e),
+            None => Err(eyre!("No candidate source files available for {}", T::name())),
+        }
     }
 }
 
@@ -120,6 +209,7 @@ impl TryFrom<Bytes> for ArchiveBytesReceiver {
             archive: Arc::new(RwLock::new(archive)),
             subdir: None,
             source_product: Arc::new(OnceLock::new()),
+            scrubbed: false,
         })
     }
 }
@@ -136,6 +226,7 @@ impl ArchiveBytesReceiver {
             archive: self.archive.clone(),
             subdir: Some(PathBuf::from(work_dir)),
             source_product: Arc::new(OnceLock::new()),
+            scrubbed: self.scrubbed,
         }
     }
 
@@ -186,5 +277,9 @@ impl ArchiveBytesReceiver {
 
     pub fn source_context(&self) -> Result<SourceContext> {
         Ok(SourceContext::new(self.source_product()?, None))
+    }
+
+    pub fn set_scrubbed(&mut self, scrubbed: bool) {
+        self.scrubbed = scrubbed;
     }
 }

--- a/src/receiver/archive/bytes.rs
+++ b/src/receiver/archive/bytes.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::{
     processor::{DataSource, SourceContext, StreamingDataSource},
-    receiver::{MissingSource, Receive, ReceiveMultiple, ReceiveRaw},
+    receiver::{MissingSource, Receive, ReceiveMultiple, ReceiveRaw, has_json_content},
 };
 use bytes::Bytes;
 use eyre::{Result, WrapErr, eyre};
@@ -70,8 +70,17 @@ impl Receive for ArchiveBytesReceiver {
                         Ok(file) => file,
                         Err(_) => return Err(eyre!("Failed to read file {filename} from archive")),
                     };
-                    let parsed = if self.scrubbed && supports_json_normalization(&filename) {
-                        let reader = BufReader::new(file);
+                    let mut reader = BufReader::new(file);
+                    if !has_json_content(&mut reader)? {
+                        last_resolve_error = Some(
+                            MissingSource::Empty {
+                                path: filename.to_string(),
+                            }
+                            .into(),
+                        );
+                        continue;
+                    }
+                    let data: T = if self.scrubbed && supports_json_normalization(&filename) {
                         let mut transformed = normalize_supported_reader_to_temp(&filename, reader)?;
                         tracing::debug!(
                             "Unscrubbed {} address fields in {}",
@@ -84,25 +93,9 @@ impl Receive for ArchiveBytesReceiver {
                         if self.scrubbed {
                             tracing::debug!("Scrubbed mode read {} (no normalization rules)", filename);
                         }
-                        let reader = BufReader::new(file);
                         serde_json::from_reader(reader)
-                    };
-                    let data: T = match parsed {
-                        Ok(data) => data,
-                        Err(error) if error.is_eof() => {
-                            last_resolve_error = Some(
-                                MissingSource::Empty {
-                                    path: filename.to_string(),
-                                }
-                                .into(),
-                            );
-                            continue;
-                        }
-                        Err(error) => {
-                            return Err(error)
-                                .wrap_err_with(|| format!("Failed to parse {filename} for {}", T::name()));
-                        }
-                    };
+                    }
+                    .wrap_err_with(|| format!("Failed to parse {filename} for {}", T::name()))?;
                     return Ok(data);
                 }
                 Err(e) => {

--- a/src/receiver/archive/file.rs
+++ b/src/receiver/archive/file.rs
@@ -306,7 +306,7 @@ mod tests {
     use super::super::scrub::synthetic_vectors as v;
     use super::ArchiveFileReceiver;
     use crate::processor::DataSource;
-    use crate::receiver::{ReceiveRaw, ScrubMode, should_enable_scrubbed};
+    use crate::receiver::ReceiveRaw;
     use std::io::Write;
     use std::path::PathBuf;
     use zip::{ZipWriter, write::SimpleFileOptions};
@@ -375,9 +375,11 @@ mod tests {
     async fn non_scrubbed_archive_passes_nodes_json_unchanged() {
         let archive_path =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/archives/elasticsearch-api-diagnostics-9.3.3.zip");
-        if !archive_path.exists() {
-            return;
-        }
+        assert!(
+            archive_path.exists(),
+            "missing test fixture: {}",
+            archive_path.display()
+        );
 
         let file = std::fs::File::open(&archive_path).expect("open archive");
         let mut archive = zip::ZipArchive::new(file).expect("read archive");
@@ -389,11 +391,6 @@ mod tests {
         let mut receiver = ArchiveFileReceiver::try_from(archive_path).expect("receiver");
         receiver.set_scrubbed(false);
         receiver.set_source_product("elasticsearch").expect("source product");
-
-        assert!(!should_enable_scrubbed(
-            ScrubMode::Auto,
-            Some("elasticsearch-api-diagnostics-9.3.3.zip")
-        ));
 
         let actual = receiver.get_raw::<NodesSource>().await.expect("get raw nodes");
         assert_eq!(actual, expected);

--- a/src/receiver/archive/file.rs
+++ b/src/receiver/archive/file.rs
@@ -2,7 +2,9 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::resolve_archive_path;
+use super::{
+    normalize_supported_content, normalize_supported_reader_to_temp, resolve_archive_path, supports_json_normalization,
+};
 use crate::{
     processor::{DataSource, SourceContext, StreamingDataSource},
     receiver::{MissingSource, RawResponse, Receive, ReceiveMultiple, ReceiveRaw},
@@ -28,6 +30,7 @@ pub struct ArchiveFileReceiver {
     subdir: Option<PathBuf>,
     modified_date: SystemTime,
     source_product: Arc<OnceLock<&'static str>>,
+    scrubbed: bool,
 }
 
 impl TryFrom<PathBuf> for ArchiveFileReceiver {
@@ -47,6 +50,7 @@ impl TryFrom<PathBuf> for ArchiveFileReceiver {
                     filename,
                     subdir: None,
                     source_product: Arc::new(OnceLock::new()),
+                    scrubbed: false,
                 })
             }
             false => {
@@ -90,21 +94,45 @@ impl Receive for ArchiveFileReceiver {
         for source_path in source_paths {
             match resolve_archive_path(self.subdir.as_ref(), &mut *archive, &source_path) {
                 Ok(filename) => {
-                    tracing::debug!("Reading {}", filename);
-                    let file = archive.by_name(&filename)?;
-                    let mut contents = String::new();
-                    BufReader::new(file).read_to_string(&mut contents)?;
-                    if contents.trim().is_empty() {
-                        last_resolve_error = Some(
-                            MissingSource::Empty {
-                                path: filename.to_string(),
-                            }
-                            .into(),
-                        );
-                        continue;
+                    if self.scrubbed {
+                        tracing::debug!("Reading {} (scrubbed mode)", filename);
+                    } else {
+                        tracing::debug!("Reading {}", filename);
                     }
-                    let data: T = serde_json::from_str(&contents)
-                        .wrap_err_with(|| format!("Failed to parse {filename} for {}", T::name()))?;
+                    let file = archive.by_name(&filename)?;
+                    let parsed = if self.scrubbed && supports_json_normalization(&filename) {
+                        let reader = BufReader::new(file);
+                        let mut transformed = normalize_supported_reader_to_temp(&filename, reader)?;
+                        tracing::debug!(
+                            "Unscrubbed {} address fields in {}",
+                            transformed.transformed_fields,
+                            filename
+                        );
+                        let reader = BufReader::new(transformed.file.as_file_mut());
+                        serde_json::from_reader(reader)
+                    } else {
+                        if self.scrubbed {
+                            tracing::debug!("Scrubbed mode read {} (no normalization rules)", filename);
+                        }
+                        let reader = BufReader::new(file);
+                        serde_json::from_reader(reader)
+                    };
+                    let data: T = match parsed {
+                        Ok(data) => data,
+                        Err(error) if error.is_eof() => {
+                            last_resolve_error = Some(
+                                MissingSource::Empty {
+                                    path: filename.to_string(),
+                                }
+                                .into(),
+                            );
+                            continue;
+                        }
+                        Err(error) => {
+                            return Err(error)
+                                .wrap_err_with(|| format!("Failed to parse {filename} for {}", T::name()));
+                        }
+                    };
                     return Ok(data);
                 }
                 Err(e) => {
@@ -126,7 +154,7 @@ impl Receive for ArchiveFileReceiver {
         T::Item: DeserializeOwned + Send + 'static,
     {
         let ctx = self.source_context()?;
-        super::get_stream_from_archive::<File, T>(self.archive.clone(), self.subdir.clone(), ctx).await
+        super::get_stream_from_archive::<File, T>(self.archive.clone(), self.subdir.clone(), ctx, self.scrubbed).await
     }
 }
 
@@ -150,14 +178,33 @@ impl ReceiveRaw for ArchiveFileReceiver {
         for source_path in source_paths {
             match resolve_archive_path(self.subdir.as_ref(), &mut *archive, &source_path) {
                 Ok(filename) => {
-                    tracing::debug!("Reading {}", filename);
+                    if self.scrubbed {
+                        tracing::debug!("Reading {} (scrubbed mode)", filename);
+                    } else {
+                        tracing::debug!("Reading {}", filename);
+                    }
                     let file = archive.by_name(&filename)?;
                     let mut reader = BufReader::new(file);
                     let mut data = String::new();
                     reader.read_to_string(&mut data)?;
-                    let response_size_bytes = data.len() as u64;
+                    let body = if self.scrubbed {
+                        let transformed = normalize_supported_content(&filename, data)?;
+                        if transformed.supported {
+                            tracing::debug!(
+                                "Unscrubbed {} address fields in {}",
+                                transformed.transformed_fields,
+                                filename
+                            );
+                        } else {
+                            tracing::debug!("Scrubbed mode read {} (no normalization rules)", filename);
+                        }
+                        transformed.content
+                    } else {
+                        data
+                    };
+                    let response_size_bytes = body.len() as u64;
                     return Ok(RawResponse {
-                        body: data,
+                        body,
                         status: None,
                         response_time_ms: 0,
                         response_size_bytes,
@@ -199,6 +246,7 @@ impl ArchiveFileReceiver {
             subdir: Some(PathBuf::from(work_dir)),
             modified_date: self.modified_date,
             source_product: Arc::new(OnceLock::new()),
+            scrubbed: self.scrubbed,
         }
     }
 
@@ -246,5 +294,150 @@ impl ArchiveFileReceiver {
 
     pub fn source_context(&self) -> Result<SourceContext> {
         Ok(SourceContext::new(self.source_product()?, None))
+    }
+
+    pub fn set_scrubbed(&mut self, scrubbed: bool) {
+        self.scrubbed = scrubbed;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::scrub::synthetic_vectors as v;
+    use super::ArchiveFileReceiver;
+    use crate::processor::DataSource;
+    use crate::receiver::{ReceiveRaw, ScrubMode, should_enable_scrubbed};
+    use std::io::Write;
+    use std::path::PathBuf;
+    use zip::{ZipWriter, write::SimpleFileOptions};
+
+    struct NodesSource;
+
+    impl DataSource for NodesSource {
+        fn name() -> String {
+            "nodes".to_string()
+        }
+    }
+
+    fn write_test_archive(base_dir: &str, nodes_json: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let zip_path = dir.path().join("scrubbed-api-diagnostics-test.zip");
+        let file = std::fs::File::create(&zip_path).expect("create zip");
+        let mut zip = ZipWriter::new(file);
+        let options = SimpleFileOptions::default();
+
+        let prefix = format!("{base_dir}/");
+        zip.start_file(format!("{prefix}diagnostic_manifest.json"), options)
+            .expect("manifest");
+        zip.write_all(
+            br#"{
+  "mode": "full",
+  "product": "elasticsearch",
+  "type": "elasticsearch_diagnostic",
+  "runner": "cli",
+  "version": "9.1.3",
+  "timestamp": "2025-09-18T00:18:07.432Z"
+}"#,
+        )
+        .expect("manifest body");
+
+        zip.start_file(format!("{prefix}version.json"), options)
+            .expect("version");
+        zip.write_all(
+            br#"{
+  "name": "esdiag-node",
+  "cluster_name": "esdiag-cluster",
+  "cluster_uuid": "aukedefkRcGa0BT16uuuNQ",
+  "version": {
+    "number": "9.1.3",
+    "build_flavor": "default",
+    "build_type": "docker",
+    "build_hash": "abc",
+    "build_date": "2025-01-01T00:00:00.000000000Z",
+    "build_snapshot": false,
+    "lucene_version": "10.2.2",
+    "minimum_wire_compatibility_version": "8.19.0",
+    "minimum_index_compatibility_version": "8.0.0"
+  },
+  "tagline": "You Know, for Search"
+}"#,
+        )
+        .expect("version body");
+
+        zip.start_file(format!("{prefix}nodes.json"), options).expect("nodes");
+        zip.write_all(nodes_json.as_bytes()).expect("nodes body");
+
+        zip.finish().expect("finish zip");
+        (dir, zip_path)
+    }
+
+    #[tokio::test]
+    async fn non_scrubbed_archive_passes_nodes_json_unchanged() {
+        let archive_path =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/archives/elasticsearch-api-diagnostics-9.3.3.zip");
+        if !archive_path.exists() {
+            return;
+        }
+
+        let file = std::fs::File::open(&archive_path).expect("open archive");
+        let mut archive = zip::ZipArchive::new(file).expect("read archive");
+        let entry_path = "nodes.json";
+        let mut expected = String::new();
+        let mut zip_entry = archive.by_name(entry_path).expect("nodes.json");
+        std::io::Read::read_to_string(&mut zip_entry, &mut expected).expect("read nodes.json");
+
+        let mut receiver = ArchiveFileReceiver::try_from(archive_path).expect("receiver");
+        receiver.set_scrubbed(false);
+        receiver.set_source_product("elasticsearch").expect("source product");
+
+        assert!(!should_enable_scrubbed(
+            ScrubMode::Auto,
+            Some("elasticsearch-api-diagnostics-9.3.3.zip")
+        ));
+
+        let actual = receiver.get_raw::<NodesSource>().await.expect("get raw nodes");
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn scrubbed_receiver_normalizes_malformed_nodes_json() {
+        let nodes_json = format!(
+            r#"{{
+  "_nodes": {{"total": 1, "successful": 1, "failed": 0}},
+  "nodes": {{
+    "{node_id}": {{
+      "name": "{node_id}",
+      "transport_address": "{malformed_port}",
+      "host": "{malformed}",
+      "ip": "{malformed}",
+      "version": "9.1.3",
+      "build_flavor": "default",
+      "build_hash": "abc",
+      "build_type": "docker",
+      "roles": ["data_hot", "master"],
+      "os": {{
+        "refresh_interval_in_millis": 1000,
+        "available_processors": 8,
+        "allocated_processors": 8
+      }},
+      "jvm": {{}},
+      "process": {{}},
+      "thread_pool": {{}}
+    }}
+  }}
+}}"#,
+            node_id = v::SYNTHETIC_HEX_NODE_ID,
+            malformed = v::MALFORMED_IP,
+            malformed_port = v::MALFORMED_IP_WITH_PORT,
+        );
+        let (_dir, zip_path) = write_test_archive("api-diagnostics-scrubbed-test", &nodes_json);
+        let mut receiver = ArchiveFileReceiver::try_from(zip_path).expect("receiver");
+        receiver.set_scrubbed(true);
+        receiver.set_source_product("elasticsearch").expect("source product");
+
+        let raw = receiver.get_raw::<NodesSource>().await.expect("get raw nodes");
+        assert!(raw.contains(&format!("\"ip\":\"{}\"", v::NORMALIZED_IP)));
+        assert!(raw.contains(&format!("\"host\":\"{}\"", v::NORMALIZED_IP)));
+        assert!(raw.contains(&format!("\"transport_address\":\"{}\"", v::NORMALIZED_IP_WITH_PORT)));
     }
 }

--- a/src/receiver/archive/file.rs
+++ b/src/receiver/archive/file.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::{
     processor::{DataSource, SourceContext, StreamingDataSource},
-    receiver::{MissingSource, RawResponse, Receive, ReceiveMultiple, ReceiveRaw},
+    receiver::{MissingSource, RawResponse, Receive, ReceiveMultiple, ReceiveRaw, has_json_content},
 };
 use eyre::{Result, WrapErr, eyre};
 use futures::stream::BoxStream;
@@ -100,8 +100,17 @@ impl Receive for ArchiveFileReceiver {
                         tracing::debug!("Reading {}", filename);
                     }
                     let file = archive.by_name(&filename)?;
-                    let parsed = if self.scrubbed && supports_json_normalization(&filename) {
-                        let reader = BufReader::new(file);
+                    let mut reader = BufReader::new(file);
+                    if !has_json_content(&mut reader)? {
+                        last_resolve_error = Some(
+                            MissingSource::Empty {
+                                path: filename.to_string(),
+                            }
+                            .into(),
+                        );
+                        continue;
+                    }
+                    let data: T = if self.scrubbed && supports_json_normalization(&filename) {
                         let mut transformed = normalize_supported_reader_to_temp(&filename, reader)?;
                         tracing::debug!(
                             "Unscrubbed {} address fields in {}",
@@ -114,25 +123,9 @@ impl Receive for ArchiveFileReceiver {
                         if self.scrubbed {
                             tracing::debug!("Scrubbed mode read {} (no normalization rules)", filename);
                         }
-                        let reader = BufReader::new(file);
                         serde_json::from_reader(reader)
-                    };
-                    let data: T = match parsed {
-                        Ok(data) => data,
-                        Err(error) if error.is_eof() => {
-                            last_resolve_error = Some(
-                                MissingSource::Empty {
-                                    path: filename.to_string(),
-                                }
-                                .into(),
-                            );
-                            continue;
-                        }
-                        Err(error) => {
-                            return Err(error)
-                                .wrap_err_with(|| format!("Failed to parse {filename} for {}", T::name()));
-                        }
-                    };
+                    }
+                    .wrap_err_with(|| format!("Failed to parse {filename} for {}", T::name()))?;
                     return Ok(data);
                 }
                 Err(e) => {

--- a/src/receiver/archive/scrub.rs
+++ b/src/receiver/archive/scrub.rs
@@ -1,0 +1,708 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+use eyre::Result;
+use serde_json::Value;
+use std::io::{BufRead, Seek, SeekFrom, Write};
+use std::path::Path;
+
+/// Fields mapped as `ip` or keyword mirrors of node addresses in esdiag exports.
+const PURE_IP_FIELDS: &[&str] = &["ip", "host", "publish_host", "bind_host"];
+const IP_OR_PORT_FIELDS: &[&str] = &[
+    "transport_address",
+    "publish_address",
+    "bound_address",
+    "local_address",
+    "remote_address",
+    "x_forwarded_for",
+];
+const EXCLUDED_JSON_FILES: &[&str] = &["diagnostic_manifest.json", "version.json"];
+
+pub struct TransformResult {
+    pub content: String,
+    pub transformed_fields: usize,
+    pub supported: bool,
+}
+
+pub struct TempTransformResult {
+    pub file: tempfile::NamedTempFile,
+    pub transformed_fields: usize,
+}
+
+pub fn supports_json_normalization(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    let filename = Path::new(&normalized)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    filename.ends_with(".json") && !EXCLUDED_JSON_FILES.contains(&filename)
+}
+
+pub fn normalize_supported_content(path: &str, input: String) -> Result<TransformResult> {
+    if !supports_json_normalization(path) {
+        return Ok(TransformResult {
+            content: input,
+            transformed_fields: 0,
+            supported: false,
+        });
+    }
+
+    let mut json: Value = serde_json::from_str(&input)?;
+    let mut transformed = 0usize;
+    normalize_value(&mut json, &mut Vec::new(), &mut transformed);
+
+    Ok(TransformResult {
+        content: serde_json::to_string(&json)?,
+        transformed_fields: transformed,
+        supported: true,
+    })
+}
+
+pub fn normalize_supported_reader_to_temp<R: BufRead>(path: &str, mut reader: R) -> Result<TempTransformResult> {
+    let mut file = tempfile::NamedTempFile::new()?;
+    if !supports_json_normalization(path) {
+        std::io::copy(&mut reader, &mut file)?;
+        file.as_file_mut().seek(SeekFrom::Start(0))?;
+        return Ok(TempTransformResult {
+            file,
+            transformed_fields: 0,
+        });
+    }
+
+    let mut transformed = 0usize;
+    normalize_json_stream(reader, &mut file, &mut transformed)?;
+    file.as_file_mut().seek(SeekFrom::Start(0))?;
+
+    Ok(TempTransformResult {
+        file,
+        transformed_fields: transformed,
+    })
+}
+
+fn normalize_json_stream<R: BufRead, W: Write>(reader: R, writer: &mut W, transformed: &mut usize) -> Result<()> {
+    let mut bytes = reader.bytes().peekable();
+    let mut stack = Vec::<JsonContext>::new();
+
+    while let Some(byte) = bytes.next() {
+        let byte = byte?;
+        match byte {
+            b'"' => {
+                let raw = read_json_string_body(&mut bytes)?;
+                if is_object_key_context(&stack) {
+                    let key = serde_json::from_str::<String>(&format!("\"{raw}\""))?;
+                    write!(writer, "\"{raw}\"")?;
+                    if let Some(JsonContext::Object { pending_key, .. }) = stack.last_mut() {
+                        *pending_key = Some(key);
+                    }
+                } else {
+                    let value = serde_json::from_str::<String>(&format!("\"{raw}\""))?;
+                    let path = path_for_string_value(&stack);
+                    if matches_http_client_id(&path)
+                        && let Some(client_id) = normalize_http_client_id(&value)
+                    {
+                        write!(writer, "{client_id}")?;
+                        *transformed += 1;
+                        mark_value_written(&mut stack);
+                        continue;
+                    }
+
+                    match normalize_string_for_path(&path, &value) {
+                        Some(updated) if updated != value => {
+                            serde_json::to_writer(&mut *writer, &updated)?;
+                            *transformed += 1;
+                        }
+                        _ => write!(writer, "\"{raw}\"")?,
+                    }
+                    mark_value_written(&mut stack);
+                }
+            }
+            b'{' => {
+                let segment = take_pending_key(&mut stack);
+                writer.write_all(b"{")?;
+                stack.push(JsonContext::Object {
+                    segment,
+                    pending_key: None,
+                    expecting_key: true,
+                });
+            }
+            b'[' => {
+                let segment = take_pending_key(&mut stack);
+                writer.write_all(b"[")?;
+                stack.push(JsonContext::Array { segment });
+            }
+            b'}' | b']' => {
+                writer.write_all(&[byte])?;
+                stack.pop();
+                mark_value_written(&mut stack);
+            }
+            b',' => {
+                writer.write_all(b",")?;
+                if let Some(JsonContext::Object {
+                    pending_key,
+                    expecting_key,
+                    ..
+                }) = stack.last_mut()
+                {
+                    *pending_key = None;
+                    *expecting_key = true;
+                }
+            }
+            b':' => {
+                writer.write_all(b":")?;
+                if let Some(JsonContext::Object { expecting_key, .. }) = stack.last_mut() {
+                    *expecting_key = false;
+                }
+            }
+            byte if byte.is_ascii_whitespace() => writer.write_all(&[byte])?,
+            byte => {
+                writer.write_all(&[byte])?;
+                copy_literal_tail(&mut bytes, writer)?;
+                mark_value_written(&mut stack);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+enum JsonContext {
+    Object {
+        segment: Option<String>,
+        pending_key: Option<String>,
+        expecting_key: bool,
+    },
+    Array {
+        segment: Option<String>,
+    },
+}
+
+impl JsonContext {
+    fn segment(&self) -> Option<&str> {
+        match self {
+            JsonContext::Object { segment, .. } | JsonContext::Array { segment } => segment.as_deref(),
+        }
+    }
+}
+
+fn read_json_string_body<I>(bytes: &mut std::iter::Peekable<I>) -> Result<String>
+where
+    I: Iterator<Item = std::io::Result<u8>>,
+{
+    let mut raw = Vec::new();
+    let mut escaped = false;
+    for byte in bytes.by_ref() {
+        let byte = byte?;
+        if escaped {
+            raw.push(byte);
+            escaped = false;
+        } else if byte == b'\\' {
+            raw.push(byte);
+            escaped = true;
+        } else if byte == b'"' {
+            break;
+        } else {
+            raw.push(byte);
+        }
+    }
+    Ok(String::from_utf8(raw)?)
+}
+
+fn is_object_key_context(stack: &[JsonContext]) -> bool {
+    matches!(
+        stack.last(),
+        Some(JsonContext::Object {
+            expecting_key: true,
+            ..
+        })
+    )
+}
+
+fn take_pending_key(stack: &mut [JsonContext]) -> Option<String> {
+    match stack.last_mut() {
+        Some(JsonContext::Object { pending_key, .. }) => pending_key.take(),
+        _ => None,
+    }
+}
+
+fn mark_value_written(stack: &mut [JsonContext]) {
+    if let Some(JsonContext::Object {
+        pending_key,
+        expecting_key,
+        ..
+    }) = stack.last_mut()
+    {
+        *pending_key = None;
+        *expecting_key = false;
+    }
+}
+
+fn path_for_string_value(stack: &[JsonContext]) -> Vec<String> {
+    let mut path: Vec<String> = stack
+        .iter()
+        .filter_map(|ctx| ctx.segment().map(ToString::to_string))
+        .collect();
+    if let Some(JsonContext::Object {
+        pending_key: Some(key), ..
+    }) = stack.last()
+    {
+        path.push(key.clone());
+    }
+    path
+}
+
+fn normalize_string_for_path(path: &[String], raw: &str) -> Option<String> {
+    let key = path.last().map(String::as_str)?;
+    if PURE_IP_FIELDS.contains(&key) {
+        normalize_pure_ip(raw)
+    } else if IP_OR_PORT_FIELDS.contains(&key) {
+        normalize_ip_or_ip_port(raw)
+    } else {
+        None
+    }
+}
+
+fn copy_literal_tail<I, W>(bytes: &mut std::iter::Peekable<I>, writer: &mut W) -> Result<()>
+where
+    I: Iterator<Item = std::io::Result<u8>>,
+    W: Write,
+{
+    while let Some(byte) = bytes.peek() {
+        let byte = match byte {
+            Ok(byte) => *byte,
+            Err(_) => break,
+        };
+        if byte == b',' || byte == b'}' || byte == b']' || byte.is_ascii_whitespace() {
+            break;
+        }
+        let byte = bytes.next().transpose()?.expect("peeked byte");
+        writer.write_all(&[byte])?;
+    }
+    Ok(())
+}
+
+fn normalize_value(value: &mut Value, path: &mut Vec<String>, transformed: &mut usize) {
+    if matches_http_client_id(path)
+        && let Value::String(raw) = value
+        && let Some(client_id) = normalize_http_client_id(raw)
+    {
+        *value = Value::Number(client_id.into());
+        *transformed += 1;
+        return;
+    }
+
+    match value {
+        Value::Object(object) => {
+            for (key, child) in object.iter_mut() {
+                path.push(key.clone());
+                normalize_value(child, path, transformed);
+                path.pop();
+            }
+        }
+        Value::Array(array) => {
+            for child in array.iter_mut() {
+                normalize_value(child, path, transformed);
+            }
+        }
+        Value::String(raw) => {
+            let Some(key) = path.last().map(String::as_str) else {
+                return;
+            };
+
+            let normalized = if PURE_IP_FIELDS.contains(&key) {
+                normalize_pure_ip(raw)
+            } else if IP_OR_PORT_FIELDS.contains(&key) {
+                normalize_ip_or_ip_port(raw)
+            } else {
+                None
+            };
+
+            if let Some(updated) = normalized
+                && updated != *raw
+            {
+                *raw = updated;
+                *transformed += 1;
+            }
+        }
+        _ => {}
+    }
+}
+
+fn normalize_pure_ip(value: &str) -> Option<String> {
+    let (candidate_ip, port) = split_ip_port(value);
+    if port.is_none() {
+        return normalize_malformed_ipv4(candidate_ip);
+    }
+
+    normalize_malformed_ipv4(candidate_ip).or_else(|| parse_ipv4_octets(candidate_ip).map(|_| candidate_ip.to_string()))
+}
+
+fn normalize_ip_or_ip_port(value: &str) -> Option<String> {
+    let (candidate_ip, port) = split_ip_port(value);
+    let normalized_ip = normalize_malformed_ipv4(candidate_ip)?;
+    match port {
+        Some(port) => Some(format!("{normalized_ip}:{port}")),
+        None => Some(normalized_ip),
+    }
+}
+
+fn split_ip_port(value: &str) -> (&str, Option<&str>) {
+    let Some((ip, port)) = value.rsplit_once(':') else {
+        return (value, None);
+    };
+
+    if ip.contains(':') || !port.chars().all(|c| c.is_ascii_digit()) {
+        return (value, None);
+    }
+
+    (ip, Some(port))
+}
+
+fn normalize_malformed_ipv4(value: &str) -> Option<String> {
+    let octets = parse_ipv4_octets(value)?;
+
+    if octets.iter().all(|octet| *octet <= 255) {
+        return None;
+    }
+
+    Some(
+        octets
+            .iter()
+            .map(|octet| (octet % 255).to_string())
+            .collect::<Vec<String>>()
+            .join("."),
+    )
+}
+
+fn normalize_http_client_id(value: &str) -> Option<u64> {
+    let octets = parse_ipv4_octets(value)?;
+    if octets.iter().all(|octet| *octet <= 255) {
+        return None;
+    }
+
+    let normalized = octets.map(|octet| octet % 255);
+    let id = ((normalized[0] as u64) << 24)
+        | ((normalized[1] as u64) << 16)
+        | ((normalized[2] as u64) << 8)
+        | normalized[3] as u64;
+    Some(id)
+}
+
+fn matches_http_client_id(path: &[String]) -> bool {
+    path.len() >= 3
+        && path[path.len() - 3] == "http"
+        && path[path.len() - 2] == "clients"
+        && path[path.len() - 1] == "id"
+}
+
+fn parse_ipv4_octets(value: &str) -> Option<[u16; 4]> {
+    let mut octets = [0u16; 4];
+    let mut parts = value.split('.');
+    for octet in &mut octets {
+        let part = parts.next()?;
+        if part.is_empty() || !part.chars().all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        *octet = part.parse().ok()?;
+    }
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(octets)
+}
+
+#[cfg(test)]
+pub(super) mod synthetic_vectors {
+    // Hand-authored scrub test vectors only. Do NOT copy values from customer diagnostics.
+
+    /// Malformed IPv4-like string used in unit/integration tests (each octet > 255).
+    pub const MALFORMED_IP: &str = "512.768.1024.1280";
+    pub const MALFORMED_IP_WITH_PORT: &str = "512.768.1024.1280:19840";
+    pub const NORMALIZED_IP: &str = "2.3.4.5";
+    pub const NORMALIZED_IP_WITH_PORT: &str = "2.3.4.5:19840";
+
+    pub const MALFORMED_IP_SECONDARY: &str = "513.769.1025.1281";
+    pub const NORMALIZED_IP_SECONDARY: &str = "3.4.5.6";
+    pub const MALFORMED_IP_SECONDARY_WITH_PORT: &str = "513.769.1025.1281:19033";
+    pub const NORMALIZED_IP_SECONDARY_WITH_PORT: &str = "3.4.5.6:19033";
+
+    pub const MALFORMED_HTTP_CLIENT_ID: &str = "516.772.1028.1284";
+    pub const NORMALIZED_HTTP_CLIENT_ID: u64 = 101_124_105;
+
+    /// RFC 5737 TEST-NET-1 address for valid pass-through cases.
+    pub const VALID_IP: &str = "192.0.2.50";
+    pub const VALID_IP_WITH_PORT: &str = "192.0.2.50:9300";
+
+    /// 19-char lowercase hex node id/name for scrub humanization tests.
+    pub const SYNTHETIC_HEX_NODE_ID: &str = "aaaabbbbccccddddee0";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::synthetic_vectors as v;
+    use super::*;
+    use std::io::Read;
+
+    #[test]
+    fn normalizes_supported_ip_fields_only() {
+        let input = format!(
+            r#"{{
+            "nodes": {{
+                "a": {{
+                    "ip": "{malformed}",
+                    "host": "{malformed_port}",
+                    "transport_address": "{malformed_port}",
+                    "name": "{malformed}",
+                    "transport": {{
+                        "publish_address": "{malformed_secondary_port}",
+                        "x_forwarded_for": "{malformed_secondary}"
+                    }},
+                    "http": {{
+                        "clients": [
+                            {{ "id": "{malformed_client_id}" }}
+                        ]
+                    }}
+                }}
+            }}
+        }}"#,
+            malformed = v::MALFORMED_IP,
+            malformed_port = v::MALFORMED_IP_WITH_PORT,
+            malformed_secondary = v::MALFORMED_IP_SECONDARY,
+            malformed_secondary_port = v::MALFORMED_IP_SECONDARY_WITH_PORT,
+            malformed_client_id = v::MALFORMED_HTTP_CLIENT_ID,
+        );
+
+        let result = normalize_supported_content("diag/nodes.json", input).expect("normalize");
+
+        assert!(result.supported);
+        assert_eq!(result.transformed_fields, 6);
+        assert!(result.content.contains(&format!("\"ip\":\"{}\"", v::NORMALIZED_IP)));
+        assert!(result.content.contains(&format!("\"host\":\"{}\"", v::NORMALIZED_IP)));
+        assert!(
+            result
+                .content
+                .contains(&format!("\"transport_address\":\"{}\"", v::NORMALIZED_IP_WITH_PORT))
+        );
+        assert!(result.content.contains(&format!(
+            "\"publish_address\":\"{}\"",
+            v::NORMALIZED_IP_SECONDARY_WITH_PORT
+        )));
+        assert!(
+            result
+                .content
+                .contains(&format!("\"x_forwarded_for\":\"{}\"", v::NORMALIZED_IP_SECONDARY))
+        );
+        assert!(result.content.contains(&format!("\"name\":\"{}\"", v::MALFORMED_IP)));
+        assert!(
+            result
+                .content
+                .contains(&format!("\"id\":{}", v::NORMALIZED_HTTP_CLIENT_ID))
+        );
+    }
+
+    #[test]
+    fn normalizes_supported_reader_to_temp_without_value_materialization() {
+        let input = format!(
+            r#"{{
+            "nodes": {{
+                "a": {{
+                    "ip": "{malformed}",
+                    "transport_address": "{malformed_port}",
+                    "http": {{
+                        "clients": [
+                            {{ "id": "{malformed_client_id}" }}
+                        ]
+                    }}
+                }}
+            }}
+        }}"#,
+            malformed = v::MALFORMED_IP,
+            malformed_port = v::MALFORMED_IP_WITH_PORT,
+            malformed_client_id = v::MALFORMED_HTTP_CLIENT_ID,
+        );
+
+        let mut result = normalize_supported_reader_to_temp("diag/nodes.json", input.as_bytes()).expect("normalize");
+        let mut content = String::new();
+        result
+            .file
+            .as_file_mut()
+            .read_to_string(&mut content)
+            .expect("read normalized temp");
+
+        assert_eq!(result.transformed_fields, 3);
+        assert!(content.contains(&format!("\"{}\"", v::NORMALIZED_IP)));
+        assert!(content.contains(&format!("\"{}\"", v::NORMALIZED_IP_WITH_PORT)));
+        assert!(content.contains(&v::NORMALIZED_HTTP_CLIENT_ID.to_string()));
+    }
+
+    #[test]
+    fn skips_unsupported_files() {
+        let input = format!("{{\"ip\":\"{}\"}}", v::MALFORMED_IP);
+        let result = normalize_supported_content("diag/version.json", input.clone()).expect("normalize");
+        assert!(!result.supported);
+        assert_eq!(result.transformed_fields, 0);
+        assert_eq!(result.content, input);
+    }
+
+    #[test]
+    fn does_not_match_files_with_tasks_suffix_only() {
+        assert!(supports_json_normalization("diag/cluster_pending_tasks.json"));
+        assert!(supports_json_normalization("diag/tasks.json"));
+    }
+
+    #[test]
+    fn normalizes_publish_host_and_bind_host() {
+        let input = format!(
+            r#"{{
+            "nodes": {{
+                "a": {{
+                    "ip": "{malformed}",
+                    "settings": {{
+                        "network": {{
+                            "publish_host": "{malformed}",
+                            "bind_host": "{malformed}"
+                        }}
+                    }}
+                }}
+            }}
+        }}"#,
+            malformed = v::MALFORMED_IP,
+        );
+
+        let result = normalize_supported_content("diag/nodes.json", input).expect("normalize");
+
+        assert!(result.supported);
+        assert_eq!(result.transformed_fields, 3);
+        assert!(
+            result
+                .content
+                .contains(&format!("\"publish_host\":\"{}\"", v::NORMALIZED_IP))
+        );
+        assert!(
+            result
+                .content
+                .contains(&format!("\"bind_host\":\"{}\"", v::NORMALIZED_IP))
+        );
+    }
+
+    #[test]
+    fn normalizes_ip_fields_in_other_diagnostic_json_files() {
+        let input = format!(
+            r#"{{"master_node":{{"ip":"{malformed}","host":"{malformed}"}}}}"#,
+            malformed = v::MALFORMED_IP
+        );
+        let result = normalize_supported_content("diag/master.json", input).expect("normalize");
+        assert!(result.supported);
+        assert_eq!(result.transformed_fields, 2);
+    }
+
+    #[test]
+    fn normalizes_tasks_json_malformed_addresses() {
+        let input = format!(
+            r#"{{
+            "nodes": {{
+                "node-a": {{
+                    "tasks": {{
+                        "1": {{
+                            "action": "indices:data/write/bulk",
+                            "description": "bulk",
+                            "running_time_in_nanos": 100,
+                            "start_time_in_millis": 1,
+                            "type": "transport",
+                            "headers": {{}}
+                        }}
+                    }},
+                    "host": "{malformed}",
+                    "ip": "{malformed_port}",
+                    "transport_address": "{malformed_port}"
+                }}
+            }}
+        }}"#,
+            malformed = v::MALFORMED_IP,
+            malformed_port = v::MALFORMED_IP_WITH_PORT,
+        );
+
+        let result = normalize_supported_content("diag/tasks.json", input).expect("normalize");
+
+        assert!(result.supported);
+        assert_eq!(result.transformed_fields, 3);
+        assert!(result.content.contains(&format!("\"host\":\"{}\"", v::NORMALIZED_IP)));
+        assert!(result.content.contains(&format!("\"ip\":\"{}\"", v::NORMALIZED_IP)));
+        assert!(
+            result
+                .content
+                .contains(&format!("\"transport_address\":\"{}\"", v::NORMALIZED_IP_WITH_PORT))
+        );
+    }
+
+    #[test]
+    fn leaves_valid_ipv4_unchanged() {
+        let input = format!(
+            r#"{{
+            "nodes": {{
+                "a": {{
+                    "ip": "{valid}",
+                    "host": "{valid}",
+                    "transport_address": "{valid_port}",
+                    "transport": {{
+                        "publish_address": "{valid_port}"
+                    }},
+                    "http": {{
+                        "clients": [
+                            {{ "id": "{valid}" }}
+                        ]
+                    }}
+                }}
+            }}
+        }}"#,
+            valid = v::VALID_IP,
+            valid_port = v::VALID_IP_WITH_PORT,
+        );
+
+        let result = normalize_supported_content("diag/nodes.json", input).expect("normalize");
+
+        assert!(result.supported);
+        assert_eq!(result.transformed_fields, 0);
+        assert!(result.content.contains(&format!("\"ip\":\"{}\"", v::VALID_IP)));
+        assert!(
+            result
+                .content
+                .contains(&format!("\"transport_address\":\"{}\"", v::VALID_IP_WITH_PORT))
+        );
+        assert!(result.content.contains(&format!("\"id\":\"{}\"", v::VALID_IP)));
+    }
+
+    #[test]
+    fn strips_valid_ports_from_pure_ip_fields() {
+        let input = format!(
+            r#"{{
+            "nodes": {{
+                "a": {{
+                    "ip": "{valid_port}",
+                    "host": "{valid_port}",
+                    "publish_host": "{valid_port}",
+                    "transport_address": "{valid_port}"
+                }}
+            }}
+        }}"#,
+            valid_port = v::VALID_IP_WITH_PORT,
+        );
+
+        let result = normalize_supported_content("diag/nodes.json", input).expect("normalize");
+
+        assert!(result.supported);
+        assert_eq!(result.transformed_fields, 3);
+        assert!(result.content.contains(&format!("\"ip\":\"{}\"", v::VALID_IP)));
+        assert!(result.content.contains(&format!("\"host\":\"{}\"", v::VALID_IP)));
+        assert!(
+            result
+                .content
+                .contains(&format!("\"publish_host\":\"{}\"", v::VALID_IP))
+        );
+        assert!(
+            result
+                .content
+                .contains(&format!("\"transport_address\":\"{}\"", v::VALID_IP_WITH_PORT))
+        );
+    }
+}

--- a/src/receiver/directory.rs
+++ b/src/receiver/directory.rs
@@ -4,7 +4,7 @@
 
 use super::super::processor::{DataSource, SourceContext, StreamingDataSource};
 use super::archive::{normalize_supported_content, normalize_supported_reader_to_temp, supports_json_normalization};
-use super::{MissingSource, RawResponse, Receive, ReceiveMultiple, ReceiveRaw};
+use super::{MissingSource, RawResponse, Receive, ReceiveMultiple, ReceiveRaw, has_json_content};
 use eyre::{Result, WrapErr, eyre};
 use futures::stream::{self, BoxStream};
 use serde::de::DeserializeOwned;
@@ -79,9 +79,18 @@ impl Receive for DirectoryReceiver {
             tracing::debug!("Reading file: {}", &filename.display());
             match File::open(&filename) {
                 Ok(file) => {
-                    let parsed = if should_normalize_file(&source_path, self.scrubbed) {
+                    let mut reader = BufReader::new(file);
+                    if !has_json_content(&mut reader)? {
+                        last_error = Some(
+                            MissingSource::Empty {
+                                path: filename.display().to_string(),
+                            }
+                            .into(),
+                        );
+                        continue;
+                    }
+                    let data: T = if should_normalize_file(&source_path, self.scrubbed) {
                         tracing::debug!("Reading {} (scrubbed mode)", source_path);
-                        let reader = BufReader::new(file);
                         let mut transformed = normalize_supported_reader_to_temp(&source_path, reader)?;
                         tracing::debug!(
                             "Unscrubbed {} address fields in {}",
@@ -94,24 +103,9 @@ impl Receive for DirectoryReceiver {
                         if self.scrubbed {
                             tracing::debug!("Scrubbed mode read {} (no normalization rules)", source_path);
                         }
-                        serde_json::from_reader(BufReader::new(file))
-                    };
-                    let data: T = match parsed {
-                        Ok(data) => data,
-                        Err(error) if error.is_eof() => {
-                            last_error = Some(
-                                MissingSource::Empty {
-                                    path: filename.display().to_string(),
-                                }
-                                .into(),
-                            );
-                            continue;
-                        }
-                        Err(error) => {
-                            return Err(error)
-                                .wrap_err_with(|| format!("Failed to parse {} for {}", filename.display(), T::name()));
-                        }
-                    };
+                        serde_json::from_reader(reader)
+                    }
+                    .wrap_err_with(|| format!("Failed to parse {} for {}", filename.display(), T::name()))?;
                     return Ok(data);
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {

--- a/src/receiver/directory.rs
+++ b/src/receiver/directory.rs
@@ -3,6 +3,7 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use super::super::processor::{DataSource, SourceContext, StreamingDataSource};
+use super::archive::{normalize_supported_content, normalize_supported_reader_to_temp, supports_json_normalization};
 use super::{MissingSource, RawResponse, Receive, ReceiveMultiple, ReceiveRaw};
 use eyre::{Result, WrapErr, eyre};
 use futures::stream::{self, BoxStream};
@@ -23,6 +24,7 @@ pub struct DirectoryReceiver {
     work_dir: String,
     modified_date: SystemTime,
     source_product: Arc<OnceLock<&'static str>>,
+    scrubbed: bool,
 }
 
 impl TryFrom<PathBuf> for DirectoryReceiver {
@@ -37,6 +39,7 @@ impl TryFrom<PathBuf> for DirectoryReceiver {
                     work_dir: String::from(""),
                     modified_date: path.metadata()?.modified()?,
                     source_product: Arc::new(OnceLock::new()),
+                    scrubbed: false,
                 })
             }
             false => {
@@ -72,23 +75,43 @@ impl Receive for DirectoryReceiver {
         let mut last_error = None;
 
         for source_path in source_paths {
-            let filename = self.path.join(&self.work_dir).join(source_path);
+            let filename = self.path.join(&self.work_dir).join(&source_path);
             tracing::debug!("Reading file: {}", &filename.display());
             match File::open(&filename) {
                 Ok(file) => {
-                    let mut contents = String::new();
-                    BufReader::new(file).read_to_string(&mut contents)?;
-                    if contents.trim().is_empty() {
-                        last_error = Some(
-                            MissingSource::Empty {
-                                path: filename.display().to_string(),
-                            }
-                            .into(),
+                    let parsed = if should_normalize_file(&source_path, self.scrubbed) {
+                        tracing::debug!("Reading {} (scrubbed mode)", source_path);
+                        let reader = BufReader::new(file);
+                        let mut transformed = normalize_supported_reader_to_temp(&source_path, reader)?;
+                        tracing::debug!(
+                            "Unscrubbed {} address fields in {}",
+                            transformed.transformed_fields,
+                            source_path
                         );
-                        continue;
-                    }
-                    let data: T = serde_json::from_str(&contents)
-                        .wrap_err_with(|| format!("Failed to parse {} for {}", filename.display(), T::name()))?;
+                        let reader = BufReader::new(transformed.file.as_file_mut());
+                        serde_json::from_reader(reader)
+                    } else {
+                        if self.scrubbed {
+                            tracing::debug!("Scrubbed mode read {} (no normalization rules)", source_path);
+                        }
+                        serde_json::from_reader(BufReader::new(file))
+                    };
+                    let data: T = match parsed {
+                        Ok(data) => data,
+                        Err(error) if error.is_eof() => {
+                            last_error = Some(
+                                MissingSource::Empty {
+                                    path: filename.display().to_string(),
+                                }
+                                .into(),
+                            );
+                            continue;
+                        }
+                        Err(error) => {
+                            return Err(error)
+                                .wrap_err_with(|| format!("Failed to parse {} for {}", filename.display(), T::name()));
+                        }
+                    };
                     return Ok(data);
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -112,20 +135,49 @@ impl Receive for DirectoryReceiver {
     {
         let ctx = self.source_context()?;
         let source_path = T::resolve_source_file_path(&ctx)?;
-        let filename = self.path.join(&self.work_dir).join(source_path);
+        let filename = self.path.join(&self.work_dir).join(&source_path);
         tracing::debug!("Streaming file: {}", &filename.display());
 
         let filename_clone = filename.clone();
+        let scrubbed = self.scrubbed;
+        let source_path_for_scrub = source_path.clone();
+        let should_normalize = should_normalize_file(&source_path, scrubbed);
         let (tx, rx) = mpsc::channel(100);
 
         let tx_err = tx.clone();
         let handle = tokio::task::spawn_blocking(move || match File::open(&filename_clone) {
             Ok(file) => {
-                let reader = BufReader::new(file);
-                let mut deserializer = serde_json::Deserializer::from_reader(reader);
-                if let Err(e) = T::deserialize_stream(&mut deserializer, tx.clone()) {
-                    tracing::error!("Error deserializing stream: {}", e);
-                    let _ = tx.blocking_send(Err(eyre!(e)));
+                if should_normalize {
+                    tracing::debug!("Reading {} (scrubbed mode)", source_path_for_scrub);
+                    let reader = BufReader::new(file);
+                    match normalize_supported_reader_to_temp(&source_path_for_scrub, reader) {
+                        Ok(mut transformed) => {
+                            tracing::debug!(
+                                "Unscrubbed {} address fields in {}",
+                                transformed.transformed_fields,
+                                source_path_for_scrub
+                            );
+                            let reader = BufReader::new(transformed.file.as_file_mut());
+                            let mut deserializer = serde_json::Deserializer::from_reader(reader);
+                            if let Err(e) = T::deserialize_stream(&mut deserializer, tx.clone()) {
+                                tracing::error!("Error deserializing stream: {}", e);
+                                let _ = tx.blocking_send(Err(eyre!(e)));
+                            }
+                        }
+                        Err(e) => {
+                            let _ = tx.blocking_send(Err(eyre!(e)));
+                        }
+                    }
+                } else {
+                    if scrubbed {
+                        tracing::debug!("Scrubbed mode read {} (no normalization rules)", source_path_for_scrub);
+                    }
+                    let reader = BufReader::new(file);
+                    let mut deserializer = serde_json::Deserializer::from_reader(reader);
+                    if let Err(e) = T::deserialize_stream(&mut deserializer, tx.clone()) {
+                        tracing::error!("Error deserializing stream: {}", e);
+                        let _ = tx.blocking_send(Err(eyre!(e)));
+                    }
                 }
             }
             Err(e) => {
@@ -162,16 +214,20 @@ impl ReceiveRaw for DirectoryReceiver {
         let mut last_open_error = None;
 
         for source_path in source_paths {
-            let filename = self.path.join(&self.work_dir).join(source_path);
+            let filename = self.path.join(&self.work_dir).join(&source_path);
             tracing::debug!("Reading file: {}", &filename.display());
             match File::open(&filename) {
                 Ok(file) => {
+                    if self.scrubbed {
+                        tracing::debug!("Reading {} (scrubbed mode)", source_path);
+                    }
                     let mut reader = BufReader::new(file);
                     let mut data = String::new();
                     reader.read_to_string(&mut data)?;
-                    let response_size_bytes = data.len() as u64;
+                    let body = normalize_file_content_if_needed(&source_path, self.scrubbed, data)?;
+                    let response_size_bytes = body.len() as u64;
                     return Ok(RawResponse {
-                        body: data,
+                        body,
                         status: None,
                         response_time_ms: 0,
                         response_size_bytes,
@@ -200,7 +256,7 @@ impl ReceiveMultiple for DirectoryReceiver {
 }
 
 impl std::fmt::Display for DirectoryReceiver {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Directory {}", self.path.display())
     }
 }
@@ -212,7 +268,12 @@ impl DirectoryReceiver {
             work_dir: work_dir.to_string(),
             modified_date: self.modified_date,
             source_product: Arc::new(OnceLock::new()),
+            scrubbed: self.scrubbed,
         }
+    }
+
+    pub fn set_scrubbed(&mut self, scrubbed: bool) {
+        self.scrubbed = scrubbed;
     }
 
     pub async fn read_bundle_json<T>(&self, filename: &str) -> Result<T>
@@ -222,8 +283,19 @@ impl DirectoryReceiver {
         let path = self.path.join(&self.work_dir).join(filename);
         tracing::debug!("Reading bundle file: {}", path.display());
         let file = File::open(path)?;
-        let reader = BufReader::new(file);
-        serde_json::from_reader(reader).map_err(Into::into)
+        if !should_normalize_file(filename, self.scrubbed) {
+            if self.scrubbed {
+                tracing::debug!("Scrubbed mode read {} (no normalization rules)", filename);
+            }
+            let reader = BufReader::new(file);
+            return serde_json::from_reader(reader).map_err(Into::into);
+        }
+
+        let mut reader = BufReader::new(file);
+        let mut content = String::new();
+        reader.read_to_string(&mut content)?;
+        let content = normalize_file_content_if_needed(filename, self.scrubbed, content)?;
+        serde_json::from_str(&content).map_err(Into::into)
     }
 
     /// Whether the bundle contains `dir` as a directory within the receiver's
@@ -258,4 +330,27 @@ impl DirectoryReceiver {
     pub fn source_context(&self) -> Result<SourceContext> {
         Ok(SourceContext::new(self.source_product()?, None))
     }
+}
+
+fn normalize_file_content_if_needed(logical_name: &str, scrubbed: bool, content: String) -> Result<String> {
+    if !scrubbed {
+        return Ok(content);
+    }
+
+    if !supports_json_normalization(logical_name) {
+        tracing::debug!("Scrubbed mode read {} (no normalization rules)", logical_name);
+        return Ok(content);
+    }
+
+    let transformed = normalize_supported_content(logical_name, content)?;
+    tracing::debug!(
+        "Unscrubbed {} address fields in {}",
+        transformed.transformed_fields,
+        logical_name
+    );
+    Ok(transformed.content)
+}
+
+fn should_normalize_file(logical_name: &str, scrubbed: bool) -> bool {
+    scrubbed && supports_json_normalization(logical_name)
 }

--- a/src/receiver/mod.rs
+++ b/src/receiver/mod.rs
@@ -34,6 +34,7 @@ use directory::DirectoryReceiver;
 use eyre::{Result, eyre};
 use futures::stream::BoxStream;
 use serde::de::DeserializeOwned;
+use std::io::BufRead;
 use std::path::{Component, Path};
 use std::time::Duration;
 use upload_service::UploadServiceDownloader;
@@ -91,6 +92,20 @@ impl From<Option<bool>> for ScrubMode {
 }
 
 impl std::error::Error for MissingSource {}
+
+pub(crate) fn has_json_content<R: BufRead>(reader: &mut R) -> std::io::Result<bool> {
+    loop {
+        let buffer = reader.fill_buf()?;
+        if buffer.is_empty() {
+            return Ok(false);
+        }
+        if buffer.iter().any(|byte| !matches!(byte, b' ' | b'\n' | b'\r' | b'\t')) {
+            return Ok(true);
+        }
+        let length = buffer.len();
+        reader.consume(length);
+    }
+}
 
 fn should_enable_scrubbed(mode: ScrubMode, filename: Option<&str>) -> bool {
     match mode {
@@ -588,13 +603,27 @@ impl std::fmt::Display for Receiver {
 
 #[cfg(test)]
 mod tests {
-    use super::{DirectoryReceiver, Receiver, ScrubMode, resolve_scrub_detect_name, should_enable_scrubbed};
+    use super::{
+        DirectoryReceiver, Receiver, ScrubMode, has_json_content, resolve_scrub_detect_name, should_enable_scrubbed,
+    };
     use crate::data::{Application, KnownHostBuilder};
+    use std::io::{BufReader, Cursor};
     use url::Url;
 
     fn directory_receiver() -> Receiver {
         let root = tempfile::tempdir().expect("temp diagnostic root");
         Receiver::Directory(DirectoryReceiver::try_from(root.keep()).expect("directory receiver"))
+    }
+
+    #[test]
+    fn empty_source_detection_does_not_mask_truncated_json() {
+        let mut empty = BufReader::new(Cursor::new(b" \n\t\r".as_slice()));
+        assert!(!has_json_content(&mut empty).expect("inspect empty source"));
+
+        let mut truncated = BufReader::new(Cursor::new(br#"{"nodes":"#.as_slice()));
+        assert!(has_json_content(&mut truncated).expect("inspect truncated source"));
+        let error = serde_json::from_reader::<_, serde_json::Value>(truncated).expect_err("JSON is truncated");
+        assert!(error.is_eof());
     }
 
     #[test]

--- a/src/receiver/mod.rs
+++ b/src/receiver/mod.rs
@@ -73,7 +73,46 @@ impl std::fmt::Display for MissingSource {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScrubMode {
+    Auto,
+    Enabled,
+    Disabled,
+}
+
+impl From<Option<bool>> for ScrubMode {
+    fn from(value: Option<bool>) -> Self {
+        match value {
+            Some(true) => ScrubMode::Enabled,
+            Some(false) => ScrubMode::Disabled,
+            None => ScrubMode::Auto,
+        }
+    }
+}
+
 impl std::error::Error for MissingSource {}
+
+fn should_enable_scrubbed(mode: ScrubMode, filename: Option<&str>) -> bool {
+    match mode {
+        ScrubMode::Enabled => true,
+        ScrubMode::Disabled => false,
+        ScrubMode::Auto => filename
+            .map(|value| {
+                value
+                    .split(|ch: char| !ch.is_ascii_alphanumeric())
+                    .any(|token| token.eq_ignore_ascii_case("scrubbed"))
+            })
+            .unwrap_or(false),
+    }
+}
+
+fn scrub_mode_label(mode: ScrubMode) -> &'static str {
+    match mode {
+        ScrubMode::Auto => "auto",
+        ScrubMode::Enabled => "explicit true",
+        ScrubMode::Disabled => "explicit false",
+    }
+}
 
 #[allow(async_fn_in_trait)]
 pub trait Receive {
@@ -426,15 +465,60 @@ fn validate_relative_subdir(sub_dir: &str) -> Result<()> {
 impl TryFrom<Uri> for Receiver {
     type Error = eyre::Report;
     fn try_from(uri: Uri) -> std::result::Result<Self, Self::Error> {
+        Receiver::try_from_with_scrub(uri, None, None)
+    }
+}
+
+fn resolve_scrub_detect_name(path: &str, hint: Option<&str>) -> String {
+    hint.filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| path.to_string())
+}
+
+impl Receiver {
+    pub fn try_from_with_scrub(
+        uri: Uri,
+        scrubbed_override: Option<bool>,
+        auto_detect_filename: Option<&str>,
+    ) -> std::result::Result<Self, eyre::Report> {
+        let scrub_mode = ScrubMode::from(scrubbed_override);
         let receiver = match uri {
-            Uri::Directory(dir) => Receiver::Directory(DirectoryReceiver::try_from(dir)?),
+            Uri::Directory(dir) => {
+                let path_label = dir.to_string_lossy().to_string();
+                let detect_name = resolve_scrub_detect_name(&path_label, auto_detect_filename);
+                let mut receiver = DirectoryReceiver::try_from(dir)?;
+                let scrubbed = should_enable_scrubbed(scrub_mode, Some(&detect_name));
+                tracing::debug!(
+                    "Scrub normalization {} for {} (detect name: {}, mode: {})",
+                    if scrubbed { "enabled" } else { "disabled" },
+                    path_label,
+                    detect_name,
+                    scrub_mode_label(scrub_mode)
+                );
+                receiver.set_scrubbed(scrubbed);
+                Receiver::Directory(receiver)
+            }
             Uri::ElasticCloud(host) => {
                 return Err(eyre!("Elastic Cloud API not yet implemented. {host}"));
             }
             Uri::ElasticCloudAdmin(host) | Uri::ElasticGovCloudAdmin(host) => {
                 Receiver::ElasticCloudAdmin(ElasticCloudAdminReceiver::try_from(host)?)
             }
-            Uri::File(file) => Receiver::ArchiveFile(ArchiveFileReceiver::try_from(file)?),
+            Uri::File(file) => {
+                let path = file.to_string_lossy().to_string();
+                let detect_name = resolve_scrub_detect_name(&path, auto_detect_filename);
+                let mut receiver = ArchiveFileReceiver::try_from(file)?;
+                let scrubbed = should_enable_scrubbed(scrub_mode, Some(&detect_name));
+                tracing::debug!(
+                    "Scrub normalization {} for {} (detect name: {}, mode: {})",
+                    if scrubbed { "enabled" } else { "disabled" },
+                    path,
+                    detect_name,
+                    scrub_mode_label(scrub_mode)
+                );
+                receiver.set_scrubbed(scrubbed);
+                Receiver::ArchiveFile(receiver)
+            }
             Uri::KnownHost(host) => {
                 let resolved = host.resolve()?;
                 let application = resolved.application();
@@ -448,7 +532,23 @@ impl TryFrom<Uri> for Receiver {
                     }
                 }
             }
-            Uri::ServiceLink(url) => Receiver::ArchiveBytes(UploadServiceDownloader::try_from(url)?.download()?),
+            Uri::ServiceLink(url) => {
+                let detect_name = auto_detect_filename
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string);
+                let mut receiver = UploadServiceDownloader::try_from(url)?.download()?;
+                let scrubbed = should_enable_scrubbed(scrub_mode, detect_name.as_deref());
+                if let Some(name) = detect_name.as_deref() {
+                    tracing::debug!(
+                        "Scrub normalization {} for service link (detect name: {}, mode: {})",
+                        if scrubbed { "enabled" } else { "disabled" },
+                        name,
+                        scrub_mode_label(scrub_mode)
+                    );
+                }
+                receiver.set_scrubbed(scrubbed);
+                Receiver::ArchiveBytes(receiver)
+            }
             _ => return Err(eyre!("Unsupported URI: {uri}")),
         };
         Ok(receiver)
@@ -488,7 +588,7 @@ impl std::fmt::Display for Receiver {
 
 #[cfg(test)]
 mod tests {
-    use super::{DirectoryReceiver, Receiver};
+    use super::{DirectoryReceiver, Receiver, ScrubMode, resolve_scrub_detect_name, should_enable_scrubbed};
     use crate::data::{Application, KnownHostBuilder};
     use url::Url;
 
@@ -539,5 +639,54 @@ mod tests {
 
         assert!(err.to_string().contains("out of scope by design for Agent"));
         assert!(err.to_string().contains("read/Load"));
+    }
+
+    #[test]
+    fn upload_temp_path_auto_detects_from_original_filename_hint() {
+        let temp = "esdiag-upload-1-550e8400-e29b-41d4-a716-446655440000.zip";
+        let original = "example_scrubbed-api-diagnostics.zip";
+        let detect = resolve_scrub_detect_name(temp, Some(original));
+        assert!(should_enable_scrubbed(ScrubMode::Auto, Some(&detect)));
+        assert!(!should_enable_scrubbed(ScrubMode::Auto, Some(temp)));
+    }
+
+    #[test]
+    fn scrub_mode_enabled_always_true() {
+        assert!(should_enable_scrubbed(ScrubMode::Enabled, None));
+        assert!(should_enable_scrubbed(ScrubMode::Enabled, Some("diagnostic.zip")));
+    }
+
+    #[test]
+    fn scrub_mode_disabled_always_false() {
+        assert!(!should_enable_scrubbed(ScrubMode::Disabled, None));
+        assert!(!should_enable_scrubbed(
+            ScrubMode::Disabled,
+            Some("example_scrubbed-api-diagnostics.zip")
+        ));
+    }
+
+    #[test]
+    fn scrub_mode_auto_uses_filename_match() {
+        assert!(should_enable_scrubbed(
+            ScrubMode::Auto,
+            Some("example_scrubbed-api-diagnostics.zip")
+        ));
+        assert!(should_enable_scrubbed(
+            ScrubMode::Auto,
+            Some("example-scrubbed-api-diagnostics.zip")
+        ));
+        assert!(should_enable_scrubbed(
+            ScrubMode::Auto,
+            Some("example.scrubbed.api.diagnostics.zip")
+        ));
+        assert!(!should_enable_scrubbed(
+            ScrubMode::Auto,
+            Some("example-unscrubbed-api-diagnostics.zip")
+        ));
+        assert!(!should_enable_scrubbed(
+            ScrubMode::Auto,
+            Some("example-api-diagnostics.zip")
+        ));
+        assert!(!should_enable_scrubbed(ScrubMode::Auto, None));
     }
 }

--- a/src/receiver/resolver.rs
+++ b/src/receiver/resolver.rs
@@ -27,6 +27,8 @@ enum RuntimeInput {
     Uri {
         uri: Uri,
         application: Option<Application>,
+        scrubbed_override: Option<bool>,
+        filename_hint: Option<String>,
     },
 }
 
@@ -84,7 +86,26 @@ impl InputResolver {
     }
 
     pub fn bind_uri(&mut self, key: BindingKey, uri: Uri, application: Option<Application>) {
-        self.bindings.insert(key, RuntimeInput::Uri { uri, application });
+        self.bind_uri_with_scrub(key, uri, application, None, None);
+    }
+
+    pub fn bind_uri_with_scrub(
+        &mut self,
+        key: BindingKey,
+        uri: Uri,
+        application: Option<Application>,
+        scrubbed_override: Option<bool>,
+        filename_hint: Option<String>,
+    ) {
+        self.bindings.insert(
+            key,
+            RuntimeInput::Uri {
+                uri,
+                application,
+                scrubbed_override,
+                filename_hint,
+            },
+        );
     }
 
     pub async fn resolve(
@@ -99,7 +120,7 @@ impl InputResolver {
                 self.resolve_binding(binding, materialize_remote, require_local_bundle)
                     .await
             }
-            Input::Load { uri } => self.resolve_stable_load(uri, materialize_remote).await,
+            Input::Load { uri } => self.resolve_stable_load(uri, materialize_remote, None, None).await,
         }
     }
 
@@ -123,10 +144,16 @@ impl InputResolver {
         ))
     }
 
-    async fn resolve_stable_load(&self, uri: &Uri, materialize_remote: bool) -> Result<ResolvedInput> {
+    async fn resolve_stable_load(
+        &self,
+        uri: &Uri,
+        materialize_remote: bool,
+        scrubbed_override: Option<bool>,
+        filename_hint: Option<&str>,
+    ) -> Result<ResolvedInput> {
         match uri {
             Uri::File(path) => Ok(ResolvedInput::new(
-                Receiver::try_from(uri.clone())?,
+                Receiver::try_from_with_scrub(uri.clone(), scrubbed_override, filename_hint)?,
                 None,
                 Some(path.clone()),
                 None,
@@ -141,7 +168,8 @@ impl InputResolver {
                     let _ = tokio::fs::remove_dir_all(&temp_dir).await;
                     return Err(error.into());
                 }
-                let receiver = Receiver::try_from(Uri::File(bundle_path.clone()))?;
+                let receiver =
+                    Receiver::try_from_with_scrub(Uri::File(bundle_path.clone()), scrubbed_override, filename_hint)?;
                 Ok(ResolvedInput::new(
                     receiver,
                     None,
@@ -149,7 +177,12 @@ impl InputResolver {
                     Some(TempInputCleanup(temp_dir)),
                 ))
             }
-            _ => Ok(ResolvedInput::new(Receiver::try_from(uri.clone())?, None, None, None)),
+            _ => Ok(ResolvedInput::new(
+                Receiver::try_from_with_scrub(uri.clone(), scrubbed_override, filename_hint)?,
+                None,
+                None,
+                None,
+            )),
         }
     }
 
@@ -200,8 +233,15 @@ impl InputResolver {
                     None,
                 ))
             }
-            RuntimeInput::Uri { uri, application } => {
-                let mut resolved = self.resolve_stable_load(uri, materialize_remote).await?;
+            RuntimeInput::Uri {
+                uri,
+                application,
+                scrubbed_override,
+                filename_hint,
+            } => {
+                let mut resolved = self
+                    .resolve_stable_load(uri, materialize_remote, *scrubbed_override, filename_hint.as_deref())
+                    .await?;
                 resolved.application = *application;
                 if require_local_bundle && resolved.bundle_path.is_none() {
                     return Err(eyre!(

--- a/src/server/file_upload.rs
+++ b/src/server/file_upload.rs
@@ -70,6 +70,7 @@ pub async fn submit(
                             remove_err
                         );
                     }
+                    state.record_job_rejected().await;
                     return (
                         StatusCode::BAD_REQUEST,
                         Html(format!(
@@ -82,6 +83,7 @@ pub async fn submit(
 
                 let filename = match field.file_name() {
                     Some(filename) if !filename.ends_with(".zip") => {
+                        state.record_job_rejected().await;
                         return (
                             StatusCode::BAD_REQUEST,
                             Html(format!(
@@ -93,6 +95,7 @@ pub async fn submit(
                     }
                     Some(filename) => filename.to_string(),
                     None => {
+                        state.record_job_rejected().await;
                         return (
                             StatusCode::BAD_REQUEST,
                             Html(format!(
@@ -176,6 +179,7 @@ pub async fn submit(
 
         (StatusCode::OK, Html(upload_file_element))
     } else {
+        state.record_job_rejected().await;
         (
             StatusCode::BAD_REQUEST,
             Html(format!(

--- a/src/server/file_upload.rs
+++ b/src/server/file_upload.rs
@@ -19,6 +19,19 @@ use tokio::sync::mpsc;
 use tokio::{fs::File, io::AsyncWriteExt};
 use uuid::Uuid;
 
+/// Parse upload checkbox value. When the field body cannot be read, scrub mode defaults to enabled.
+fn parse_scrubbed_upload_field<E>(text: Result<String, E>) -> bool {
+    match text {
+        Ok(value) => parse_scrubbed_checkbox_value(&value),
+        Err(_) => true,
+    }
+}
+
+fn parse_scrubbed_checkbox_value(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    matches!(normalized.as_str(), "true" | "1" | "on")
+}
+
 pub async fn submit(
     State(state): State<Arc<ServerState>>,
     headers: HeaderMap,
@@ -41,107 +54,133 @@ pub async fn submit(
             );
         }
     };
+    let mut scrubbed_override: Option<bool> = None;
+    let mut staged_upload: Option<(String, std::path::PathBuf)> = None;
 
-    // Process the multipart form
-    if let Ok(Some(field)) = multipart.next_field().await {
-        if field.name() == Some("file") {
-            // Check if the file has a valid filename
-            let filename = match field.file_name() {
-                Some(filename) if !filename.ends_with(".zip") => {
-                    return (
-                        StatusCode::BAD_REQUEST,
-                        Html(format!(
-                            r#"<div id="job-{job_id}" class="status-box history-item status-error">
-                        🛑 Invalid file type, only .zip files are allowed.
-                    </div>"#
-                        )),
-                    );
-                }
-                Some(filename) => filename.to_string(),
-                None => {
-                    return (
-                        StatusCode::BAD_REQUEST,
-                        Html(format!(
-                            r#"<div id="job-{job_id}" class="status-box history-item status-error">
-                            🛑 Missing file name
-                        </div>"#
-                        )),
-                    );
-                }
-            };
-
-            let upload_file_element = format!(
-                r#"<div id="job-{job_id}"
-                    class="status-box history-item status-processing"
-                    data-init="$loading=false; $file_upload.job_id={job_id}; if ({can_use_keystore} && $keystore.locked && $output.secure) {{ $_pending_job_action = 'upload-process'; $message = 'Unlock keystore to continue...'; @get('/keystore/modal/process', {{filterSignals: {{exclude: /.*/}}}}); }} else {{ @post('/upload/process', {{openWhenHidden: true, filterSignals: {{include: /^(metadata|archive|job|file_upload)(\.|$)/}}}}); }}"
-                >
-                    <div class="spinner"></div>
-                    <span>Processing diagnostic</span>
-                    <p><b>Filename:</b> {filename}</p>
-                </div>"#
-            );
-
-            let temp_upload_path = std::env::temp_dir().join(format!("esdiag-upload-{job_id}-{}.zip", Uuid::new_v4()));
-            match stage_upload_field(field, &temp_upload_path).await {
-                Ok(()) => {
-                    state
-                        .push_upload(job_id, identity.user, identity.account, filename, temp_upload_path)
-                        .await;
-
-                    // Add a cleanup task to remove abandoned staged uploads.
-                    let state_clone = state.clone();
-                    tokio::spawn(async move {
-                        tokio::time::sleep(tokio::time::Duration::from_secs(300)).await;
-                        if let Some(job) = state_clone.pop_job_request(job_id).await {
-                            job.cleanup().await;
-                            tracing::warn!(
-                                "Upload job {} was never processed and was removed from state to clean up the staged upload",
-                                job_id
-                            );
-                        }
-                    });
-                }
-                Err(e) => {
+    while let Ok(Some(field)) = multipart.next_field().await {
+        match field.name() {
+            Some("file") => {
+                if let Some((_filename, temp_upload_path)) = staged_upload.take() {
                     if let Err(remove_err) = tokio::fs::remove_file(&temp_upload_path).await
                         && remove_err.kind() != std::io::ErrorKind::NotFound
                     {
                         tracing::debug!(
-                            "Failed to remove partial upload {}: {}",
+                            "Failed to remove duplicate upload {}: {}",
                             temp_upload_path.display(),
                             remove_err
                         );
                     }
-                    let error_msg = format!("Failed to stage upload data: {}", e);
-                    tracing::error!("{}", error_msg);
-                    state.record_job_rejected().await;
                     return (
                         StatusCode::BAD_REQUEST,
                         Html(format!(
                             r#"<div id="job-{job_id}" class="status-box history-item status-error">
-                            🛑 Error {error_msg}
-                        </div>"#
+                                🛑 Multiple upload files are not supported
+                            </div>"#
                         )),
                     );
                 }
-            };
 
-            (StatusCode::OK, Html(upload_file_element))
-        } else {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Html(format!(
-                    r#"<div id="job-{job_id}" class="status-box history-item status-error">
-                        🛑 Upload Failed
-                    </div>"#
-                )),
-            )
+                let filename = match field.file_name() {
+                    Some(filename) if !filename.ends_with(".zip") => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Html(format!(
+                                r#"<div id="job-{job_id}" class="status-box history-item status-error">
+                            🛑 Invalid file type, only .zip files are allowed.
+                        </div>"#
+                            )),
+                        );
+                    }
+                    Some(filename) => filename.to_string(),
+                    None => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Html(format!(
+                                r#"<div id="job-{job_id}" class="status-box history-item status-error">
+                                🛑 Missing file name
+                            </div>"#
+                            )),
+                        );
+                    }
+                };
+
+                let temp_upload_path =
+                    std::env::temp_dir().join(format!("esdiag-upload-{job_id}-{}.zip", Uuid::new_v4()));
+                match stage_upload_field(field, &temp_upload_path).await {
+                    Ok(()) => staged_upload = Some((filename, temp_upload_path)),
+                    Err(e) => {
+                        if let Err(remove_err) = tokio::fs::remove_file(&temp_upload_path).await
+                            && remove_err.kind() != std::io::ErrorKind::NotFound
+                        {
+                            tracing::debug!(
+                                "Failed to remove partial upload {}: {}",
+                                temp_upload_path.display(),
+                                remove_err
+                            );
+                        }
+                        let error_msg = format!("Failed to stage upload data: {}", e);
+                        tracing::error!("{}", error_msg);
+                        state.record_job_rejected().await;
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Html(format!(
+                                r#"<div id="job-{job_id}" class="status-box history-item status-error">
+                                🛑 Error {error_msg}
+                            </div>"#
+                            )),
+                        );
+                    }
+                }
+            }
+            Some("scrubbed") => {
+                scrubbed_override = Some(parse_scrubbed_upload_field(field.text().await));
+            }
+            _ => {}
         }
+    }
+
+    if let Some((filename, temp_upload_path)) = staged_upload {
+        let upload_file_element = format!(
+            r#"<div id="job-{job_id}"
+                class="status-box history-item status-processing"
+                data-init="$loading=false; $file_upload.job_id={job_id}; if ({can_use_keystore} && $keystore.locked && $output.secure) {{ $_pending_job_action = 'upload-process'; $message = 'Unlock keystore to continue...'; @get('/keystore/modal/process', {{filterSignals: {{exclude: /.*/}}}}); }} else {{ @post('/upload/process', {{openWhenHidden: true, filterSignals: {{include: /^(metadata|archive|job|file_upload)(\.|$)/}}}}); }}"
+            >
+                <div class="spinner"></div>
+                <span>Processing diagnostic</span>
+                <p><b>Filename:</b> {filename}</p>
+            </div>"#
+        );
+
+        state
+            .push_upload(
+                job_id,
+                identity.user,
+                identity.account,
+                filename,
+                temp_upload_path,
+                scrubbed_override,
+            )
+            .await;
+
+        let state_clone = state.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_secs(300)).await;
+            if let Some(job) = state_clone.pop_job_request(job_id).await {
+                job.cleanup().await;
+                tracing::warn!(
+                    "Upload job {} was never processed and was removed from state to clean up the staged upload",
+                    job_id
+                );
+            }
+        });
+
+        (StatusCode::OK, Html(upload_file_element))
     } else {
         (
-            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::BAD_REQUEST,
             Html(format!(
                 r#"<div id="job-{job_id}" class="status-box history-item status-error">
-                    🛑 Upload Failed
+                    🛑 Missing upload file
                 </div>"#
             )),
         )
@@ -268,10 +307,35 @@ pub(super) async fn run_upload_job(
 
 #[cfg(test)]
 mod tests {
-    use super::{run_upload_job, send_terminal_signal};
+    use super::{parse_scrubbed_checkbox_value, parse_scrubbed_upload_field, run_upload_job, send_terminal_signal};
     use crate::server::{ServerEvent, UploadProcessSignals, test_server_state};
     use std::path::PathBuf;
     use tokio::sync::mpsc;
+
+    #[test]
+    fn parse_scrubbed_checkbox_value_accepts_truthy_values() {
+        for value in ["true", "TRUE", " True ", "1", " on "] {
+            assert!(
+                parse_scrubbed_checkbox_value(value),
+                "expected {value:?} to enable scrub mode"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_scrubbed_checkbox_value_rejects_falsy_or_unknown_values() {
+        for value in ["", "false", "0", "off", "yes", "scrubbed"] {
+            assert!(
+                !parse_scrubbed_checkbox_value(value),
+                "expected {value:?} to disable scrub mode"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_scrubbed_upload_field_enables_when_field_cannot_be_read() {
+        assert!(parse_scrubbed_upload_field::<()>(Err(())));
+    }
 
     #[tokio::test]
     async fn run_upload_job_missing_upload_emits_failure_and_terminal_signal() {
@@ -331,6 +395,7 @@ mod tests {
                 Some("accounts.google.com".to_string()),
                 "upload.zip".to_string(),
                 PathBuf::from("/tmp/nonexistent-upload.zip"),
+                None,
             )
             .await;
         let signals = UploadProcessSignals::default();

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -196,7 +196,8 @@ async fn execute_unified_web_job(
             ..
         } => {
             let binding = BindingKey::try_new(format!("web-local-archive-{job_id}"))?;
-            let receiver = Receiver::try_from_with_scrub(Uri::File(path.clone()), *scrubbed_override, Some(filename))?;
+            let receiver =
+                Receiver::try_from_with_scrub(Uri::File(path.clone()), *scrubbed_override, Some(filename.as_str()))?;
             context
                 .inputs
                 .bind_bundle(binding.clone(), receiver, path.clone(), None);

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -189,12 +189,24 @@ async fn execute_unified_web_job(
         }));
 
     let input = match &request.input {
-        JobInput::LocalArchive { path, .. } => Input::Load {
-            uri: Uri::File(path.clone()),
-        },
+        JobInput::LocalArchive {
+            path,
+            filename,
+            scrubbed_override,
+            ..
+        } => {
+            let binding = BindingKey::try_new(format!("web-local-archive-{job_id}"))?;
+            let receiver = Receiver::try_from_with_scrub(Uri::File(path.clone()), *scrubbed_override, Some(filename))?;
+            context
+                .inputs
+                .bind_bundle(binding.clone(), receiver, path.clone(), None);
+            Input::LoadBinding { binding }
+        }
         JobInput::FromServiceLink { uri, .. } => {
             let binding = BindingKey::try_new(format!("web-service-link-{job_id}"))?;
-            context.inputs.bind_uri(binding.clone(), uri.clone(), None);
+            context
+                .inputs
+                .bind_uri_with_scrub(binding.clone(), uri.clone(), None, None, Some(source.to_string()));
             Input::LoadBinding { binding }
         }
         JobInput::FromRemoteHost {
@@ -1034,6 +1046,7 @@ mod tests {
                 filename: "upload.zip".to_string(),
                 path: "/tmp/upload.zip".into(),
                 cleanup_path: None,
+                scrubbed_override: None,
             },
         };
 
@@ -1067,6 +1080,7 @@ mod tests {
                 filename: "uploaded.zip".to_string(),
                 path: archive,
                 cleanup_path: Some(std::path::PathBuf::from("/tmp/unused-cleanup-path")),
+                scrubbed_override: None,
             },
         };
         let (tx, mut rx) = mpsc::channel(32);
@@ -1127,6 +1141,7 @@ mod tests {
                 filename: "upload.zip".to_string(),
                 path: "/tmp/upload.zip".into(),
                 cleanup_path: Some("/tmp/upload.zip".into()),
+                scrubbed_override: None,
             },
         };
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1113,6 +1113,7 @@ impl ServerState {
         account: Option<String>,
         filename: String,
         path: PathBuf,
+        scrubbed_override: Option<bool>,
     ) -> Option<JobRequest> {
         tracing::debug!("Pushing file upload id: {id}");
         let identifiers = Identifiers {
@@ -1130,6 +1131,7 @@ impl ServerState {
                     filename,
                     path: path.clone(),
                     cleanup_path: Some(path),
+                    scrubbed_override,
                 },
             },
         )
@@ -1452,6 +1454,7 @@ pub enum JobInput {
         filename: String,
         path: PathBuf,
         cleanup_path: Option<PathBuf>,
+        scrubbed_override: Option<bool>,
     },
     FromServiceLink {
         source: String,

--- a/templates/components/main.html
+++ b/templates/components/main.html
@@ -93,6 +93,13 @@
                         </div>
                         <div class="upload-progress-text" id="upload-progress-text">0%</div>
                     </div>
+                    <input-group class="margin-before">
+                        <label for="upload-scrubbed" class="form-label">
+                            <input type="hidden" name="scrubbed" value="false" />
+                            <input type="checkbox" id="upload-scrubbed" name="scrubbed" value="true" />
+                            Treat upload as scrubbed
+                        </label>
+                    </input-group>
                     <input id="upload-button" class="button" type="submit" value="Process" disabled />
                     <button
                         id="main-upload-process-button"

--- a/templates/components/main.html
+++ b/templates/components/main.html
@@ -95,7 +95,6 @@
                     </div>
                     <input-group class="margin-before">
                         <label for="upload-scrubbed" class="form-label">
-                            <input type="hidden" name="scrubbed" value="false" />
                             <input type="checkbox" id="upload-scrubbed" name="scrubbed" value="true" />
                             Treat upload as scrubbed
                         </label>

--- a/tests/scrub_debug_log_tests.rs
+++ b/tests/scrub_debug_log_tests.rs
@@ -1,0 +1,154 @@
+//! Debug-log assertions for scrub normalization (OpenSpec task 4.5).
+//! Runs in its own test binary so tracing capture is not shared with lib unit tests.
+
+use esdiag::data::Uri;
+use esdiag::processor::DataSource;
+use esdiag::receiver::{ReceiveRaw, Receiver};
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, OnceLock};
+use tracing_subscriber::{Layer, layer::SubscriberExt};
+use zip::{ZipWriter, write::SimpleFileOptions};
+
+struct CaptureLayer {
+    logs: Arc<Mutex<Vec<String>>>,
+}
+
+struct NodesSource;
+
+impl DataSource for NodesSource {
+    fn name() -> String {
+        "nodes".to_string()
+    }
+}
+
+impl<S> Layer<S> for CaptureLayer
+where
+    S: tracing::Subscriber,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let mut message = String::new();
+        let mut visitor = MessageVisitor(&mut message);
+        event.record(&mut visitor);
+        if !message.is_empty() {
+            self.logs.lock().expect("log capture lock").push(message);
+        }
+    }
+}
+
+struct MessageVisitor<'a>(&'a mut String);
+
+impl tracing::field::Visit for MessageVisitor<'_> {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.0.push_str(format!("{value:?}").trim_matches('"'));
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            self.0.push_str(value);
+        }
+    }
+}
+
+fn log_capture() -> Arc<Mutex<Vec<String>>> {
+    static CAPTURE: OnceLock<Arc<Mutex<Vec<String>>>> = OnceLock::new();
+    CAPTURE
+        .get_or_init(|| {
+            let logs = Arc::new(Mutex::new(Vec::new()));
+            let layer = CaptureLayer { logs: logs.clone() };
+            let subscriber = tracing_subscriber::registry::Registry::default().with(layer);
+            let _ = tracing::subscriber::set_global_default(subscriber);
+            logs
+        })
+        .clone()
+}
+
+fn write_scrubbed_nodes_zip(path: &PathBuf, nodes_json: &str) {
+    let file = std::fs::File::create(path).expect("create zip");
+    let mut zip = ZipWriter::new(file);
+    let options = SimpleFileOptions::default();
+    let prefix = "api-diagnostics-scrub-log-test";
+
+    zip.start_file(format!("{prefix}/diagnostic_manifest.json"), options)
+        .expect("manifest");
+    zip.write_all(
+        br#"{"mode":"full","product":"elasticsearch","type":"elasticsearch_diagnostic","runner":"cli","version":"9.1.3","timestamp":"2025-09-18T00:18:07.432Z"}"#,
+    )
+    .expect("manifest body");
+
+    zip.start_file(format!("{prefix}/version.json"), options)
+        .expect("version");
+    zip.write_all(
+        br#"{"name":"esdiag-node","cluster_name":"esdiag-cluster","cluster_uuid":"aukedefkRcGa0BT16uuuNQ","version":{"number":"9.1.3","build_flavor":"default","build_type":"docker","build_hash":"abc","build_date":"2025-01-01T00:00:00.000000000Z","build_snapshot":false,"lucene_version":"10.2.2","minimum_wire_compatibility_version":"8.19.0","minimum_index_compatibility_version":"8.0.0"},"tagline":"You Know, for Search"}"#,
+    )
+    .expect("version body");
+
+    zip.start_file(format!("{prefix}/nodes.json"), options).expect("nodes");
+    zip.write_all(nodes_json.as_bytes()).expect("nodes body");
+
+    zip.finish().expect("finish zip");
+}
+
+#[tokio::test]
+async fn scrubbed_read_emits_mode_and_file_unscrubbed_debug_logs() {
+    let logs = log_capture();
+    logs.lock().expect("log capture lock").clear();
+
+    const MALFORMED_IP: &str = "512.768.1024.1280";
+    const NODE_ID: &str = "aaaabbbbccccddddee0";
+    let nodes_json = format!(
+        r#"{{
+  "_nodes": {{"total": 1, "successful": 1, "failed": 0}},
+  "nodes": {{
+    "{NODE_ID}": {{
+      "name": "{NODE_ID}",
+      "transport_address": "{MALFORMED_IP}:19840",
+      "host": "{MALFORMED_IP}",
+      "ip": "{MALFORMED_IP}",
+      "version": "9.1.3",
+      "build_flavor": "default",
+      "build_hash": "abc",
+      "build_type": "docker",
+      "roles": ["data_hot", "master"],
+      "os": {{"refresh_interval_in_millis": 1000, "available_processors": 8, "allocated_processors": 8}},
+      "jvm": {{}},
+      "process": {{}},
+      "thread_pool": {{}}
+    }}
+  }}
+}}"#
+    );
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let zip_path = dir.path().join("synthetic-malformed-ips-test.zip");
+    write_scrubbed_nodes_zip(&zip_path, &nodes_json);
+
+    let receiver = Receiver::try_from_with_scrub(Uri::File(zip_path), Some(true), None).expect("receiver");
+    let archive = match receiver {
+        Receiver::ArchiveFile(r) => r,
+        _ => panic!("expected archive file receiver"),
+    };
+    archive.set_source_product("elasticsearch").expect("source product");
+
+    let _raw = archive.get_raw::<NodesSource>().await.expect("get raw nodes");
+
+    let captured = logs.lock().expect("log capture lock");
+    assert!(
+        captured
+            .iter()
+            .any(|line| line.contains("Scrub normalization enabled") && line.contains("explicit true")),
+        "expected mode-context log, got: {captured:?}"
+    );
+    assert!(
+        captured.iter().any(|line| line.contains("scrubbed mode")),
+        "expected scrubbed-mode file read log, got: {captured:?}"
+    );
+    assert!(
+        captured
+            .iter()
+            .any(|line| line.contains("Unscrubbed") && line.contains("nodes.json")),
+        "expected per-file unscrubbed count log, got: {captured:?}"
+    );
+}

--- a/tests/scrub_normalization_assertions.rs
+++ b/tests/scrub_normalization_assertions.rs
@@ -1,0 +1,335 @@
+//! Shared assertions for scrubbed IP normalization integration tests.
+//! Validates deterministic transform, valid IPv4 octets, and stable node-id → IP mapping
+//! across exported NDJSON streams.
+
+use serde_json::Value;
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::Path,
+};
+
+/// NDJSON exports that embed `node.id` with `node.host` / `node.ip` from node lookup.
+const NODE_IP_STREAMS: &[&str] = &[
+    "metrics-node-esdiag.ndjson",
+    "metrics-task-esdiag.ndjson",
+    "metrics-node.transport.actions-esdiag.ndjson",
+    "metrics-node.http.clients-esdiag.ndjson",
+    "metrics-node.discovery.cluster_applier-esdiag.ndjson",
+    "metrics-node.discovery.cluster_adaptive-esdiag.ndjson",
+    "metrics-ingest.pipeline-esdiag.ndjson",
+    "metrics-ingest.processor-esdiag.ndjson",
+    "metrics-shard-esdiag.ndjson",
+    "settings-node-esdiag.ndjson",
+];
+
+pub const SECOND_NODE_ID: &str = "syntheticSecondNode0123456789ab";
+
+#[derive(Clone, Debug)]
+pub struct ScrubFixtureExpectations {
+    pub normalized_by_node_id: HashMap<String, String>,
+    malformed_by_node_id: HashMap<String, String>,
+}
+
+impl ScrubFixtureExpectations {
+    pub fn malformed_ips(&self) -> impl Iterator<Item = &String> {
+        self.malformed_by_node_id.values()
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.normalized_by_node_id.len()
+    }
+}
+
+pub fn ensure_two_nodes_in_nodes_json(content: &str) -> String {
+    duplicate_nodes_object(content, "nodes")
+}
+
+pub fn ensure_two_nodes_in_nodes_stats_json(content: &str) -> String {
+    duplicate_nodes_object(content, "nodes")
+}
+
+pub fn ensure_two_nodes_in_tasks_json(content: &str) -> String {
+    duplicate_nodes_object(content, "nodes")
+}
+
+fn duplicate_nodes_object(content: &str, nodes_key: &str) -> String {
+    let mut value: Value = serde_json::from_str(content).expect("parse nodes object json");
+    let Some(nodes) = value.get_mut(nodes_key).and_then(Value::as_object_mut) else {
+        return content.to_string();
+    };
+    if nodes.len() >= 2 {
+        return serde_json::to_string(&value).expect("serialize nodes object json");
+    }
+
+    let first_node = nodes.values().next().expect("fixture node").clone();
+    nodes.insert(SECOND_NODE_ID.to_string(), first_node);
+    serde_json::to_string(&value).expect("serialize nodes object json")
+}
+
+pub fn malformed_ip_for_index(index: usize) -> String {
+    format!("512.768.{}.{}", 1024 + index, 1280 + index)
+}
+
+pub fn expected_normalized_ip(value: &str) -> String {
+    value
+        .split('.')
+        .map(|octet| octet.parse::<u16>().unwrap_or(0) % 255)
+        .map(|octet| octet.to_string())
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+pub fn strip_port(value: &str) -> &str {
+    let Some((ip, port)) = value.rsplit_once(':') else {
+        return value;
+    };
+    if ip.contains(':') || !port.chars().all(|c| c.is_ascii_digit()) {
+        return value;
+    }
+    ip
+}
+
+pub fn is_valid_ipv4(value: &str) -> bool {
+    let ip = strip_port(value);
+    let octets: Vec<u16> = ip.split('.').filter_map(|part| part.parse().ok()).collect();
+    octets.len() == 4 && octets.iter().all(|octet| *octet <= 255)
+}
+
+pub fn inject_malformed_ips_in_nodes_json(content: &str) -> (String, ScrubFixtureExpectations) {
+    let mut value: Value = serde_json::from_str(content).expect("parse nodes.json");
+    let mut normalized_by_node_id = HashMap::new();
+    let mut malformed_by_node_id = HashMap::new();
+
+    if let Some(nodes) = value.get_mut("nodes").and_then(Value::as_object_mut) {
+        let mut node_ids: Vec<_> = nodes.keys().cloned().collect();
+        node_ids.sort();
+
+        for (index, node_id) in node_ids.iter().enumerate() {
+            let malformed = malformed_ip_for_index(index);
+            let normalized = expected_normalized_ip(&malformed);
+            let node = nodes.get_mut(node_id).expect("node id from sorted keys");
+            if let Some(obj) = node.as_object_mut() {
+                obj.insert("ip".into(), Value::String(malformed.clone()));
+                obj.insert("host".into(), Value::String(malformed.clone()));
+                obj.insert("transport_address".into(), Value::String(format!("{malformed}:9300")));
+                if let Some(transport) = obj.get_mut("transport").and_then(Value::as_object_mut) {
+                    transport.insert("publish_address".into(), Value::String(format!("{malformed}:9300")));
+                }
+                let settings = obj
+                    .entry("settings")
+                    .or_insert_with(|| Value::Object(Default::default()));
+                if let Some(settings) = settings.as_object_mut() {
+                    let network_settings = settings
+                        .entry("network")
+                        .or_insert_with(|| Value::Object(Default::default()));
+                    if let Some(net) = network_settings.as_object_mut() {
+                        net.insert("publish_host".into(), Value::String(malformed.clone()));
+                    }
+                }
+            }
+            normalized_by_node_id.insert(node_id.clone(), normalized);
+            malformed_by_node_id.insert(node_id.clone(), malformed);
+        }
+    }
+
+    let expectations = ScrubFixtureExpectations {
+        normalized_by_node_id,
+        malformed_by_node_id,
+    };
+    (
+        serde_json::to_string(&value).expect("serialize nodes.json"),
+        expectations,
+    )
+}
+
+pub fn inject_malformed_ips_in_nodes_stats_json(content: &str, expectations: &ScrubFixtureExpectations) -> String {
+    let mut value: Value = serde_json::from_str(content).expect("parse nodes_stats.json");
+
+    if let Some(nodes) = value.get_mut("nodes").and_then(Value::as_object_mut) {
+        for (node_id, node) in nodes.iter_mut() {
+            let Some(malformed) = expectations.malformed_by_node_id.get(node_id) else {
+                continue;
+            };
+            if let Some(obj) = node.as_object_mut() {
+                obj.insert("ip".into(), Value::String(format!("{malformed}:9300")));
+                obj.insert("host".into(), Value::String(malformed.clone()));
+                obj.insert("transport_address".into(), Value::String(format!("{malformed}:9300")));
+            }
+        }
+    }
+
+    serde_json::to_string(&value).expect("serialize nodes_stats.json")
+}
+
+pub fn inject_malformed_ips_in_tasks_json(content: &str, expectations: &ScrubFixtureExpectations) -> String {
+    let mut value: Value = serde_json::from_str(content).expect("parse tasks.json");
+
+    if let Some(nodes) = value.get_mut("nodes").and_then(Value::as_object_mut) {
+        for (node_id, node) in nodes.iter_mut() {
+            let Some(malformed) = expectations.malformed_by_node_id.get(node_id) else {
+                continue;
+            };
+            if let Some(obj) = node.as_object_mut() {
+                obj.insert("ip".into(), Value::String(format!("{malformed}:9300")));
+                obj.insert("host".into(), Value::String(malformed.clone()));
+                obj.insert("transport_address".into(), Value::String(format!("{malformed}:9300")));
+            }
+        }
+    }
+
+    serde_json::to_string(&value).expect("serialize tasks.json")
+}
+
+pub fn assert_scrubbed_export(output_dir: &Path, expectations: &ScrubFixtureExpectations) {
+    let mut observed_by_node: HashMap<String, HashSet<String>> = HashMap::new();
+
+    for stream in NODE_IP_STREAMS {
+        let path = output_dir.join(stream);
+        if !path.exists() {
+            continue;
+        }
+
+        let content = fs::read_to_string(&path).unwrap_or_else(|err| {
+            panic!("read {}: {err}", path.display());
+        });
+
+        for (line_no, line) in content.lines().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let doc: Value = serde_json::from_str(line).unwrap_or_else(|err| {
+                panic!("parse {stream} line {}: {err}", line_no + 1);
+            });
+            let Some(node) = doc.get("node").and_then(Value::as_object) else {
+                continue;
+            };
+            let Some(node_id) = node.get("id").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(expected_ip) = expectations.normalized_by_node_id.get(node_id) else {
+                continue;
+            };
+
+            for field in ["host", "ip", "transport_address"] {
+                let Some(raw) = node.get(field).and_then(Value::as_str) else {
+                    continue;
+                };
+                assert_normalized_address_field(
+                    stream,
+                    line_no + 1,
+                    &format!("node.{field}"),
+                    raw,
+                    expected_ip,
+                    expectations,
+                );
+
+                observed_by_node
+                    .entry(node_id.to_string())
+                    .or_default()
+                    .insert(strip_port(raw).to_string());
+            }
+
+            if *stream == "settings-node-esdiag.ndjson"
+                && let Some(publish_host) = node
+                    .get("settings")
+                    .and_then(|settings| settings.get("network"))
+                    .and_then(|network| network.get("publish_host"))
+                    .and_then(Value::as_str)
+                && looks_like_dotted_quad(publish_host)
+            {
+                assert_normalized_address_field(
+                    stream,
+                    line_no + 1,
+                    "node.settings.network.publish_host",
+                    publish_host,
+                    expected_ip,
+                    expectations,
+                );
+            }
+        }
+    }
+
+    assert!(
+        expectations.node_count() >= 2,
+        "fixture must include at least two nodes to validate mapping isolation"
+    );
+    let distinct_expected: HashSet<_> = expectations.normalized_by_node_id.values().collect();
+    assert_eq!(
+        distinct_expected.len(),
+        expectations.node_count(),
+        "each node must have a distinct normalized IP in the fixture"
+    );
+
+    for (node_id, expected_ip) in &expectations.normalized_by_node_id {
+        let seen = observed_by_node.get(node_id).cloned().unwrap_or_default();
+        assert!(
+            seen.contains(expected_ip),
+            "expected normalized IP {expected_ip} for node_id={node_id} in at least one export stream, saw {seen:?}"
+        );
+        assert_eq!(
+            seen.len(),
+            1,
+            "node_id={node_id} should map to exactly one normalized IP across streams, saw {seen:?}"
+        );
+    }
+}
+
+fn looks_like_dotted_quad(value: &str) -> bool {
+    let ip = strip_port(value);
+    ip.split('.').count() == 4
+        && ip
+            .split('.')
+            .all(|part| !part.is_empty() && part.chars().all(|ch| ch.is_ascii_digit()))
+}
+
+fn assert_normalized_address_field(
+    stream: &str,
+    line_no: usize,
+    field_path: &str,
+    raw: &str,
+    expected_ip: &str,
+    expectations: &ScrubFixtureExpectations,
+) {
+    let normalized_field = strip_port(raw).to_string();
+    assert!(
+        is_valid_ipv4(raw),
+        "{stream} line {line_no} {field_path}={raw:?} is not valid IPv4"
+    );
+    for malformed in expectations.malformed_ips() {
+        assert!(
+            !raw.contains(malformed),
+            "{stream} line {line_no} {field_path} still contains malformed IP {malformed}"
+        );
+    }
+    assert_eq!(
+        &normalized_field, expected_ip,
+        "{stream} line {line_no} {field_path} mismatch"
+    );
+}
+
+pub fn assert_malformed_ips_preserved_in_node_metrics(output_dir: &Path, malformed: &str) {
+    let path = output_dir.join("metrics-node-esdiag.ndjson");
+    assert!(path.exists(), "expected {}", path.display());
+    let content = fs::read_to_string(&path).expect("read node metrics");
+    assert!(
+        content.contains(malformed),
+        "expected malformed IP {malformed} to remain when scrub is disabled"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distinct_malformed_ips_normalize_to_distinct_valid_ips() {
+        let mut normalized = HashSet::new();
+        for index in 0..4 {
+            let malformed = malformed_ip_for_index(index);
+            let fixed = expected_normalized_ip(&malformed);
+            assert!(is_valid_ipv4(&fixed));
+            assert!(normalized.insert(fixed));
+        }
+    }
+}

--- a/tests/scrubbed_normalization_tests.rs
+++ b/tests/scrubbed_normalization_tests.rs
@@ -1,0 +1,233 @@
+mod scrub_normalization_assertions;
+
+use esdiag::{
+    data::Uri,
+    exporter::DocumentExporter,
+    job::{
+        context::ExecutionContext,
+        executor::execute_with_context,
+        model::{BindingKey, ExportTarget, Input, Job, Process},
+    },
+    processor::Identifiers,
+    receiver::Receiver,
+};
+use scrub_normalization_assertions::{
+    ScrubFixtureExpectations, assert_malformed_ips_preserved_in_node_metrics, assert_scrubbed_export,
+    ensure_two_nodes_in_nodes_json, ensure_two_nodes_in_nodes_stats_json, ensure_two_nodes_in_tasks_json,
+    inject_malformed_ips_in_nodes_json, inject_malformed_ips_in_nodes_stats_json, inject_malformed_ips_in_tasks_json,
+};
+use std::{
+    fs,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+use tempfile::tempdir;
+use zip::{ZipArchive, ZipWriter, write::SimpleFileOptions};
+
+const GOLDEN_ARCHIVE: &str = "tests/archives/elasticsearch-api-diagnostics-9.3.3.zip";
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn build_synthetic_scrubbed_archive(out_zip: &Path) -> ScrubFixtureExpectations {
+    let golden = manifest_dir().join(GOLDEN_ARCHIVE);
+    let entries = [
+        "diagnostic_manifest.json",
+        "version.json",
+        "cluster_settings_defaults.json",
+        "cluster_settings.json",
+        "nodes.json",
+        "nodes_stats.json",
+        "tasks.json",
+    ];
+
+    let source_file = fs::File::open(&golden).expect("open golden esdiag test archive");
+    let mut source_archive = ZipArchive::new(source_file).expect("read golden archive");
+    let dest_file = fs::File::create(out_zip).expect("create synthetic scrubbed zip");
+    let mut dest_archive = ZipWriter::new(dest_file);
+    let options = SimpleFileOptions::default();
+
+    let mut expectations = None;
+
+    for entry in entries {
+        let mut content = String::new();
+        source_archive
+            .by_name(entry)
+            .unwrap_or_else(|_| panic!("missing {entry}"))
+            .read_to_string(&mut content)
+            .expect("read entry");
+
+        content = match entry {
+            "nodes.json" => {
+                let content = ensure_two_nodes_in_nodes_json(&content);
+                let (updated, exp) = inject_malformed_ips_in_nodes_json(&content);
+                expectations = Some(exp);
+                updated
+            }
+            "nodes_stats.json" => {
+                let content = ensure_two_nodes_in_nodes_stats_json(&content);
+                let exp = expectations
+                    .as_ref()
+                    .expect("nodes.json must be processed before nodes_stats.json");
+                inject_malformed_ips_in_nodes_stats_json(&content, exp)
+            }
+            "tasks.json" => {
+                let content = ensure_two_nodes_in_tasks_json(&content);
+                let exp = expectations
+                    .as_ref()
+                    .expect("nodes.json must be processed before tasks.json");
+                inject_malformed_ips_in_tasks_json(&content, exp)
+            }
+            _ => content,
+        };
+
+        dest_archive.start_file(entry, options).expect("start zip entry");
+        dest_archive.write_all(content.as_bytes()).expect("write zip entry");
+    }
+
+    dest_archive.finish().expect("finish synthetic scrubbed zip");
+    expectations.expect("nodes.json expectations")
+}
+
+async fn process_input_to_directory(
+    input: Uri,
+    scrubbed: Option<bool>,
+    auto_detect_filename: Option<&str>,
+) -> (tempfile::TempDir, PathBuf) {
+    let output = tempdir().expect("output tempdir");
+    let output_path = output.path().to_path_buf();
+
+    let receiver = Receiver::try_from_with_scrub(input, scrubbed, auto_detect_filename).expect("receiver");
+    let input_binding = BindingKey::try_new("scrub-test-input").expect("input binding");
+    let output_binding = BindingKey::try_new("scrub-test-output").expect("output binding");
+    let mut context = ExecutionContext::default();
+    context.inputs.bind_receiver(input_binding.clone(), receiver, None);
+    context.bind_document_exporter(
+        output_binding.clone(),
+        DocumentExporter::try_from(Uri::Directory(output_path.clone())).expect("exporter"),
+    );
+    let job = Job::try_new(
+        Identifiers::default(),
+        Input::LoadBinding { binding: input_binding },
+        None,
+        Some(Process {
+            selection: None,
+            export: ExportTarget::Binding {
+                binding: output_binding,
+            },
+        }),
+        None,
+    )
+    .expect("processing job");
+    let outcome = execute_with_context(job, context).await;
+    assert!(outcome.succeeded(), "processing failed: {:?}", outcome.stages);
+
+    (output, output_path)
+}
+
+#[tokio::test]
+async fn archive_export_normalizes_ips_with_stable_node_mapping() {
+    let golden = manifest_dir().join(GOLDEN_ARCHIVE);
+    if !golden.exists() {
+        return;
+    }
+
+    let fixture_dir = tempdir().expect("fixture tempdir");
+    let scrubbed_zip = fixture_dir.path().join("synthetic-malformed-ips-test.zip");
+    let expectations = build_synthetic_scrubbed_archive(&scrubbed_zip);
+
+    let (_output, output_path) = process_input_to_directory(Uri::File(scrubbed_zip), Some(true), None).await;
+    assert_scrubbed_export(&output_path, &expectations);
+}
+
+#[tokio::test]
+async fn directory_export_normalizes_ips_with_stable_node_mapping() {
+    let golden = manifest_dir().join(GOLDEN_ARCHIVE);
+    if !golden.exists() {
+        return;
+    }
+
+    let fixture_dir = tempdir().expect("fixture tempdir");
+    let scrubbed_zip = fixture_dir.path().join("synthetic-malformed-ips-test.zip");
+    let expectations = build_synthetic_scrubbed_archive(&scrubbed_zip);
+
+    let extract_dir = fixture_dir.path().join("synthetic-scrubbed-extracted");
+    {
+        let source_file = fs::File::open(&scrubbed_zip).expect("open synthetic zip");
+        let mut archive = ZipArchive::new(source_file).expect("read synthetic zip");
+        archive.extract(&extract_dir).expect("extract synthetic zip");
+    }
+
+    let (_output, output_path) = process_input_to_directory(Uri::Directory(extract_dir), Some(true), None).await;
+    assert_scrubbed_export(&output_path, &expectations);
+}
+
+#[tokio::test]
+async fn directory_auto_detect_enables_scrub_when_path_contains_scrubbed() {
+    let golden = manifest_dir().join(GOLDEN_ARCHIVE);
+    if !golden.exists() {
+        return;
+    }
+
+    let fixture_dir = tempdir().expect("fixture tempdir");
+    let scrubbed_zip = fixture_dir.path().join("synthetic-malformed-ips-test.zip");
+    let expectations = build_synthetic_scrubbed_archive(&scrubbed_zip);
+
+    let extract_dir = fixture_dir.path().join("extracted-scrubbed-api-diagnostics");
+    {
+        let source_file = fs::File::open(&scrubbed_zip).expect("open synthetic zip");
+        let mut archive = ZipArchive::new(source_file).expect("read synthetic zip");
+        archive.extract(&extract_dir).expect("extract synthetic zip");
+    }
+
+    let (_output, output_path) = process_input_to_directory(Uri::Directory(extract_dir), None, None).await;
+    assert_scrubbed_export(&output_path, &expectations);
+}
+
+#[tokio::test]
+async fn directory_with_scrub_disabled_preserves_malformed_ips() {
+    let golden = manifest_dir().join(GOLDEN_ARCHIVE);
+    if !golden.exists() {
+        return;
+    }
+
+    let fixture_dir = tempdir().expect("fixture tempdir");
+    let scrubbed_zip = fixture_dir.path().join("synthetic-malformed-ips-test.zip");
+    let expectations = build_synthetic_scrubbed_archive(&scrubbed_zip);
+    let malformed = expectations
+        .malformed_ips()
+        .next()
+        .expect("fixture malformed IP")
+        .clone();
+
+    let extract_dir = fixture_dir.path().join("synthetic-scrubbed-extracted");
+    {
+        let source_file = fs::File::open(&scrubbed_zip).expect("open synthetic zip");
+        let mut archive = ZipArchive::new(source_file).expect("read synthetic zip");
+        archive.extract(&extract_dir).expect("extract synthetic zip");
+    }
+
+    let (_output, output_path) = process_input_to_directory(Uri::Directory(extract_dir), Some(false), None).await;
+    assert_malformed_ips_preserved_in_node_metrics(&output_path, &malformed);
+}
+
+#[tokio::test]
+async fn processes_non_scrubbed_golden_archive_without_error() {
+    let archive = manifest_dir().join(GOLDEN_ARCHIVE);
+    if !archive.exists() {
+        return;
+    }
+
+    let (_output, output_path) = process_input_to_directory(Uri::File(archive), Some(false), None).await;
+    let node_metrics = output_path.join("metrics-node-esdiag.ndjson");
+    assert!(
+        node_metrics.exists(),
+        "expected metrics-node-esdiag.ndjson in {}",
+        output_path.display()
+    );
+
+    let content = fs::read_to_string(node_metrics).expect("read node metrics");
+    assert!(!content.trim().is_empty(), "golden archive should export node metrics");
+    assert!(content.contains("\"node\""));
+}

--- a/tests/scrubbed_normalization_tests.rs
+++ b/tests/scrubbed_normalization_tests.rs
@@ -30,8 +30,14 @@ fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
+fn golden_archive() -> PathBuf {
+    let path = manifest_dir().join(GOLDEN_ARCHIVE);
+    assert!(path.exists(), "missing test fixture: {}", path.display());
+    path
+}
+
 fn build_synthetic_scrubbed_archive(out_zip: &Path) -> ScrubFixtureExpectations {
-    let golden = manifest_dir().join(GOLDEN_ARCHIVE);
+    let golden = golden_archive();
     let entries = [
         "diagnostic_manifest.json",
         "version.json",
@@ -128,11 +134,6 @@ async fn process_input_to_directory(
 
 #[tokio::test]
 async fn archive_export_normalizes_ips_with_stable_node_mapping() {
-    let golden = manifest_dir().join(GOLDEN_ARCHIVE);
-    if !golden.exists() {
-        return;
-    }
-
     let fixture_dir = tempdir().expect("fixture tempdir");
     let scrubbed_zip = fixture_dir.path().join("synthetic-malformed-ips-test.zip");
     let expectations = build_synthetic_scrubbed_archive(&scrubbed_zip);
@@ -143,11 +144,6 @@ async fn archive_export_normalizes_ips_with_stable_node_mapping() {
 
 #[tokio::test]
 async fn directory_export_normalizes_ips_with_stable_node_mapping() {
-    let golden = manifest_dir().join(GOLDEN_ARCHIVE);
-    if !golden.exists() {
-        return;
-    }
-
     let fixture_dir = tempdir().expect("fixture tempdir");
     let scrubbed_zip = fixture_dir.path().join("synthetic-malformed-ips-test.zip");
     let expectations = build_synthetic_scrubbed_archive(&scrubbed_zip);
@@ -165,11 +161,6 @@ async fn directory_export_normalizes_ips_with_stable_node_mapping() {
 
 #[tokio::test]
 async fn directory_auto_detect_enables_scrub_when_path_contains_scrubbed() {
-    let golden = manifest_dir().join(GOLDEN_ARCHIVE);
-    if !golden.exists() {
-        return;
-    }
-
     let fixture_dir = tempdir().expect("fixture tempdir");
     let scrubbed_zip = fixture_dir.path().join("synthetic-malformed-ips-test.zip");
     let expectations = build_synthetic_scrubbed_archive(&scrubbed_zip);
@@ -187,11 +178,6 @@ async fn directory_auto_detect_enables_scrub_when_path_contains_scrubbed() {
 
 #[tokio::test]
 async fn directory_with_scrub_disabled_preserves_malformed_ips() {
-    let golden = manifest_dir().join(GOLDEN_ARCHIVE);
-    if !golden.exists() {
-        return;
-    }
-
     let fixture_dir = tempdir().expect("fixture tempdir");
     let scrubbed_zip = fixture_dir.path().join("synthetic-malformed-ips-test.zip");
     let expectations = build_synthetic_scrubbed_archive(&scrubbed_zip);
@@ -214,10 +200,7 @@ async fn directory_with_scrub_disabled_preserves_malformed_ips() {
 
 #[tokio::test]
 async fn processes_non_scrubbed_golden_archive_without_error() {
-    let archive = manifest_dir().join(GOLDEN_ARCHIVE);
-    if !archive.exists() {
-        return;
-    }
+    let archive = golden_archive();
 
     let (_output, output_path) = process_input_to_directory(Uri::File(archive), Some(false), None).await;
     let node_metrics = output_path.join("metrics-node-esdiag.ndjson");


### PR DESCRIPTION
## Summary

Receiver-stage normalization for scrubbed Elasticsearch API diagnostics. Malformed dotted-quad addresses from the support-diagnostics scrub utility (e.g. `463.386.302.467`) are rewritten to valid IPv4 via deterministic `octet % 255` before processors run, so `node.ip`, `node.host`, `transport_address`, and related fields ingest cleanly and node dashboards join correctly.

Rebased onto current `main` (`983d670`). OpenSpec change archived to `openspec/changes/archive/2026-06-04-normalize-malformed-scrubbed-ips/`; main spec synced at `openspec/specs/malformed-ip-normalization/spec.md`.

Operator docs: `docs/scrubbed-diagnostics.md`

## Problem

Scrubbed bundles can contain invalid IPv4 octets in address fields. These break Elasticsearch `ip` mappings and leave node summary views partially empty even when bulk ingest succeeds.

## Solution

- **Receiver-first:** normalization in archive and directory read paths; processors receive already-normalized JSON
- **Activation:** auto when filename/path contains `scrubbed`; manual via CLI `--scrubbed true|false` or upload checkbox
- **Transform:** per-octet `% 255`; preserve ports on `ip:port` fields; pure IP on `ip`/`host`
- **Node names:** 19-char lowercase hex scrubbed names → tier + last-4 suffix; existing `instance-…` rename unchanged
- **Lookup fallback:** exact node ID first, then an unambiguous node name; unresolved or ambiguous matches omit lookup-derived identity and tier metadata
- **Observability:** `tracing::debug` per normalized file with field count (no new telemetry)

## Upstream merge notes

Rebased with conflict resolution against recent `main` changes:

- Preserved upstream `RawResponse`, `LONG_RUNNING_REQUEST_TIMEOUT`, and `tracing::` logging
- Wired scrub mode through `job_runner` upload path (not legacy-only upload handler)
- Directory/archive `get_raw_response` returns normalized body inside `RawResponse`

## Ryan decision points

| Topic | Decision | Implementation |
|-------|----------|----------------|
| Default strategy | Receiver-only; no ingest-pipeline fallback | `receiver/archive/*`, `receiver/directory.rs` |
| Detection contract | Auto-detect when path/filename contains `scrubbed`; manual override available | `ScrubMode` in `receiver/mod.rs`; upload uses original filename |
| Override precedence | CLI and UI are separate channels; no cross-channel override | CLI: `--scrubbed BOOL`; UI: checkbox |
| Non-mangling guarantee | Non-scrubbed inputs pass through unchanged | Golden archive test + scrub-disabled regression test |
| Safety boundary | Explicit address fields only; no global malformed-IPv4 scan | Allowlist in `receiver/archive/scrub.rs`; hyphenated K8s hostnames not rewritten |
| Collision tolerance | `octet % 255` acceptable; deterministic output required | Modulo transform |
| Failure mode | Elasticsearch handles any remaining bad values; no dead-letter stream | — |
| Performance target | ≤ 20% RSS increase vs non-scrubbed baseline | Measured 98.9% on golden archive (validation gates doc) |
| Governance | No separate opt-in product flag; `--scrubbed false` disables when needed | — |
| Auditability | Debug logging only | `Unscrubbed N address fields in …` |

## Files / scope

**Allowlisted fields:** `ip`, `host`, `publish_host`, `bind_host`, `transport_address`, `publish_address`, `bound_address`, `local_address`, `remote_address`, `x_forwarded_for`. HTTP-client identifiers retain their original values and JSON types

**JSON scope:** all diagnostic `*.json` except `diagnostic_manifest.json` and `version.json`

**Key paths:** `src/receiver/archive/scrub.rs`, `archive/file.rs`, `archive/bytes.rs`, `directory.rs`, `receiver/mod.rs`, `main.rs`, `server/file_upload.rs`, `server/job_runner.rs`, `nodes/lookup.rs`, `nodes_stats/processor.rs`, integration tests under `tests/scrub_*`

## Non-goals

- No rewrite of hyphenated K8s hostnames (`ip-10-36-64-176…`)
- No change to Elastic support-diagnostics scrubber
- No committed customer diagnostic bundles
- No global free-text IP replacement

## Test plan

Deterministic (CI-safe):

```bash
cargo test --lib scrub
cargo test --test scrubbed_normalization_tests
cargo test --lib server::file_upload::tests
cargo test --lib processor::elasticsearch::nodes::lookup::tests
cargo test --test scrub_normalization_assertions
cargo clippy --workspace --all-targets
npx openspec validate
```

Targeted scrub normalization, upload, node lookup, and fixture integration tests passed. The upload suite includes a filename-injection regression that failed before the fix and passes afterward; a live-response browser smoke check confirmed literal filename rendering.

Optional environment-gated dev ingest: see `docs/scrubbed-diagnostics.md` and archived validation gates.

## Checklist

- [x] Rebased onto `main`
- [x] OpenSpec change archived (`check-archived` CI gate)
- [x] Main spec synced (`openspec/specs/malformed-ip-normalization/spec.md`)
- [x] CHANGELOG updated
- [ ] Contributor License Agreement signed (required for merge)


## AI assistance

Developed with assistance from Cursor (LLM-assisted editing and test scaffolding).
The author reviewed, modified, and validated all code and tests.
Commits use `Assisted-by: Cursor/Auto` (not `Co-authored-by`) per Elastic policy.

Review fixes and validation also contributed by Oh My Pi (github-copilot/gpt-6-astra).

Co-authored-by: Oh My Pi
