### PR TITLE
perf: optimize JSON deserialization I/O path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ published release notes, maintenance branches, and tagged history.
 
 ### Changed
 
+- Optimized archive processing: replaced `from_reader` with buffered `from_slice` deserialization and eliminated ZIP archive lock contention for 43-56% faster processing (#324). Peak memory increases proportionally to bundle size.
 - Increased the long-running collection request timeout so large Elasticsearch API payloads can finish returning.
 - Changed diagnostic manifests to record `requested_apis` including status, response time, and response size.
 - Moved the Tauri desktop app root under `desktop/` while keeping root-level `cargo tauri build` and desktop packaging workflows working.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,6 +1054,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1442,7 @@ dependencies = [
  "indexmap 2.14.0",
  "json-patch 4.2.0",
  "kibana-sync",
+ "libmimalloc-sys",
  "mimalloc",
  "pbkdf2",
  "portpicker",
@@ -2813,6 +2820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
+ "cty",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ futures = "0.3"
 indexmap = { version = "2.14.0", features = ["serde"] }
 json-patch = "4.2"
 kibana-sync = "0.2.0"
+libmimalloc-sys = { version = "0.1.49", features = ["extended"] }
 mimalloc = "0.1.52"
 tracing = "0.1"
 tracing-log = "0.2"

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -5,7 +5,7 @@ Copyright 2012-2025 Elasticsearch B.V.
 This document lists the licenses of the projects used in esdiag.
 
 ## Overview of licenses
-- [Apache License 2.0](#Apache-2.0) (227)
+- [Apache License 2.0](#Apache-2.0) (228)
 - [MIT License](#MIT) (72)
 - [Unicode License v3](#Unicode-3.0) (19)
 - [BSD 3-Clause "New" or "Revised" License](#BSD-3-Clause) (3)
@@ -3487,6 +3487,7 @@ Apache License 2.0
 - [crossbeam-deque]( https://github.com/crossbeam-rs/crossbeam ) 0.8.6
 - [crossbeam-epoch]( https://github.com/crossbeam-rs/crossbeam ) 0.9.18
 - [crossbeam-utils]( https://github.com/crossbeam-rs/crossbeam ) 0.8.21
+- [cty]( https://github.com/japaric/cty ) 0.2.2
 - [displaydoc]( https://github.com/yaahc/displaydoc ) 0.2.5
 - [either]( https://github.com/rayon-rs/either ) 1.16.0
 - [equivalent]( https://github.com/indexmap-rs/equivalent ) 1.0.2

--- a/src/main.rs
+++ b/src/main.rs
@@ -436,11 +436,24 @@ enum KeystoreCommands {
 const TOKIO_THREAD_STACK_SIZE: usize = 8 * 1024 * 1024;
 
 fn main() -> Result<()> {
+    configure_allocator();
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_stack_size(TOKIO_THREAD_STACK_SIZE)
         .build()?
         .block_on(async_main())
+}
+
+fn configure_allocator() {
+    // mimalloc v3 option index (not exposed as a constant in the Rust bindings).
+    // Verified against libmimalloc-sys 0.1.49 c_src/mimalloc/v3/include/mimalloc.h.
+    const MI_OPTION_PURGE_DELAY: i32 = 15;
+
+    // Return freed memory to the OS immediately instead of the default 10ms delay.
+    // Without this, mimalloc retains large arenas that inflate RSS in containers.
+    unsafe {
+        libmimalloc_sys::mi_option_set(MI_OPTION_PURGE_DELAY, 0);
+    }
 }
 
 async fn async_main() -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -449,7 +449,7 @@ fn configure_allocator() {
     // Verified against libmimalloc-sys 0.1.49 c_src/mimalloc/v3/include/mimalloc.h.
     const MI_OPTION_PURGE_DELAY: i32 = 15;
 
-    // Return freed memory to the OS immediately instead of the default 10ms delay.
+    // Return freed memory to the OS immediately instead of the default delay.
     // Without this, mimalloc retains large arenas that inflate RSS in containers.
     unsafe {
         libmimalloc_sys::mi_option_set(MI_OPTION_PURGE_DELAY, 0);

--- a/src/receiver/archive.rs
+++ b/src/receiver/archive.rs
@@ -14,6 +14,10 @@ use std::{
 use tokio::sync::{RwLock, mpsc};
 use zip::ZipArchive;
 
+// Cap pre-allocation from ZipFile::size() to avoid trusting unverified archive metadata.
+// Real files larger than this still work — read_to_end grows the Vec organically.
+pub(crate) const MAX_PREALLOC: usize = 256 * 1024 * 1024;
+
 mod bytes;
 mod file;
 
@@ -59,7 +63,7 @@ where
                     return;
                 }
             };
-            let mut buf = Vec::with_capacity(file.size() as usize);
+            let mut buf = Vec::with_capacity((file.size() as usize).min(MAX_PREALLOC));
             if let Err(e) = std::io::Read::read_to_end(&mut file, &mut buf) {
                 let _ = tx.blocking_send(Err(eyre::eyre!(e)));
                 return;

--- a/src/receiver/archive.rs
+++ b/src/receiver/archive.rs
@@ -7,7 +7,7 @@ use eyre::Result;
 use futures::stream::{self, BoxStream};
 use serde::de::DeserializeOwned;
 use std::{
-    io::{BufReader, Read, Seek},
+    io::{Read, Seek},
     path::PathBuf,
     sync::Arc,
 };
@@ -51,14 +51,25 @@ where
         };
 
         tracing::debug!("Streaming from archive: {}", filename);
-        let stream_result = match archive_guard.by_name(&filename) {
-            Ok(file) => {
-                let reader = BufReader::new(file);
-                let mut deserializer = serde_json::Deserializer::from_reader(reader);
-                T::deserialize_stream(&mut deserializer, tx.clone()).map_err(|e| eyre::eyre!(e.to_string()))
+        let buf = {
+            let mut file = match archive_guard.by_name(&filename) {
+                Ok(f) => f,
+                Err(e) => {
+                    let _ = tx.blocking_send(Err(eyre::eyre!(e)));
+                    return;
+                }
+            };
+            let mut buf = Vec::with_capacity(file.size() as usize);
+            if let Err(e) = std::io::Read::read_to_end(&mut file, &mut buf) {
+                let _ = tx.blocking_send(Err(eyre::eyre!(e)));
+                return;
             }
-            Err(e) => Err(eyre::eyre!(e)),
+            buf
         };
+        drop(archive_guard);
+        let mut deserializer = serde_json::Deserializer::from_slice(&buf);
+        let stream_result = T::deserialize_stream(&mut deserializer, tx.clone())
+            .map_err(|e| eyre::eyre!(e.to_string()));
 
         if let Err(e) = stream_result {
             tracing::error!("Error deserializing stream from archive: {}", e);

--- a/src/receiver/archive.rs
+++ b/src/receiver/archive.rs
@@ -18,6 +18,10 @@ use zip::ZipArchive;
 // Real files larger than this still work — read_to_end grows the Vec organically.
 pub(crate) const MAX_PREALLOC: usize = 256 * 1024 * 1024;
 
+pub(crate) fn capped_prealloc_capacity(zip_size: u64) -> usize {
+    zip_size.min(MAX_PREALLOC as u64) as usize
+}
+
 mod bytes;
 mod file;
 
@@ -63,7 +67,7 @@ where
                     return;
                 }
             };
-            let mut buf = Vec::with_capacity((file.size() as usize).min(MAX_PREALLOC));
+            let mut buf = Vec::with_capacity(capped_prealloc_capacity(file.size()));
             if let Err(e) = std::io::Read::read_to_end(&mut file, &mut buf) {
                 let _ = tx.blocking_send(Err(eyre::eyre!(e)));
                 return;
@@ -72,8 +76,8 @@ where
         };
         drop(archive_guard);
         let mut deserializer = serde_json::Deserializer::from_slice(&buf);
-        let stream_result = T::deserialize_stream(&mut deserializer, tx.clone())
-            .map_err(|e| eyre::eyre!(e.to_string()));
+        let stream_result =
+            T::deserialize_stream(&mut deserializer, tx.clone()).map_err(|e| eyre::eyre!(e.to_string()));
 
         if let Err(e) = stream_result {
             tracing::error!("Error deserializing stream from archive: {}", e);
@@ -257,6 +261,12 @@ mod tests {
         let mut archive = ZipArchive::new(Cursor::new(archive_data)).unwrap();
         let result = resolve_archive_path(None, &mut archive, "missing.json");
         assert!(result.unwrap_err().to_string().contains("File not found"));
+    }
+
+    #[test]
+    fn capped_prealloc_capacity_caps_before_casting_to_usize() {
+        assert_eq!(capped_prealloc_capacity(42), 42);
+        assert_eq!(capped_prealloc_capacity(u64::MAX), MAX_PREALLOC);
     }
 
     #[test]

--- a/src/receiver/archive/bytes.rs
+++ b/src/receiver/archive/bytes.rs
@@ -128,7 +128,7 @@ impl std::fmt::Display for ArchiveBytesReceiver {
 impl ArchiveBytesReceiver {
     pub(crate) fn clone_for_subdir(&self, work_dir: &str) -> Self {
         Self {
-            archive: self.archive.clone(),
+            bytes: self.bytes.clone(),
             subdir: Some(PathBuf::from(work_dir)),
             source_product: Arc::new(OnceLock::new()),
         }

--- a/src/receiver/archive/bytes.rs
+++ b/src/receiver/archive/bytes.rs
@@ -59,12 +59,13 @@ impl Receive for ArchiveBytesReceiver {
             match resolve_archive_path(self.subdir.as_ref(), &mut *archive, &source_path) {
                 Ok(filename) => {
                     tracing::debug!("Reading {}", filename);
-                    let file = match archive.by_name(&filename) {
+                    let mut file = match archive.by_name(&filename) {
                         Ok(file) => file,
                         Err(_) => return Err(eyre!("Failed to read file {filename} from archive")),
                     };
-                    let reader = BufReader::new(file);
-                    let data: T = serde_json::from_reader(reader)?;
+                    let mut buf = Vec::with_capacity(file.size() as usize);
+                    std::io::Read::read_to_end(&mut file, &mut buf)?;
+                    let data: T = serde_json::from_slice(&buf)?;
                     return Ok(data);
                 }
                 Err(e) => {
@@ -135,12 +136,13 @@ impl ArchiveBytesReceiver {
         let mut archive = self.archive.write().await;
         let filename = resolve_archive_path(self.subdir.as_ref(), &mut *archive, filename)?;
         tracing::debug!("Reading bundle file {}", filename);
-        let file = match archive.by_name(&filename) {
+        let mut file = match archive.by_name(&filename) {
             Ok(file) => file,
             Err(_) => return Err(eyre!("Failed to read file {filename} from archive")),
         };
-        let reader = BufReader::new(file);
-        serde_json::from_reader(reader).map_err(Into::into)
+        let mut buf = Vec::with_capacity(file.size() as usize);
+        std::io::Read::read_to_end(&mut file, &mut buf)?;
+        serde_json::from_slice(&buf).map_err(Into::into)
     }
 
     pub fn set_source_product(&self, product: &'static str) -> Result<()> {

--- a/src/receiver/archive/bytes.rs
+++ b/src/receiver/archive/bytes.rs
@@ -67,7 +67,7 @@ impl Receive for ArchiveBytesReceiver {
                         Ok(file) => file,
                         Err(_) => return Err(eyre!("Failed to read file {filename} from archive")),
                     };
-                    let mut buf = Vec::with_capacity(file.size() as usize);
+                    let mut buf = Vec::with_capacity((file.size() as usize).min(super::MAX_PREALLOC));
                     std::io::Read::read_to_end(&mut file, &mut buf)?;
                     let data: T = serde_json::from_slice(&buf)?;
                     return Ok(data);
@@ -145,7 +145,7 @@ impl ArchiveBytesReceiver {
             Ok(file) => file,
             Err(_) => return Err(eyre!("Failed to read file {filename} from archive")),
         };
-        let mut buf = Vec::with_capacity(file.size() as usize);
+        let mut buf = Vec::with_capacity((file.size() as usize).min(super::MAX_PREALLOC));
         std::io::Read::read_to_end(&mut file, &mut buf)?;
         serde_json::from_slice(&buf).map_err(Into::into)
     }

--- a/src/receiver/archive/bytes.rs
+++ b/src/receiver/archive/bytes.rs
@@ -17,17 +17,21 @@ use std::{
     sync::Arc,
     sync::OnceLock,
 };
-use tokio::sync::RwLock;
 use zip::ZipArchive;
 
 type ArchiveCursor = ZipArchive<BufReader<Cursor<Bytes>>>;
-type ArchivePointer = Arc<RwLock<ArchiveCursor>>;
 
 #[derive(Clone)]
 pub struct ArchiveBytesReceiver {
-    archive: ArchivePointer,
+    bytes: Bytes,
     subdir: Option<PathBuf>,
     source_product: Arc<OnceLock<&'static str>>,
+}
+
+impl ArchiveBytesReceiver {
+    fn open_archive(&self) -> Result<ArchiveCursor> {
+        ZipArchive::new(BufReader::new(Cursor::new(self.bytes.clone()))).map_err(Into::into)
+    }
 }
 
 /// A receiver for the Elastic Uploader service (https://upload.elastic.co).
@@ -50,13 +54,13 @@ impl Receive for ArchiveBytesReceiver {
     where
         T: DataSource + DeserializeOwned,
     {
-        let mut archive = self.archive.write().await;
+        let mut archive = self.open_archive()?;
         let ctx = self.source_context()?;
         let source_paths = T::candidate_source_file_paths(&ctx)?;
         let mut last_resolve_error = None;
 
         for source_path in source_paths {
-            match resolve_archive_path(self.subdir.as_ref(), &mut *archive, &source_path) {
+            match resolve_archive_path(self.subdir.as_ref(), &mut archive, &source_path) {
                 Ok(filename) => {
                     tracing::debug!("Reading {}", filename);
                     let mut file = match archive.by_name(&filename) {
@@ -87,7 +91,8 @@ impl Receive for ArchiveBytesReceiver {
         T::Item: DeserializeOwned + Send + 'static,
     {
         let ctx = self.source_context()?;
-        super::get_stream_from_archive::<BufReader<Cursor<Bytes>>, T>(self.archive.clone(), self.subdir.clone(), ctx)
+        let archive = Arc::new(tokio::sync::RwLock::new(self.open_archive()?));
+        super::get_stream_from_archive::<BufReader<Cursor<Bytes>>, T>(archive, self.subdir.clone(), ctx)
             .await
     }
 }
@@ -105,9 +110,9 @@ impl TryFrom<Bytes> for ArchiveBytesReceiver {
 
     fn try_from(bytes: Bytes) -> Result<Self> {
         tracing::debug!("Using in-memory archive");
-        let archive = ZipArchive::new(BufReader::new(Cursor::new(bytes)))?;
+        ZipArchive::new(BufReader::new(Cursor::new(bytes.clone())))?;
         Ok(Self {
-            archive: Arc::new(RwLock::new(archive)),
+            bytes,
             subdir: None,
             source_product: Arc::new(OnceLock::new()),
         })
@@ -133,8 +138,8 @@ impl ArchiveBytesReceiver {
     where
         T: DeserializeOwned,
     {
-        let mut archive = self.archive.write().await;
-        let filename = resolve_archive_path(self.subdir.as_ref(), &mut *archive, filename)?;
+        let mut archive = self.open_archive()?;
+        let filename = resolve_archive_path(self.subdir.as_ref(), &mut archive, filename)?;
         tracing::debug!("Reading bundle file {}", filename);
         let mut file = match archive.by_name(&filename) {
             Ok(file) => file,

--- a/src/receiver/archive/bytes.rs
+++ b/src/receiver/archive/bytes.rs
@@ -67,7 +67,7 @@ impl Receive for ArchiveBytesReceiver {
                         Ok(file) => file,
                         Err(_) => return Err(eyre!("Failed to read file {filename} from archive")),
                     };
-                    let mut buf = Vec::with_capacity((file.size() as usize).min(super::MAX_PREALLOC));
+                    let mut buf = Vec::with_capacity(super::capped_prealloc_capacity(file.size()));
                     std::io::Read::read_to_end(&mut file, &mut buf)?;
                     let data: T = serde_json::from_slice(&buf)?;
                     return Ok(data);
@@ -92,8 +92,7 @@ impl Receive for ArchiveBytesReceiver {
     {
         let ctx = self.source_context()?;
         let archive = Arc::new(tokio::sync::RwLock::new(self.open_archive()?));
-        super::get_stream_from_archive::<BufReader<Cursor<Bytes>>, T>(archive, self.subdir.clone(), ctx)
-            .await
+        super::get_stream_from_archive::<BufReader<Cursor<Bytes>>, T>(archive, self.subdir.clone(), ctx).await
     }
 }
 
@@ -145,7 +144,7 @@ impl ArchiveBytesReceiver {
             Ok(file) => file,
             Err(_) => return Err(eyre!("Failed to read file {filename} from archive")),
         };
-        let mut buf = Vec::with_capacity((file.size() as usize).min(super::MAX_PREALLOC));
+        let mut buf = Vec::with_capacity(super::capped_prealloc_capacity(file.size()));
         std::io::Read::read_to_end(&mut file, &mut buf)?;
         serde_json::from_slice(&buf).map_err(Into::into)
     }

--- a/src/receiver/archive/file.rs
+++ b/src/receiver/archive/file.rs
@@ -73,14 +73,16 @@ impl Receive for ArchiveFileReceiver {
             Ok(archive) => {
                 let is_empty = archive.is_empty();
                 if tracing::enabled!(tracing::Level::TRACE) {
-                    let file_names: Vec<String> =
-                        archive.file_names().map(|name| name.to_string()).collect();
+                    let file_names: Vec<String> = archive.file_names().map(|name| name.to_string()).collect();
                     tracing::trace!("Files in archive: {:?}", file_names);
                 }
                 tracing::debug!("Archive {} is valid: {}", &self.filename, !is_empty);
                 !is_empty
             }
-            Err(_) => false,
+            Err(e) => {
+                tracing::debug!("Archive {} is not connected: {}", &self.filename, e);
+                false
+            }
         }
     }
 
@@ -103,7 +105,7 @@ impl Receive for ArchiveFileReceiver {
                 Ok(filename) => {
                     tracing::debug!("Reading {}", filename);
                     let mut file = archive.by_name(&filename)?;
-                    let mut buf = Vec::with_capacity((file.size() as usize).min(super::MAX_PREALLOC));
+                    let mut buf = Vec::with_capacity(super::capped_prealloc_capacity(file.size()));
                     std::io::Read::read_to_end(&mut file, &mut buf)?;
                     let data: T = serde_json::from_slice(&buf)?;
                     return Ok(data);
@@ -212,7 +214,7 @@ impl ArchiveFileReceiver {
         let filename = resolve_archive_path(self.subdir.as_ref(), &mut archive, filename)?;
         tracing::debug!("Reading bundle file {}", filename);
         let mut file = archive.by_name(&filename)?;
-        let mut buf = Vec::with_capacity((file.size() as usize).min(super::MAX_PREALLOC));
+        let mut buf = Vec::with_capacity(super::capped_prealloc_capacity(file.size()));
         std::io::Read::read_to_end(&mut file, &mut buf)?;
         serde_json::from_slice(&buf).map_err(Into::into)
     }

--- a/src/receiver/archive/file.rs
+++ b/src/receiver/archive/file.rs
@@ -196,7 +196,7 @@ impl std::fmt::Display for ArchiveFileReceiver {
 impl ArchiveFileReceiver {
     pub(crate) fn clone_for_subdir(&self, work_dir: &str) -> Self {
         Self {
-            archive: self.archive.clone(),
+            path: self.path.clone(),
             filename: self.filename.clone(),
             subdir: Some(PathBuf::from(work_dir)),
             modified_date: self.modified_date,

--- a/src/receiver/archive/file.rs
+++ b/src/receiver/archive/file.rs
@@ -18,16 +18,22 @@ use std::{
     sync::OnceLock,
     time::SystemTime,
 };
-use tokio::sync::RwLock;
 use zip::ZipArchive;
 
 #[derive(Clone)]
 pub struct ArchiveFileReceiver {
-    archive: Arc<RwLock<ZipArchive<File>>>,
+    path: PathBuf,
     filename: String,
     subdir: Option<PathBuf>,
     modified_date: SystemTime,
     source_product: Arc<OnceLock<&'static str>>,
+}
+
+impl ArchiveFileReceiver {
+    fn open_archive(&self) -> Result<ZipArchive<File>> {
+        let file = File::open(&self.path)?;
+        ZipArchive::new(file).map_err(Into::into)
+    }
 }
 
 impl TryFrom<PathBuf> for ArchiveFileReceiver {
@@ -38,11 +44,11 @@ impl TryFrom<PathBuf> for ArchiveFileReceiver {
         match path.is_file() {
             true => {
                 tracing::debug!("File is valid: {}", path.display());
-                let file = File::open(path)?;
+                let file = File::open(&path)?;
                 let modified_date = file.metadata()?.modified()?;
-                let archive = ZipArchive::new(file)?;
+                ZipArchive::new(file)?;
                 Ok(Self {
-                    archive: Arc::new(RwLock::new(archive)),
+                    path,
                     modified_date,
                     filename,
                     subdir: None,
@@ -63,14 +69,19 @@ impl Receive for ArchiveFileReceiver {
     }
 
     async fn is_connected(&self) -> bool {
-        let archive = self.archive.read().await;
-        let is_empty = archive.is_empty();
-        if tracing::enabled!(tracing::Level::TRACE) {
-            let file_names: Vec<String> = archive.file_names().map(|name| name.to_string()).collect();
-            tracing::trace!("Files in archive: {:?}", file_names);
+        match self.open_archive() {
+            Ok(archive) => {
+                let is_empty = archive.is_empty();
+                if tracing::enabled!(tracing::Level::TRACE) {
+                    let file_names: Vec<String> =
+                        archive.file_names().map(|name| name.to_string()).collect();
+                    tracing::trace!("Files in archive: {:?}", file_names);
+                }
+                tracing::debug!("Archive {} is valid: {}", &self.filename, !is_empty);
+                !is_empty
+            }
+            Err(_) => false,
         }
-        tracing::debug!("Archive {} is valid: {}", &self.filename, !is_empty);
-        !is_empty
     }
 
     fn filename(&self) -> Option<String> {
@@ -82,13 +93,13 @@ impl Receive for ArchiveFileReceiver {
     where
         T: DeserializeOwned + DataSource,
     {
-        let mut archive = self.archive.write().await;
+        let mut archive = self.open_archive()?;
         let ctx = self.source_context()?;
         let source_paths = T::candidate_source_file_paths(&ctx)?;
         let mut last_resolve_error = None;
 
         for source_path in source_paths {
-            match resolve_archive_path(self.subdir.as_ref(), &mut *archive, &source_path) {
+            match resolve_archive_path(self.subdir.as_ref(), &mut archive, &source_path) {
                 Ok(filename) => {
                     tracing::debug!("Reading {}", filename);
                     let mut file = archive.by_name(&filename)?;
@@ -116,7 +127,8 @@ impl Receive for ArchiveFileReceiver {
         T::Item: DeserializeOwned + Send + 'static,
     {
         let ctx = self.source_context()?;
-        super::get_stream_from_archive::<File, T>(self.archive.clone(), self.subdir.clone(), ctx).await
+        let archive = Arc::new(tokio::sync::RwLock::new(self.open_archive()?));
+        super::get_stream_from_archive::<File, T>(archive, self.subdir.clone(), ctx).await
     }
 }
 
@@ -132,13 +144,13 @@ impl ReceiveRaw for ArchiveFileReceiver {
     where
         T: DataSource,
     {
-        let mut archive = self.archive.write().await;
+        let mut archive = self.open_archive()?;
         let ctx = self.source_context()?;
         let source_paths = T::candidate_source_file_paths(&ctx)?;
         let mut last_resolve_error = None;
 
         for source_path in source_paths {
-            match resolve_archive_path(self.subdir.as_ref(), &mut *archive, &source_path) {
+            match resolve_archive_path(self.subdir.as_ref(), &mut archive, &source_path) {
                 Ok(filename) => {
                     tracing::debug!("Reading {}", filename);
                     let file = archive.by_name(&filename)?;
@@ -196,8 +208,8 @@ impl ArchiveFileReceiver {
     where
         T: DeserializeOwned,
     {
-        let mut archive = self.archive.write().await;
-        let filename = resolve_archive_path(self.subdir.as_ref(), &mut *archive, filename)?;
+        let mut archive = self.open_archive()?;
+        let filename = resolve_archive_path(self.subdir.as_ref(), &mut archive, filename)?;
         tracing::debug!("Reading bundle file {}", filename);
         let mut file = archive.by_name(&filename)?;
         let mut buf = Vec::with_capacity(file.size() as usize);

--- a/src/receiver/archive/file.rs
+++ b/src/receiver/archive/file.rs
@@ -103,7 +103,7 @@ impl Receive for ArchiveFileReceiver {
                 Ok(filename) => {
                     tracing::debug!("Reading {}", filename);
                     let mut file = archive.by_name(&filename)?;
-                    let mut buf = Vec::with_capacity(file.size() as usize);
+                    let mut buf = Vec::with_capacity((file.size() as usize).min(super::MAX_PREALLOC));
                     std::io::Read::read_to_end(&mut file, &mut buf)?;
                     let data: T = serde_json::from_slice(&buf)?;
                     return Ok(data);
@@ -212,7 +212,7 @@ impl ArchiveFileReceiver {
         let filename = resolve_archive_path(self.subdir.as_ref(), &mut archive, filename)?;
         tracing::debug!("Reading bundle file {}", filename);
         let mut file = archive.by_name(&filename)?;
-        let mut buf = Vec::with_capacity(file.size() as usize);
+        let mut buf = Vec::with_capacity((file.size() as usize).min(super::MAX_PREALLOC));
         std::io::Read::read_to_end(&mut file, &mut buf)?;
         serde_json::from_slice(&buf).map_err(Into::into)
     }

--- a/src/receiver/archive/file.rs
+++ b/src/receiver/archive/file.rs
@@ -91,9 +91,10 @@ impl Receive for ArchiveFileReceiver {
             match resolve_archive_path(self.subdir.as_ref(), &mut *archive, &source_path) {
                 Ok(filename) => {
                     tracing::debug!("Reading {}", filename);
-                    let file = archive.by_name(&filename)?;
-                    let reader = BufReader::new(file);
-                    let data: T = serde_json::from_reader(reader)?;
+                    let mut file = archive.by_name(&filename)?;
+                    let mut buf = Vec::with_capacity(file.size() as usize);
+                    std::io::Read::read_to_end(&mut file, &mut buf)?;
+                    let data: T = serde_json::from_slice(&buf)?;
                     return Ok(data);
                 }
                 Err(e) => {
@@ -198,9 +199,10 @@ impl ArchiveFileReceiver {
         let mut archive = self.archive.write().await;
         let filename = resolve_archive_path(self.subdir.as_ref(), &mut *archive, filename)?;
         tracing::debug!("Reading bundle file {}", filename);
-        let file = archive.by_name(&filename)?;
-        let reader = BufReader::new(file);
-        serde_json::from_reader(reader).map_err(Into::into)
+        let mut file = archive.by_name(&filename)?;
+        let mut buf = Vec::with_capacity(file.size() as usize);
+        std::io::Read::read_to_end(&mut file, &mut buf)?;
+        serde_json::from_slice(&buf).map_err(Into::into)
     }
 
     pub fn set_source_product(&self, product: &'static str) -> Result<()> {


### PR DESCRIPTION
## Summary

- Use `from_slice` instead of `from_reader` for JSON deserialization — eliminates per-byte I/O processing overhead in serde_json's `IoRead` adapter, the dominant bottleneck (~47% wall-time improvement)
- Open independent ZIP archive handles per access instead of contending on a shared `Arc<RwLock<ZipArchive>>` — eliminates lock contention, ~7% additional improvement with tighter variance
- Cap `Vec::with_capacity` pre-allocation from ZIP metadata to 256 MB to avoid trusting unverified archive sizes

**Combined result: 43-56% wall-time improvement** validated on both macOS (M4 Pro, arm64) and Linux (x86_64, 32-core). Output correctness validated — identical document counts and content on both test bundles.

Each commit is independently buildable and all tests pass at every point.

### Benchmark results

5 iterations per configuration, sequential, median reported.

**macOS (M4 Pro, arm64) — large bundle (521 MB):**

| Configuration | Wall (median) | RSS (median) | Wall Δ vs baseline |
|---|---|---|---|
| Baseline (main) | 16.88s | 1355 MB | — |
| from_slice only | 8.97s | 3534 MB | -47% |
| from_slice + parallel ZIP | **7.44s** | 3358 MB | **-56%** |

**Linux (x86_64, 32-core, 124 GB) — combined stack:**

| Configuration | Large wall | Large RSS | Medium wall | Medium RSS |
|---|---|---|---|---|
| Baseline | 17.89s | 1134 MB | 5.10s | 626 MB |
| All commits | **9.50s** | 3239 MB | **2.93s** | 879 MB |
| **Improvement** | **-47%** | +186% | **-43%** | +40% |

### RSS trade-off

The `from_slice` approach increases peak RSS because decompressed file contents are held in memory during parsing. On the large bundle: ~3.2 GB vs ~1.1 GB. On the medium bundle: ~880 MB vs ~630 MB. This is proportional to the data being processed and acceptable for a batch CLI tool. Sequential processing of large files was tested as an RSS mitigation (~260 MB savings) but the wall-time cost (~9%) was not worth it.

### Context

Follow-up to the simd-json investigation in #324. The real bottleneck was not the JSON parser — it was `serde_json::from_reader`'s `IoRead` adapter processing input one byte at a time. Confirmed via stack sampling (macOS `sample`) and kernel-level syscall tracing (bpftrace on Linux). Full investigation notes in the issue comment.

During investigation, jemalloc was also evaluated as a mimalloc replacement — it showed ~10% lower RSS and eliminated the allocation fragmentation that caused #332's regression, but is not included in this PR. Findings are documented in the issue comment for reference.

Supersedes #332 (metadata value caching), which showed 0% wall-time improvement and 67% RSS regression at production scale.

## Test plan

- [x] All existing tests pass (`cargo test`)
- [x] Output correctness: identical doc counts and content on both test bundles (87,936 and 759,775 docs)
- [x] Benchmarked on macOS (arm64) and Linux (x86_64)
- [x] Profiled: macOS `sample` confirms per-byte I/O functions eliminated; bpftrace confirms bottleneck is application-level