### PR TITLE
[0.15] Fix quoted Service Link curl parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ published release notes, maintenance branches, and tagged history.
 
 - Fixed Elasticsearch node stats processing to preserve lookup-enriched node identity fields.
 - Fixed Elastic Cloud and GovCloud host normalization to use the documented `_main` single-resource reference.
+- Fixed Service Link curl parsing to remove single, double, and escaped quotes from pasted URLs and values (#326).
 
 ## [0.14] - 2026-02-25
 

--- a/templates/components/advanced.html
+++ b/templates/components/advanced.html
@@ -520,26 +520,7 @@
                         xhr.send(formData);
                     });
 
-                    const parseToken = (cmd) => {
-                        const token = cmd.match(/Authorization(?: Token)?:\s*([^ '"]+[^ '"])/);
-                        return token ? token[1] : null;
-                    };
-
-                    const parseFilename = (cmd) => {
-                        const filename =
-                            cmd.match(/File name:\s*(\S+)/) ||
-                            cmd.match(/-o\s+['"]([^'"]+)['"]/) ||
-                            cmd.match(/-o\s+(\S+)/) ||
-                            cmd.match(/--output\s+['"]([^'"]+)['"]/) ||
-                            cmd.match(/--output\s+(\S+)/);
-                        return filename ? filename[1] : null;
-                    };
-
-                    const parseUrl = (cmd) => {
-                        const match = cmd.match(/https?:\/\/\S+/);
-                        const url = match ? match[0].replace(/\.$/, "") : null;
-                        return url;
-                    };
+                    {% include "components/service_link_parser.js" %}
                 </script>
             </div>
 

--- a/templates/components/jobs.html
+++ b/templates/components/jobs.html
@@ -1248,26 +1248,7 @@
             xhr.send(formData);
         });
 
-        const parseToken = (cmd) => {
-            const token = cmd.match(/Authorization(?: Token)?:\s*([^ '"]+[^ '"])/);
-            return token ? token[1] : null;
-        };
-
-        const parseFilename = (cmd) => {
-            const filename =
-                cmd.match(/File name:\s*(\S+)/) ||
-                cmd.match(/-o\s+['"]([^'"]+)['"]/) ||
-                cmd.match(/-o\s+(\S+)/) ||
-                cmd.match(/--output\s+['"]([^'"]+)['"]/) ||
-                cmd.match(/--output\s+(\S+)/);
-            return filename ? filename[1] : null;
-        };
-
-        const parseUrl = (cmd) => {
-            const match = cmd.match(/https?:\/\/\S+/);
-            const url = match ? match[0].replace(/\.$/, "") : null;
-            return url;
-        };
+        {% include "components/service_link_parser.js" %}
     </script>
     {% if show_keystore_bootstrap %}
     <div

--- a/templates/components/main.html
+++ b/templates/components/main.html
@@ -325,29 +325,7 @@
                         data-attr:disabled="$loading || !$service_link.url || !$service_link.token"
                     />
                     <script>
-                        // Extract token from Authorization header
-                        const parseToken = (cmd) => {
-                            const token = cmd.match(/Authorization(?: Token)?:\s*([^ '"]+[^ '"])/);
-                            return token ? token[1] : null;
-                        };
-
-                        // Extract filename from -o option
-                        const parseFilename = (cmd) => {
-                            const filename =
-                                cmd.match(/File name:\s*(\S+)/) ||
-                                cmd.match(/-o\s+['"]([^'"]+)['"]/) ||
-                                cmd.match(/-o\s+(\S+)/) ||
-                                cmd.match(/--output\s+['"]([^'"]+)['"]/) ||
-                                cmd.match(/--output\s+(\S+)/);
-                            return filename ? filename[1] : null;
-                        };
-
-                        // Extract URL
-                        const parseUrl = (cmd) => {
-                            const match = cmd.match(/https?:\/\/\S+/);
-                            const url = match ? match[0].replace(/\.$/, "") : null;
-                            return url;
-                        };
+                        {% include "components/service_link_parser.js" %}
                     </script>
                 </form>
 

--- a/templates/components/service_link_parser.js
+++ b/templates/components/service_link_parser.js
@@ -1,0 +1,55 @@
+function cleanServiceLinkValue(value, trimTrailingPeriod = false) {
+    if (!value) {
+        return "";
+    }
+
+    let cleaned = value.trim();
+
+    // Case comments and copied curl commands often escape shell quotes as \"...\".
+    cleaned = cleaned.replace(/\\"/g, '"').replace(/\\'/g, "'");
+
+    while (
+        (cleaned.startsWith('"') && cleaned.endsWith('"')) ||
+        (cleaned.startsWith("'") && cleaned.endsWith("'"))
+    ) {
+        cleaned = cleaned.slice(1, -1).trim();
+    }
+
+    cleaned = cleaned.replace(/^['"]+|['"]+$/g, "");
+
+    if (trimTrailingPeriod) {
+        cleaned = cleaned.replace(/\.$/, "");
+    }
+
+    return cleaned || "";
+}
+
+function parseToken(cmd) {
+    if (!cmd) {
+        return "";
+    }
+
+    const token = cmd.match(/Authorization(?: Token)?:\s*(?:"([^"]+)"|'([^']+)'|(\S+))/);
+    return token ? cleanServiceLinkValue(token[1] || token[2] || token[3]) : "";
+}
+
+function parseFilename(cmd) {
+    if (!cmd) {
+        return "";
+    }
+
+    const filename =
+        cmd.match(/File name:\s*(?:"([^"]+)"|'([^']+)'|(\S+))/) ||
+        cmd.match(/-o\s+(?:"([^"]+)"|'([^']+)'|(\S+))/) ||
+        cmd.match(/--output\s+(?:"([^"]+)"|'([^']+)'|(\S+))/);
+    return filename ? cleanServiceLinkValue(filename[1] || filename[2] || filename[3]) : "";
+}
+
+function parseUrl(cmd) {
+    if (!cmd) {
+        return "";
+    }
+
+    const match = cmd.match(/https?:\/\/[^\s"'\\]+/);
+    return match ? cleanServiceLinkValue(match[0], true) : "";
+}

--- a/tests/service_link_parser_tests.rs
+++ b/tests/service_link_parser_tests.rs
@@ -1,0 +1,98 @@
+use std::process::Command;
+
+const SERVICE_LINK_PARSER: &str = include_str!("../templates/components/service_link_parser.js");
+
+#[test]
+#[ignore = "requires node to execute the shared JavaScript parser"]
+fn service_link_parser_strips_quotes_from_pasted_curl_command() {
+    let script = format!(
+        r#"
+{SERVICE_LINK_PARSER}
+
+const assert = require("node:assert/strict");
+
+const cases = [
+    {{
+        name: "escaped quotes from case comment",
+        command: String.raw`curl -s -L -H \"Authorization: api_key_value\" -o 'diag_file_name.zip' \"https://hostname/path/file\"`,
+        expected: {{
+            token: "api_key_value",
+            filename: "diag_file_name.zip",
+            url: "https://hostname/path/file",
+        }},
+    }},
+    {{
+        name: "double quoted curl values",
+        command: `curl -H "Authorization: token" -o "diag.zip" "https://host/path/file"`,
+        expected: {{
+            token: "token",
+            filename: "diag.zip",
+            url: "https://host/path/file",
+        }},
+    }},
+    {{
+        name: "single quoted curl values with trailing sentence period",
+        command: `curl -H 'Authorization: token' --output 'diag.zip' 'https://host/path/file.'`,
+        expected: {{
+            token: "token",
+            filename: "diag.zip",
+            url: "https://host/path/file",
+        }},
+    }},
+];
+
+for (const testCase of cases) {{
+    assert.deepEqual(
+        {{
+            token: parseToken(testCase.command),
+            filename: parseFilename(testCase.command),
+            url: parseUrl(testCase.command),
+        }},
+        testCase.expected,
+        testCase.name,
+    );
+}}
+
+assert.deepEqual(
+    {{
+        token: parseToken("not a curl command"),
+        filename: parseFilename("not a curl command"),
+        url: parseUrl("not a curl command"),
+    }},
+    {{
+        token: "",
+        filename: "",
+        url: "",
+    }},
+    "missing values return empty strings",
+);
+
+assert.deepEqual(
+    {{
+        token: parseToken(undefined),
+        filename: parseFilename(undefined),
+        url: parseUrl(undefined),
+    }},
+    {{
+        token: "",
+        filename: "",
+        url: "",
+    }},
+    "undefined input returns empty strings",
+);
+"#,
+    );
+
+    let output = Command::new("node")
+        .arg("-e")
+        .arg(script)
+        .output()
+        .expect("node must be available to run the Service Link parser regression test");
+
+    assert!(
+        output.status.success(),
+        "service link parser test failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary
- Backport #334 to the 0.15 branch.
- Centralize Service Link curl parsing in a shared JavaScript include.
- Strip single, double, and escaped quotes from pasted Service Link curl URL/token/filename values.

## Test plan
- [x] cargo test
- [x] cargo test --test service_link_parser_tests -- --ignored

Backports #334
Fixes #326

Made with [Cursor](https://cursor.com)