### PR TITLE
Fix bulk batching and node-derived metrics ingest

### DIFF
--- a/.agents/skills/esdiag/references/env-vars.md
+++ b/.agents/skills/esdiag/references/env-vars.md
@@ -44,7 +44,8 @@ Use these variables when configuring `esdiag` without saved hosts, or to supply 
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `ESDIAG_ES_BULK_SIZE` | `5000` | Number of documents per Elasticsearch bulk request |
+| `ESDIAG_ES_BULK_SIZE` | `10000` | Maximum number of documents per Elasticsearch bulk request |
+| `ESDIAG_ES_BULK_BYTES` | `52428800` | Approximate maximum serialized bulk request size in bytes for Elasticsearch output; set to `0` to disable byte-based splitting |
 | `ESDIAG_ES_WORKERS` | `4` | Number of parallel worker threads for export |
 | `ESDIAG_OUTPUT_TASK_LIMIT` | — | Max concurrent tasks when sending to Elasticsearch |
 | `ESDIAG_REQUEST_TIMEOUT_MS` | — | HTTP request timeout in milliseconds |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ published release notes, maintenance branches, and tagged history.
 
 ### Fixed
 
+- Fixed large Elasticsearch task exports and node-derived metrics ingestion so cluster sends are batched, child streams use their matching templates, and failed sends are recorded in diagnostic reports.
 - Fixed Elasticsearch node stats processing to preserve lookup-enriched node identity fields.
 - Fixed Elastic Cloud and GovCloud host normalization to use the documented `_main` single-resource reference.
 - Fixed Service Link curl parsing to remove single, double, and escaped quotes from pasted URLs and values (#326).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ published release notes, maintenance branches, and tagged history.
 ### Fixed
 
 - Fixed large Elasticsearch task exports and node-derived metrics ingestion so cluster sends are batched, child streams use their matching templates, and failed sends are recorded in diagnostic reports.
+- Fixed Logstash diagnostic processing across fixture versions and allowed Logstash sub-streams to ingest with their concrete data stream datasets (#338).
 - Fixed Elasticsearch node stats processing to preserve lookup-enriched node identity fields.
 - Fixed Elastic Cloud and GovCloud host normalization to use the documented `_main` single-resource reference.
 - Fixed Service Link curl parsing to remove single, double, and escaped quotes from pasted URLs and values (#326).

--- a/assets/elasticsearch/index_templates/metrics-logstash.json
+++ b/assets/elasticsearch/index_templates/metrics-logstash.json
@@ -33,8 +33,7 @@
           "type": "object",
           "properties": {
             "dataset": {
-              "type": "constant_keyword",
-              "value": "logstash"
+              "type": "constant_keyword"
             },
             "type": {
               "type": "constant_keyword",

--- a/assets/elasticsearch/index_templates/metrics-node.discovery.cluster_adaptive.json
+++ b/assets/elasticsearch/index_templates/metrics-node.discovery.cluster_adaptive.json
@@ -1,0 +1,39 @@
+{
+  "_meta": {
+    "description": "ESDiag Elasticsearch node adaptive selection stats"
+  },
+  "index_patterns": ["metrics-node.discovery.cluster_adaptive-esdiag*"],
+  "composed_of": [
+    "esdiag@mappings",
+    "esdiag@metadata",
+    "esdiag@settings",
+    "esdiag@node"
+  ],
+  "allow_auto_create": true,
+  "data_stream": {
+    "hidden": false,
+    "allow_custom_routing": false
+  },
+  "priority": 310,
+  "template": {
+    "mappings": {
+      "dynamic": true,
+      "properties": {
+        "data_stream": {
+          "type": "object",
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword",
+              "value": "node.discovery.cluster_adaptive"
+            },
+            "type": {
+              "type": "constant_keyword",
+              "value": "metrics"
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": 2
+}

--- a/assets/elasticsearch/index_templates/metrics-node.discovery.cluster_applier.json
+++ b/assets/elasticsearch/index_templates/metrics-node.discovery.cluster_applier.json
@@ -1,0 +1,42 @@
+{
+  "_meta": {
+    "description": "ESDiag Elasticsearch node cluster applier stats"
+  },
+  "index_patterns": ["metrics-node.discovery.cluster_applier-esdiag*"],
+  "composed_of": [
+    "esdiag@mappings",
+    "esdiag@metadata",
+    "esdiag@settings",
+    "esdiag@node"
+  ],
+  "allow_auto_create": true,
+  "data_stream": {
+    "hidden": false,
+    "allow_custom_routing": false
+  },
+  "priority": 310,
+  "template": {
+    "mappings": {
+      "properties": {
+        "data_stream": {
+          "type": "object",
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword",
+              "value": "node.discovery.cluster_applier"
+            },
+            "type": {
+              "type": "constant_keyword",
+              "value": "metrics"
+            }
+          }
+        },
+        "cluster_applier_stats": {
+          "type": "object",
+          "enabled": false
+        }
+      }
+    }
+  },
+  "version": 2
+}

--- a/assets/elasticsearch/index_templates/metrics-node.http.clients.json
+++ b/assets/elasticsearch/index_templates/metrics-node.http.clients.json
@@ -1,0 +1,46 @@
+{
+  "_meta": {
+    "description": "ESDiag Elasticsearch node HTTP client stats"
+  },
+  "index_patterns": ["metrics-node.http.clients-esdiag*"],
+  "composed_of": [
+    "esdiag@mappings",
+    "esdiag@metadata",
+    "esdiag@settings",
+    "esdiag@node"
+  ],
+  "allow_auto_create": true,
+  "data_stream": {
+    "hidden": false,
+    "allow_custom_routing": false
+  },
+  "priority": 310,
+  "template": {
+    "mappings": {
+      "properties": {
+        "data_stream": {
+          "type": "object",
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword",
+              "value": "node.http.clients"
+            },
+            "type": {
+              "type": "constant_keyword",
+              "value": "metrics"
+            }
+          }
+        },
+        "http": {
+          "properties": {
+            "client": {
+              "type": "object",
+              "enabled": false
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": 2
+}

--- a/assets/elasticsearch/index_templates/metrics-node.transport.actions.json
+++ b/assets/elasticsearch/index_templates/metrics-node.transport.actions.json
@@ -1,0 +1,50 @@
+{
+  "_meta": {
+    "description": "ESDiag Elasticsearch node transport action stats"
+  },
+  "index_patterns": ["metrics-node.transport.actions-esdiag*"],
+  "composed_of": [
+    "esdiag@mappings",
+    "esdiag@metadata",
+    "esdiag@settings",
+    "esdiag@node"
+  ],
+  "allow_auto_create": true,
+  "data_stream": {
+    "hidden": false,
+    "allow_custom_routing": false
+  },
+  "priority": 310,
+  "template": {
+    "mappings": {
+      "dynamic": true,
+      "properties": {
+        "data_stream": {
+          "type": "object",
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword",
+              "value": "node.transport.actions"
+            },
+            "type": {
+              "type": "constant_keyword",
+              "value": "metrics"
+            }
+          }
+        },
+        "transport": {
+          "properties": {
+            "action": {
+              "properties": {
+                "name": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": 2
+}

--- a/assets/elasticsearch/index_templates/settings-logstash.json
+++ b/assets/elasticsearch/index_templates/settings-logstash.json
@@ -33,8 +33,7 @@
           "type": "object",
           "properties": {
             "dataset": {
-              "type": "constant_keyword",
-              "value": "logstash"
+              "type": "constant_keyword"
             },
             "type": {
               "type": "constant_keyword",

--- a/src/env.rs
+++ b/src/env.rs
@@ -2,7 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-pub const ESDIAG_ES_BULK_SIZE: usize = 5_000;
+pub const ESDIAG_ES_BULK_SIZE: usize = 10_000;
+pub const ESDIAG_ES_BULK_BYTES: usize = 50 * 1024 * 1024;
 pub const ESDIAG_ES_WORKERS: usize = 4;
 pub static ESDIAG_HOME: &str = ".esdiag";
 pub static LOG_LEVEL: &str = "info";
@@ -12,6 +13,7 @@ pub static ESDIAG_KEYSTORE_PASSWORD: &str = "ESDIAG_KEYSTORE_PASSWORD";
 
 fn default_int(name: &str) -> Option<usize> {
     match name {
+        "ESDIAG_ES_BULK_BYTES" => Some(ESDIAG_ES_BULK_BYTES),
         "ESDIAG_ES_BULK_SIZE" => Some(ESDIAG_ES_BULK_SIZE),
         "ESDIAG_ES_WORKERS" => Some(ESDIAG_ES_WORKERS),
         _ => None,

--- a/src/exporter/directory.rs
+++ b/src/exporter/directory.rs
@@ -134,6 +134,7 @@ impl Export for DirectoryExporter {
     {
         let start_time = tokio::time::Instant::now();
         let mut batch = BatchResponse::new(docs.len() as u32);
+        batch.status_code = 200;
         let mut doc_count = 0;
         {
             let writer = get_writer(self.writers.clone(), &self.path, &index).await?;

--- a/src/exporter/directory.rs
+++ b/src/exporter/directory.rs
@@ -161,6 +161,7 @@ impl Export for DirectoryExporter {
         T: Serialize + Sized + Send + Sync + 'static,
     {
         let (tx, rx) = oneshot::channel();
+        let doc_count = docs.len() as u32;
 
         // File exporter writes synchronously, so we just write and send a simple response
         match self.batch_send(index, docs).await {
@@ -169,7 +170,12 @@ impl Export for DirectoryExporter {
                     tracing::error!("Failed to send batch response");
                 }
             }
-            Err(e) => tracing::warn!("File write failed: {}", e),
+            Err(e) => {
+                tracing::warn!("File write failed: {}", e);
+                if tx.send(BatchResponse::failed(doc_count, 0)).is_err() {
+                    tracing::error!("Failed to send failed batch response");
+                }
+            }
         }
 
         Ok(rx)

--- a/src/exporter/directory.rs
+++ b/src/exporter/directory.rs
@@ -166,7 +166,7 @@ impl Export for DirectoryExporter {
         let target_dir = self.path.display().to_string();
         let index_for_error = index.clone();
 
-        // File exporter writes synchronously, so we just write and send a simple response
+        // Directory exporter writes synchronously, so we just write and send a simple response.
         match self.batch_send(index, docs).await {
             Ok(batch_response) => {
                 if tx.send(batch_response).is_err() {

--- a/src/exporter/directory.rs
+++ b/src/exporter/directory.rs
@@ -162,6 +162,8 @@ impl Export for DirectoryExporter {
     {
         let (tx, rx) = oneshot::channel();
         let doc_count = docs.len() as u32;
+        let target_dir = self.path.display().to_string();
+        let index_for_error = index.clone();
 
         // File exporter writes synchronously, so we just write and send a simple response
         match self.batch_send(index, docs).await {
@@ -171,7 +173,12 @@ impl Export for DirectoryExporter {
                 }
             }
             Err(e) => {
-                tracing::warn!("File write failed: {}", e);
+                tracing::warn!(
+                    "Directory write failed for index {} in {}: {}",
+                    index_for_error,
+                    target_dir,
+                    e
+                );
                 if tx.send(BatchResponse::failed(doc_count, 0)).is_err() {
                     tracing::error!("Failed to send failed batch response");
                 }

--- a/src/exporter/elasticsearch.rs
+++ b/src/exporter/elasticsearch.rs
@@ -251,14 +251,9 @@ impl Export for ElasticsearchExporter {
                         "{index} - http 429, batch dropped after {} attempts",
                         u32::from(config.max_retries) + 1,
                     );
-                    return Ok(BatchResponse {
-                        docs: values.len() as u32,
-                        errors: values.len() as u32,
-                        retries,
-                        size: 0,
-                        status_code: 429,
-                        time: 0,
-                    });
+                    let mut response = BatchResponse::failed(values.len() as u32, 429);
+                    response.retries = retries;
+                    return Ok(response);
                 }
                 Err(ExporterError::Fatal(e)) => return Err(e),
             }
@@ -293,6 +288,9 @@ impl Export for ElasticsearchExporter {
                 }
                 Err(e) => {
                     tracing::warn!("Bulk batch failed: {}", e);
+                    if tx.send(BatchResponse::failed(doc_count as u32, 0)).is_err() {
+                        tracing::error!("Failed to send failed batch response: receiver dropped");
+                    }
                 }
             }
         });
@@ -356,8 +354,32 @@ async fn parse_response(
     let response = response.map_err(|e| ExporterError::Fatal(e.into()))?;
     tracing::trace!("{:?}", &response);
     let status_code = response.status_code().as_u16();
-    if status_code == 429 {
-        return Err(ExporterError::RateLimited);
+    match status_code {
+        200 => {}
+        400 => {
+            return Err(ExporterError::Fatal(eyre!("{} - http 400 bad request", index)));
+        }
+        401 => {
+            return Err(ExporterError::Fatal(eyre!("{} - http 401 unauthorized", index)));
+        }
+        403 => {
+            return Err(ExporterError::Fatal(eyre!("{} - http 403 forbidden", index)));
+        }
+        404 => {
+            return Err(ExporterError::Fatal(eyre!("{} - http 404 not found", index)));
+        }
+        413 => {
+            return Err(ExporterError::Fatal(eyre!("{} - http 413 request too large", index)));
+        }
+        429 => return Err(ExporterError::RateLimited),
+        500..=599 => {
+            return Err(ExporterError::Fatal(eyre!(
+                "{} - server errors: http {}",
+                index,
+                status_code
+            )));
+        }
+        _ => tracing::warn!("unexpected http response: {}", status_code),
     }
     let body: Value = response.json().await.map_err(|e| ExporterError::Fatal(e.into()))?;
     let mut items: Vec<Value> = body.get("items").and_then(Value::as_array).cloned().unwrap_or_default();
@@ -387,32 +409,9 @@ async fn parse_response(
         .map_err(ExporterError::Fatal)?;
     }
 
-    match status_code {
-        200 if error_count == 0 => tracing::debug!("{}, created {} docs", index, doc_count),
-        200 => tracing::warn!("{}, created {} docs with {} errors", index, doc_count, error_count),
-        400 => {
-            return Err(ExporterError::Fatal(eyre!("{} - http 400 bad request", index)));
-        }
-        401 => {
-            return Err(ExporterError::Fatal(eyre!("{} - http 401 unauthorized", index)));
-        }
-        403 => {
-            return Err(ExporterError::Fatal(eyre!("{} - http 403 forbidden", index)));
-        }
-        404 => {
-            return Err(ExporterError::Fatal(eyre!("{} - http 404 not found", index)));
-        }
-        413 => {
-            return Err(ExporterError::Fatal(eyre!("{} - http 413 request too large", index)));
-        }
-        500..=599 => {
-            return Err(ExporterError::Fatal(eyre!(
-                "{} - server errors: http {}",
-                index,
-                status_code
-            )));
-        }
-        _ => tracing::warn!("unexpected http response: {}", status_code),
+    match error_count {
+        0 => tracing::debug!("{}, created {} docs", index, doc_count),
+        _ => tracing::warn!("{}, created {} docs with {} errors", index, doc_count, error_count),
     }
 
     if error_count > 0 {
@@ -428,14 +427,11 @@ async fn parse_response(
         .map_err(ExporterError::Fatal)?;
     }
 
-    let batch_response = BatchResponse {
-        docs: item_count as u32,
-        errors: error_count as u32,
-        retries,
-        size: 0,
-        status_code,
-        time: body.get("took").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
-    };
+    let mut batch_response = BatchResponse::new(doc_count as u32);
+    batch_response.errors = error_count as u32;
+    batch_response.retries = retries;
+    batch_response.status_code = status_code;
+    batch_response.time = body.get("took").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
 
     Ok(batch_response)
 }
@@ -506,6 +502,31 @@ mod tests {
         (url, call_count)
     }
 
+    async fn mock_bulk_server_raw(status: u16, body: &'static str) -> Url {
+        #[derive(Clone)]
+        struct MockState {
+            status: u16,
+            body: &'static str,
+        }
+
+        async fn bulk_handler(State(state): State<MockState>) -> impl IntoResponse {
+            (StatusCode::from_u16(state.status).unwrap(), state.body)
+        }
+
+        let app = Router::new()
+            .route("/{*path}", post(bulk_handler))
+            .with_state(MockState { status, body });
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        format!("http://{addr}").parse().unwrap()
+    }
+
     static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
     struct RetryEnvGuard {
@@ -546,6 +567,31 @@ mod tests {
                 match &self.prev_max_ms {
                     Some(v) => std::env::set_var("ESDIAG_EXPORT_RETRY_MAX_MS", v),
                     None => std::env::remove_var("ESDIAG_EXPORT_RETRY_MAX_MS"),
+                }
+            }
+        }
+    }
+
+    struct BulkBytesEnvGuard {
+        prev_bytes: Option<String>,
+    }
+
+    impl BulkBytesEnvGuard {
+        fn set(bytes: &str) -> Self {
+            let prev_bytes = std::env::var("ESDIAG_ES_BULK_BYTES").ok();
+            unsafe {
+                std::env::set_var("ESDIAG_ES_BULK_BYTES", bytes);
+            }
+            Self { prev_bytes }
+        }
+    }
+
+    impl Drop for BulkBytesEnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.prev_bytes {
+                    Some(v) => std::env::set_var("ESDIAG_ES_BULK_BYTES", v),
+                    None => std::env::remove_var("ESDIAG_ES_BULK_BYTES"),
                 }
             }
         }
@@ -601,5 +647,74 @@ mod tests {
 
         assert!(result.is_err(), "expected Err for 400");
         assert_eq!(*call_count.lock().await, 1, "400 must not be retried");
+    }
+
+    #[tokio::test]
+    async fn request_too_large_reports_status_without_decoding_body() {
+        let url = mock_bulk_server_raw(413, "request entity too large").await;
+        let exporter = ElasticsearchExporter::try_new(url, Auth::None).unwrap();
+
+        let result = exporter
+            .batch_send("test-index".to_string(), vec![json!({"x": 1})])
+            .await;
+
+        let err = match result {
+            Ok(_) => panic!("expected 413 to fail"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("test-index - http 413 request too large"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_tx_reports_failed_batch_response() {
+        let url = mock_bulk_server_raw(413, "request entity too large").await;
+        let exporter = ElasticsearchExporter::try_new(url, Auth::None).unwrap();
+
+        let rx = exporter
+            .batch_tx("test-index".to_string(), vec![json!({"x": 1}), json!({"x": 2})])
+            .await
+            .expect("batch tx starts");
+        let response = rx.await.expect("failed batch response");
+
+        assert_eq!(response.docs, 0);
+        assert_eq!(response.errors, 2);
+        assert_eq!(response.status_code, 0);
+    }
+
+    #[tokio::test]
+    async fn exporter_send_splits_bulk_requests_by_configured_size() {
+        let _lock = ENV_LOCK.lock().await;
+        let _env = BulkBytesEnvGuard::set("104857600");
+        let (url, call_count) = mock_bulk_server(vec![200, 200]).await;
+        let exporter =
+            crate::exporter::Exporter::Elasticsearch(ElasticsearchExporter::try_new(url, Auth::None).unwrap());
+        let docs = (0..=crate::env::ESDIAG_ES_BULK_SIZE)
+            .map(|id| json!({ "x": id }))
+            .collect::<Vec<_>>();
+
+        let result = exporter.send("test-index".to_string(), docs).await;
+
+        assert!(result.is_ok(), "expected split send to succeed");
+        assert_eq!(result.unwrap().batch_count, 2);
+        assert_eq!(*call_count.lock().await, 2, "expected two bulk requests");
+    }
+
+    #[tokio::test]
+    async fn exporter_send_splits_bulk_requests_by_estimated_bytes() {
+        let _lock = ENV_LOCK.lock().await;
+        let _env = BulkBytesEnvGuard::set("1");
+        let (url, call_count) = mock_bulk_server(vec![200, 200, 200]).await;
+        let exporter =
+            crate::exporter::Exporter::Elasticsearch(ElasticsearchExporter::try_new(url, Auth::None).unwrap());
+        let docs = vec![json!({"x": "a"}), json!({"x": "b"}), json!({"x": "c"})];
+
+        let result = exporter.send("test-index".to_string(), docs).await;
+
+        assert!(result.is_ok(), "expected byte split send to succeed");
+        assert_eq!(result.unwrap().batch_count, 3);
+        assert_eq!(*call_count.lock().await, 3, "expected three bulk requests");
     }
 }

--- a/src/exporter/elasticsearch.rs
+++ b/src/exporter/elasticsearch.rs
@@ -717,4 +717,41 @@ mod tests {
         assert_eq!(result.unwrap().batch_count, 3);
         assert_eq!(*call_count.lock().await, 3, "expected three bulk requests");
     }
+
+    #[tokio::test]
+    async fn exporter_send_allows_disabling_byte_splitting() {
+        let _lock = ENV_LOCK.lock().await;
+        let _env = BulkBytesEnvGuard::set("0");
+        let (url, call_count) = mock_bulk_server(vec![200]).await;
+        let exporter =
+            crate::exporter::Exporter::Elasticsearch(ElasticsearchExporter::try_new(url, Auth::None).unwrap());
+        let docs = vec![json!({"x": "a"}), json!({"x": "b"}), json!({"x": "c"})];
+
+        let result = exporter.send("test-index".to_string(), docs).await;
+
+        assert!(result.is_ok(), "expected byte-disabled send to succeed");
+        assert_eq!(result.unwrap().batch_count, 1);
+        assert_eq!(*call_count.lock().await, 1, "expected one bulk request");
+    }
+
+    #[tokio::test]
+    async fn exporter_send_reports_single_batch_send_failure() {
+        let _lock = ENV_LOCK.lock().await;
+        let _env = BulkBytesEnvGuard::set("0");
+        let (url, call_count) = mock_bulk_server(vec![413]).await;
+        let exporter =
+            crate::exporter::Exporter::Elasticsearch(ElasticsearchExporter::try_new(url, Auth::None).unwrap());
+        let docs = vec![json!({"x": "a"}), json!({"x": "b"})];
+
+        let response = exporter
+            .send("test-index".to_string(), docs)
+            .await
+            .expect("send failures should be recorded in the batch response");
+
+        assert_eq!(response.docs, 0);
+        assert_eq!(response.errors, 2);
+        assert_eq!(response.batch_count, 1);
+        assert_eq!(response.status_code, 0);
+        assert_eq!(*call_count.lock().await, 1, "expected one bulk request");
+    }
 }

--- a/src/exporter/elasticsearch.rs
+++ b/src/exporter/elasticsearch.rs
@@ -249,9 +249,10 @@ impl Export for ElasticsearchExporter {
         status_code == 200
     }
 
-    /// Sends a single batch of documents to Elasticsearch, retrying on HTTP 429
-    /// with exponential backoff. Serialises docs to Values upfront so the batch
-    /// can be resent without requiring `T: Clone`.
+    /// Sends documents to Elasticsearch, splitting into bulk sub-batches as needed
+    /// and retrying each sub-batch on HTTP 429 with exponential backoff.
+    /// Serialises docs to Values upfront so sub-batches can be resent without
+    /// requiring `T: Clone`.
     async fn batch_send<T>(&self, index: String, docs: Vec<T>) -> Result<BatchResponse>
     where
         T: Serialize + Sized + Send + Sync,

--- a/src/exporter/elasticsearch.rs
+++ b/src/exporter/elasticsearch.rs
@@ -272,7 +272,7 @@ impl Export for ElasticsearchExporter {
             .unwrap_or(crate::env::ESDIAG_ES_BULK_SIZE)
             .max(1);
         let bulk_bytes = elasticsearch_bulk_bytes_limit();
-        let mut summary = BatchResponse::aggregate();
+        let mut batches = Vec::new();
         let mut batch = Vec::with_capacity(bulk_size.min(values.len()));
         let mut batch_bytes = 0usize;
 
@@ -285,7 +285,7 @@ impl Export for ElasticsearchExporter {
                 .is_some_and(|max_bytes| !batch.is_empty() && batch_bytes.saturating_add(doc_bytes) > max_bytes);
 
             if would_exceed_count || would_exceed_bytes {
-                summary.merge(self.send_value_batch(index.clone(), std::mem::take(&mut batch)).await?);
+                batches.push(std::mem::take(&mut batch));
                 batch = Vec::with_capacity(bulk_size);
                 batch_bytes = 0;
             }
@@ -295,7 +295,29 @@ impl Export for ElasticsearchExporter {
         }
 
         if !batch.is_empty() {
-            summary.merge(self.send_value_batch(index, batch).await?);
+            batches.push(batch);
+        }
+
+        let mut summary = BatchResponse::aggregate();
+        for batch_index in 0..batches.len() {
+            let batch_doc_count = batches[batch_index].len() as u32;
+            let batch = std::mem::take(&mut batches[batch_index]);
+            match self.send_value_batch(index.clone(), batch).await {
+                Ok(response) => summary.merge(response),
+                Err(err) if summary.batch_count == 0 => return Err(err),
+                Err(err) => {
+                    let unsent_docs = batches
+                        .iter()
+                        .skip(batch_index + 1)
+                        .fold(0u32, |count, batch| count.saturating_add(batch.len() as u32));
+                    let failed_docs = batch_doc_count.saturating_add(unsent_docs);
+                    tracing::warn!(
+                        "{index} - bulk sub-batch failed after partial success; recording {failed_docs} failed docs: {err}"
+                    );
+                    summary.merge(BatchResponse::failed(failed_docs, 0));
+                    return Ok(summary);
+                }
+            }
         }
 
         Ok(summary)
@@ -763,6 +785,32 @@ mod tests {
         assert!(
             err.to_string().contains("test-index - http 413 request too large"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn split_send_preserves_successful_counts_after_later_fatal_error() {
+        let _lock = ENV_LOCK.lock().await;
+        let _env = BulkBytesEnvGuard::set("1");
+        let (url, call_count) = mock_bulk_server(vec![200, 413]).await;
+        let exporter = ElasticsearchExporter::try_new(url, Auth::None).unwrap();
+
+        let result = exporter
+            .batch_send(
+                "test-index".to_string(),
+                vec![json!({"x": "a"}), json!({"x": "b"}), json!({"x": "c"})],
+            )
+            .await
+            .expect("partial success should return an aggregate response");
+
+        assert_eq!(result.docs, 1);
+        assert_eq!(result.errors, 2);
+        assert_eq!(result.batch_count, 2);
+        assert_eq!(result.status_code, 0);
+        assert_eq!(
+            *call_count.lock().await,
+            2,
+            "remaining docs should not be sent after fatal error"
         );
     }
 

--- a/src/exporter/elasticsearch.rs
+++ b/src/exporter/elasticsearch.rs
@@ -145,6 +145,51 @@ impl ElasticsearchExporter {
         .map_err(|_| eyre!("Request timeout for {method:?} {path}"))?
         .map_err(|e| e.into())
     }
+
+    async fn send_value_batch(&self, index: String, values: Vec<Arc<Value>>) -> Result<BatchResponse> {
+        let config = RetryConfig::from_env();
+        let mut retries: u16 = 0;
+
+        for attempt in 0..=config.max_retries {
+            let batch: Vec<BulkOperation<Arc<Value>>> = values
+                .iter()
+                .map(|doc| BulkOperation::create(Arc::clone(doc)).pipeline("esdiag").into())
+                .collect();
+
+            let response = timeout(
+                Self::request_timeout(),
+                self.client.bulk(BulkParts::Index(&index)).body(batch).send(),
+            )
+            .await
+            .map_err(|_| eyre!("Timed out sending bulk request to {} for index {}", self.url, index))?;
+
+            match parse_response(index.clone(), response, retries).await {
+                Ok(batch_response) => return Ok(batch_response),
+                Err(ExporterError::RateLimited) if attempt < config.max_retries => {
+                    let sleep_ms = backoff_ms(attempt, &config);
+                    tracing::warn!(
+                        "{index} - http 429, retry {}/{}, sleeping {sleep_ms}ms",
+                        u32::from(attempt) + 1,
+                        config.max_retries,
+                    );
+                    tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
+                    retries += 1;
+                }
+                Err(ExporterError::RateLimited) => {
+                    tracing::error!(
+                        "{index} - http 429, batch dropped after {} attempts",
+                        u32::from(config.max_retries) + 1,
+                    );
+                    let mut response = BatchResponse::failed(values.len() as u32, 429);
+                    response.retries = retries;
+                    return Ok(response);
+                }
+                Err(ExporterError::Fatal(e)) => return Err(e),
+            }
+        }
+
+        unreachable!("retry loop always returns within attempt bounds")
+    }
 }
 
 impl TryFrom<KnownHost> for ElasticsearchExporter {
@@ -211,55 +256,49 @@ impl Export for ElasticsearchExporter {
     where
         T: Serialize + Sized + Send + Sync,
     {
-        let config = RetryConfig::from_env();
-
         let values: Vec<Arc<Value>> = docs
             .into_iter()
             .map(|doc| serde_json::to_value(doc).map(Arc::new))
             .collect::<std::result::Result<_, _>>()
             .map_err(|e| eyre!("Failed to serialize document: {e}"))?;
 
-        let mut retries: u16 = 0;
-
-        for attempt in 0..=config.max_retries {
-            let batch: Vec<BulkOperation<Arc<Value>>> = values
-                .iter()
-                .map(|doc| BulkOperation::create(Arc::clone(doc)).pipeline("esdiag").into())
-                .collect();
-
-            let response = timeout(
-                Self::request_timeout(),
-                self.client.bulk(BulkParts::Index(&index)).body(batch).send(),
-            )
-            .await
-            .map_err(|_| eyre!("Timed out sending bulk request to {} for index {}", self.url, index))?;
-
-            match parse_response(index.clone(), response, retries).await {
-                Ok(batch_response) => return Ok(batch_response),
-                Err(ExporterError::RateLimited) if attempt < config.max_retries => {
-                    let sleep_ms = backoff_ms(attempt, &config);
-                    tracing::warn!(
-                        "{index} - http 429, retry {}/{}, sleeping {sleep_ms}ms",
-                        u32::from(attempt) + 1,
-                        config.max_retries,
-                    );
-                    tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
-                    retries += 1;
-                }
-                Err(ExporterError::RateLimited) => {
-                    tracing::error!(
-                        "{index} - http 429, batch dropped after {} attempts",
-                        u32::from(config.max_retries) + 1,
-                    );
-                    let mut response = BatchResponse::failed(values.len() as u32, 429);
-                    response.retries = retries;
-                    return Ok(response);
-                }
-                Err(ExporterError::Fatal(e)) => return Err(e),
-            }
+        if values.is_empty() {
+            let mut response = BatchResponse::aggregate();
+            response.status_code = 200;
+            return Ok(response);
         }
 
-        unreachable!("retry loop always returns within attempt bounds")
+        let bulk_size = crate::env::get_int("ESDIAG_ES_BULK_SIZE")
+            .unwrap_or(crate::env::ESDIAG_ES_BULK_SIZE)
+            .max(1);
+        let bulk_bytes = elasticsearch_bulk_bytes_limit();
+        let mut summary = BatchResponse::aggregate();
+        let mut batch = Vec::with_capacity(bulk_size.min(values.len()));
+        let mut batch_bytes = 0usize;
+
+        for value in values {
+            let doc_bytes = bulk_bytes
+                .map(|_| estimated_bulk_value_bytes(&index, value.as_ref()))
+                .unwrap_or(0);
+            let would_exceed_count = batch.len() >= bulk_size;
+            let would_exceed_bytes = bulk_bytes
+                .is_some_and(|max_bytes| !batch.is_empty() && batch_bytes.saturating_add(doc_bytes) > max_bytes);
+
+            if would_exceed_count || would_exceed_bytes {
+                summary.merge(self.send_value_batch(index.clone(), std::mem::take(&mut batch)).await?);
+                batch = Vec::with_capacity(bulk_size);
+                batch_bytes = 0;
+            }
+
+            batch_bytes = batch_bytes.saturating_add(doc_bytes);
+            batch.push(value);
+        }
+
+        if !batch.is_empty() {
+            summary.merge(self.send_value_batch(index, batch).await?);
+        }
+
+        Ok(summary)
     }
 
     /// Transmits a single batch of documents with semaphore-based connection limiting.
@@ -344,6 +383,56 @@ impl std::fmt::Display for ElasticsearchExporter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.url)
     }
+}
+
+fn elasticsearch_bulk_bytes_limit() -> Option<usize> {
+    match std::env::var("ESDIAG_ES_BULK_BYTES") {
+        Ok(value) => match value.parse::<usize>() {
+            Ok(0) => None,
+            Ok(bytes) => Some(bytes),
+            Err(_) => Some(crate::env::ESDIAG_ES_BULK_BYTES),
+        },
+        Err(_) => Some(crate::env::ESDIAG_ES_BULK_BYTES),
+    }
+}
+
+fn estimated_bulk_value_bytes(index: &str, value: &Value) -> usize {
+    const BULK_ACTION_OVERHEAD_BYTES: usize = 128;
+    estimated_json_value_bytes(value)
+        .saturating_add(index.len())
+        .saturating_add(BULK_ACTION_OVERHEAD_BYTES)
+}
+
+fn estimated_json_value_bytes(value: &Value) -> usize {
+    match value {
+        Value::Null => 4,
+        Value::Bool(true) => 4,
+        Value::Bool(false) => 5,
+        Value::Number(number) => number.to_string().len(),
+        Value::String(value) => estimated_json_string_bytes(value),
+        Value::Array(values) => values.iter().enumerate().fold(2usize, |bytes, (index, value)| {
+            bytes
+                .saturating_add(usize::from(index > 0))
+                .saturating_add(estimated_json_value_bytes(value))
+        }),
+        Value::Object(values) => values.iter().enumerate().fold(2usize, |bytes, (index, (key, value))| {
+            bytes
+                .saturating_add(usize::from(index > 0))
+                .saturating_add(estimated_json_string_bytes(key))
+                .saturating_add(1)
+                .saturating_add(estimated_json_value_bytes(value))
+        }),
+    }
+}
+
+fn estimated_json_string_bytes(value: &str) -> usize {
+    value.bytes().fold(2usize, |bytes, byte| {
+        bytes.saturating_add(match byte {
+            b'"' | b'\\' | b'\n' | b'\r' | b'\t' | 0x08 | 0x0c => 2,
+            0x00..=0x1f => 6,
+            _ => 1,
+        })
+    })
 }
 
 async fn parse_response(
@@ -595,6 +684,21 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn estimated_json_value_bytes_matches_serialized_value_length() {
+        let value = json!({
+            "array": [null, true, false, 123, "quoted \" text", "line\nbreak"],
+            "nested": {
+                "plain": "operate ascii",
+                "control": "\u{001f}"
+            }
+        });
+
+        let serialized = serde_json::to_vec(&value).expect("serialize value");
+
+        assert_eq!(estimated_json_value_bytes(&value), serialized.len());
     }
 
     #[tokio::test]

--- a/src/exporter/elasticsearch.rs
+++ b/src/exporter/elasticsearch.rs
@@ -272,8 +272,9 @@ impl Export for ElasticsearchExporter {
             .unwrap_or(crate::env::ESDIAG_ES_BULK_SIZE)
             .max(1);
         let bulk_bytes = elasticsearch_bulk_bytes_limit();
+        let batch_capacity = bulk_size.min(values.len());
         let mut batches = Vec::new();
-        let mut batch = Vec::with_capacity(bulk_size.min(values.len()));
+        let mut batch = Vec::with_capacity(batch_capacity);
         let mut batch_bytes = 0usize;
 
         for value in values {
@@ -286,7 +287,7 @@ impl Export for ElasticsearchExporter {
 
             if would_exceed_count || would_exceed_bytes {
                 batches.push(std::mem::take(&mut batch));
-                batch = Vec::with_capacity(bulk_size);
+                batch = Vec::with_capacity(batch_capacity);
                 batch_bytes = 0;
             }
 

--- a/src/exporter/elasticsearch.rs
+++ b/src/exporter/elasticsearch.rs
@@ -386,14 +386,8 @@ impl std::fmt::Display for ElasticsearchExporter {
 }
 
 fn elasticsearch_bulk_bytes_limit() -> Option<usize> {
-    match std::env::var("ESDIAG_ES_BULK_BYTES") {
-        Ok(value) => match value.parse::<usize>() {
-            Ok(0) => None,
-            Ok(bytes) => Some(bytes),
-            Err(_) => Some(crate::env::ESDIAG_ES_BULK_BYTES),
-        },
-        Err(_) => Some(crate::env::ESDIAG_ES_BULK_BYTES),
-    }
+    let bytes = crate::env::get_int("ESDIAG_ES_BULK_BYTES").unwrap_or(crate::env::ESDIAG_ES_BULK_BYTES);
+    (bytes > 0).then_some(bytes)
 }
 
 fn estimated_bulk_value_bytes(index: &str, value: &Value) -> usize {

--- a/src/exporter/file.rs
+++ b/src/exporter/file.rs
@@ -124,6 +124,7 @@ impl Export for FileExporter {
         T: Serialize + Sized + Send + Sync + 'static,
     {
         let (tx, rx) = oneshot::channel();
+        let doc_count = docs.len() as u32;
 
         // File exporter writes synchronously, so we just write and send a simple response
         match self.batch_send(index, docs).await {
@@ -132,7 +133,12 @@ impl Export for FileExporter {
                     tracing::error!("Failed to send batch response");
                 }
             }
-            Err(e) => tracing::warn!("File write failed: {}", e),
+            Err(e) => {
+                tracing::warn!("File write failed: {}", e);
+                if tx.send(BatchResponse::failed(doc_count, 0)).is_err() {
+                    tracing::error!("Failed to send failed batch response");
+                }
+            }
         }
 
         Ok(rx)

--- a/src/exporter/file.rs
+++ b/src/exporter/file.rs
@@ -80,6 +80,7 @@ impl Export for FileExporter {
     {
         let start_time = tokio::time::Instant::now();
         let mut batch = BatchResponse::new(docs.len() as u32);
+        batch.status_code = 200;
         let mut doc_count = 0;
         {
             let mut writer = self

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -117,11 +117,12 @@ impl Exporter {
 
             if accumulator.len() >= batch_size {
                 let batch = std::mem::replace(&mut accumulator, Vec::with_capacity(batch_size));
+                let doc_count = batch.len() as u32;
                 match self.tx(index.clone(), batch).await {
                     Ok(batch_rx) => batch_receivers.push(batch_rx),
                     Err(err) => {
                         tracing::warn!("Failed to send document batch: {}", err);
-                        summary.add_batch(BatchResponse::failed(batch_size as u32, 0));
+                        summary.add_batch(BatchResponse::failed(doc_count, 0));
                     }
                 }
             }
@@ -477,6 +478,26 @@ mod tests {
         assert_eq!(response.errors, 0);
         assert_eq!(response.batch_count, 0);
         assert_eq!(response.status_code, 200);
+    }
+
+    #[tokio::test]
+    async fn document_channel_records_actual_failed_batch_count() {
+        let tmp = TempDir::new().expect("temp dir");
+        let exporter = Exporter::Archive(ArchiveExporter::zip(tmp.path().to_path_buf()).expect("archive exporter"));
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        tx.send(serde_json::json!({"id": 1})).await.expect("send doc");
+        tx.send(serde_json::json!({"id": 2})).await.expect("send doc");
+        tx.send(serde_json::json!({"id": 3})).await.expect("send doc");
+        drop(tx);
+
+        let summary = exporter
+            .document_channel(rx, "metrics-node-esdiag".to_string(), 0)
+            .await;
+
+        let value = serde_json::to_value(summary).expect("summary json");
+        assert_eq!(value["docs"], 0);
+        assert_eq!(value["doc_errors"], 3);
+        assert_eq!(value["batch"]["count"], 3);
     }
 
     #[test]

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -23,7 +23,10 @@ use elasticsearch::ElasticsearchExporter;
 use eyre::{Result, eyre};
 use file::FileExporter;
 use serde::Serialize;
-use std::path::{Path, PathBuf};
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
 use stream::StreamExporter;
 use tokio::sync::{mpsc, oneshot};
 use url::Url;
@@ -397,10 +400,28 @@ fn format_directory_label(value: &str) -> String {
 
 fn estimated_bulk_item_bytes<T: Serialize>(index: &str, doc: &T) -> Result<usize> {
     const BULK_ACTION_OVERHEAD_BYTES: usize = 128;
-    let doc_bytes = serde_json::to_vec(doc)?.len();
+    let mut writer = CountingWriter::default();
+    serde_json::to_writer(&mut writer, doc)?;
+    let doc_bytes = writer.bytes;
     Ok(doc_bytes
         .saturating_add(index.len())
         .saturating_add(BULK_ACTION_OVERHEAD_BYTES))
+}
+
+#[derive(Default)]
+struct CountingWriter {
+    bytes: usize,
+}
+
+impl io::Write for CountingWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.bytes = self.bytes.saturating_add(buf.len());
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 fn path_to_file_uri(path: &Path, is_dir: bool) -> String {

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -163,10 +163,7 @@ impl Exporter {
             .unwrap_or(crate::env::ESDIAG_ES_BULK_SIZE)
             .max(1);
         let bulk_bytes = match self {
-            Exporter::Elasticsearch(_) => crate::env::get_int("ESDIAG_ES_BULK_BYTES")
-                .ok()
-                .filter(|bytes| *bytes > 0)
-                .or(Some(crate::env::ESDIAG_ES_BULK_BYTES)),
+            Exporter::Elasticsearch(_) => elasticsearch_bulk_bytes_limit(),
             _ => None,
         };
         if docs.is_empty() {
@@ -179,7 +176,7 @@ impl Exporter {
         }
 
         if docs.len() <= bulk_size && bulk_bytes.is_none() {
-            return self.send_batch(index, docs).await;
+            return self.send_batch_with_failed_response(index, docs).await;
         }
 
         let mut summary = crate::processor::BatchResponse::aggregate();
@@ -198,13 +195,10 @@ impl Exporter {
 
             if would_exceed_count || would_exceed_bytes {
                 let doc_count = batch.len() as u32;
-                match self.send_batch(index.clone(), std::mem::take(&mut batch)).await {
-                    Ok(response) => summary.merge(response),
-                    Err(err) => {
-                        tracing::warn!("Failed to send document batch: {}", err);
-                        summary.merge(BatchResponse::failed(doc_count, 0));
-                    }
-                }
+                summary.merge(
+                    self.send_batch_with_failed_response(index.clone(), std::mem::take(&mut batch))
+                        .await?,
+                );
                 batch = Vec::with_capacity(bulk_size);
                 batch_bytes = 0;
             }
@@ -214,17 +208,28 @@ impl Exporter {
         }
 
         if !batch.is_empty() {
-            let doc_count = batch.len() as u32;
-            match self.send_batch(index, batch).await {
-                Ok(response) => summary.merge(response),
-                Err(err) => {
-                    tracing::warn!("Failed to send final document batch: {}", err);
-                    summary.merge(BatchResponse::failed(doc_count, 0));
-                }
-            }
+            summary.merge(self.send_batch_with_failed_response(index, batch).await?);
         }
 
         Ok(summary)
+    }
+
+    async fn send_batch_with_failed_response<T>(
+        &self,
+        index: String,
+        docs: Vec<T>,
+    ) -> Result<crate::processor::BatchResponse>
+    where
+        T: Serialize + Sized + Send + Sync,
+    {
+        let doc_count = docs.len() as u32;
+        match self.send_batch(index, docs).await {
+            Ok(response) => Ok(response),
+            Err(err) => {
+                tracing::warn!("Failed to send document batch: {}", err);
+                Ok(BatchResponse::failed(doc_count, 0))
+            }
+        }
     }
 
     async fn send_batch<T>(&self, index: String, docs: Vec<T>) -> Result<crate::processor::BatchResponse>
@@ -406,6 +411,17 @@ fn estimated_bulk_item_bytes<T: Serialize>(index: &str, doc: &T) -> Result<usize
     Ok(doc_bytes
         .saturating_add(index.len())
         .saturating_add(BULK_ACTION_OVERHEAD_BYTES))
+}
+
+fn elasticsearch_bulk_bytes_limit() -> Option<usize> {
+    match std::env::var("ESDIAG_ES_BULK_BYTES") {
+        Ok(value) => match value.parse::<usize>() {
+            Ok(0) => None,
+            Ok(bytes) => Some(bytes),
+            Err(_) => Some(crate::env::ESDIAG_ES_BULK_BYTES),
+        },
+        Err(_) => Some(crate::env::ESDIAG_ES_BULK_BYTES),
+    }
 }
 
 #[derive(Default)]

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -167,7 +167,7 @@ impl Exporter {
             _ => None,
         };
         if docs.is_empty() {
-            let mut response = crate::processor::BatchResponse::new(0);
+            let mut response = crate::processor::BatchResponse::aggregate();
             response.status_code = 200;
             return Ok(response);
         }
@@ -521,6 +521,7 @@ mod tests {
 
         assert_eq!(response.docs, 0);
         assert_eq!(response.errors, 0);
+        assert_eq!(response.batch_count, 0);
         assert_eq!(response.status_code, 200);
     }
 

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -156,9 +156,6 @@ impl Exporter {
     where
         T: Serialize + Sized + Send + Sync,
     {
-        let bulk_size = crate::env::get_int("ESDIAG_ES_BULK_SIZE")
-            .unwrap_or(crate::env::ESDIAG_ES_BULK_SIZE)
-            .max(1);
         if docs.is_empty() {
             let mut response = crate::processor::BatchResponse::aggregate();
             response.status_code = 200;
@@ -168,32 +165,7 @@ impl Exporter {
             return Err(eyre!("batch send not supported for archive exporter"));
         }
 
-        if docs.len() <= bulk_size {
-            return self.send_batch_with_failed_response(index, docs).await;
-        }
-
-        let mut summary = crate::processor::BatchResponse::aggregate();
-        let mut batch = Vec::with_capacity(bulk_size);
-
-        for doc in docs {
-            let would_exceed_count = batch.len() >= bulk_size;
-
-            if would_exceed_count {
-                summary.merge(
-                    self.send_batch_with_failed_response(index.clone(), std::mem::take(&mut batch))
-                        .await?,
-                );
-                batch = Vec::with_capacity(bulk_size);
-            }
-
-            batch.push(doc);
-        }
-
-        if !batch.is_empty() {
-            summary.merge(self.send_batch_with_failed_response(index, batch).await?);
-        }
-
-        Ok(summary)
+        self.send_batch_with_failed_response(index, docs).await
     }
 
     async fn send_batch_with_failed_response<T>(

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -119,16 +119,23 @@ impl Exporter {
                 let batch = std::mem::replace(&mut accumulator, Vec::with_capacity(batch_size));
                 match self.tx(index.clone(), batch).await {
                     Ok(batch_rx) => batch_receivers.push(batch_rx),
-                    Err(err) => tracing::warn!("Failed to send document batch: {}", err),
+                    Err(err) => {
+                        tracing::warn!("Failed to send document batch: {}", err);
+                        summary.add_batch(BatchResponse::failed(batch_size as u32, 0));
+                    }
                 }
             }
         }
 
         // Send final partial batch
         if !accumulator.is_empty() {
+            let doc_count = accumulator.len() as u32;
             match self.tx(index.clone(), accumulator).await {
                 Ok(batch_rx) => batch_receivers.push(batch_rx),
-                Err(err) => tracing::warn!("Failed to send final document batch: {}", err),
+                Err(err) => {
+                    tracing::warn!("Failed to send final document batch: {}", err);
+                    summary.add_batch(BatchResponse::failed(doc_count, 0));
+                }
             }
         }
 
@@ -149,17 +156,78 @@ impl Exporter {
     where
         T: Serialize + Sized + Send + Sync,
     {
+        let bulk_size = crate::env::get_int("ESDIAG_ES_BULK_SIZE")
+            .unwrap_or(crate::env::ESDIAG_ES_BULK_SIZE)
+            .max(1);
+        let bulk_bytes = match self {
+            Exporter::Elasticsearch(_) => crate::env::get_int("ESDIAG_ES_BULK_BYTES")
+                .ok()
+                .filter(|bytes| *bytes > 0)
+                .or(Some(crate::env::ESDIAG_ES_BULK_BYTES)),
+            _ => None,
+        };
         if docs.is_empty() {
-            return Ok(crate::processor::BatchResponse {
-                docs: 0,
-                errors: 0,
-                retries: 0,
-                size: 0,
-                status_code: 200,
-                time: 0,
-            });
+            let mut response = crate::processor::BatchResponse::new(0);
+            response.status_code = 200;
+            return Ok(response);
+        }
+        if matches!(self, Exporter::Archive(_)) {
+            return Err(eyre!("batch send not supported for archive exporter"));
         }
 
+        if docs.len() <= bulk_size && bulk_bytes.is_none() {
+            return self.send_batch(index, docs).await;
+        }
+
+        let mut summary = crate::processor::BatchResponse::aggregate();
+        let mut batch = Vec::with_capacity(bulk_size);
+        let mut batch_bytes = 0usize;
+
+        for doc in docs {
+            let doc_bytes = match bulk_bytes {
+                Some(_) => estimated_bulk_item_bytes(&index, &doc)?,
+                None => 0,
+            };
+
+            let would_exceed_count = batch.len() >= bulk_size;
+            let would_exceed_bytes = bulk_bytes
+                .is_some_and(|max_bytes| !batch.is_empty() && batch_bytes.saturating_add(doc_bytes) > max_bytes);
+
+            if would_exceed_count || would_exceed_bytes {
+                let doc_count = batch.len() as u32;
+                match self.send_batch(index.clone(), std::mem::take(&mut batch)).await {
+                    Ok(response) => summary.merge(response),
+                    Err(err) => {
+                        tracing::warn!("Failed to send document batch: {}", err);
+                        summary.merge(BatchResponse::failed(doc_count, 0));
+                    }
+                }
+                batch = Vec::with_capacity(bulk_size);
+                batch_bytes = 0;
+            }
+
+            batch_bytes = batch_bytes.saturating_add(doc_bytes);
+            batch.push(doc);
+        }
+
+        if !batch.is_empty() {
+            let doc_count = batch.len() as u32;
+            match self.send_batch(index, batch).await {
+                Ok(response) => summary.merge(response),
+                Err(err) => {
+                    tracing::warn!("Failed to send final document batch: {}", err);
+                    summary.merge(BatchResponse::failed(doc_count, 0));
+                }
+            }
+        }
+
+        Ok(summary)
+    }
+
+    async fn send_batch<T>(&self, index: String, docs: Vec<T>) -> Result<crate::processor::BatchResponse>
+    where
+        T: Serialize + Sized + Send + Sync,
+    {
         match self {
             Exporter::Archive(_) => Err(eyre!("batch send not supported for archive exporter")),
             Exporter::Directory(exporter) => exporter.batch_send(index, docs).await,
@@ -325,6 +393,14 @@ fn format_directory_label(value: &str) -> String {
     } else {
         format!("{value}{}", std::path::MAIN_SEPARATOR)
     }
+}
+
+fn estimated_bulk_item_bytes<T: Serialize>(index: &str, doc: &T) -> Result<usize> {
+    const BULK_ACTION_OVERHEAD_BYTES: usize = 128;
+    let doc_bytes = serde_json::to_vec(doc)?.len();
+    Ok(doc_bytes
+        .saturating_add(index.len())
+        .saturating_add(BULK_ACTION_OVERHEAD_BYTES))
 }
 
 fn path_to_file_uri(path: &Path, is_dir: bool) -> String {

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -23,10 +23,7 @@ use elasticsearch::ElasticsearchExporter;
 use eyre::{Result, eyre};
 use file::FileExporter;
 use serde::Serialize;
-use std::{
-    io,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 use stream::StreamExporter;
 use tokio::sync::{mpsc, oneshot};
 use url::Url;
@@ -162,10 +159,6 @@ impl Exporter {
         let bulk_size = crate::env::get_int("ESDIAG_ES_BULK_SIZE")
             .unwrap_or(crate::env::ESDIAG_ES_BULK_SIZE)
             .max(1);
-        let bulk_bytes = match self {
-            Exporter::Elasticsearch(_) => elasticsearch_bulk_bytes_limit(),
-            _ => None,
-        };
         if docs.is_empty() {
             let mut response = crate::processor::BatchResponse::aggregate();
             response.status_code = 200;
@@ -175,34 +168,24 @@ impl Exporter {
             return Err(eyre!("batch send not supported for archive exporter"));
         }
 
-        if docs.len() <= bulk_size && bulk_bytes.is_none() {
+        if docs.len() <= bulk_size {
             return self.send_batch_with_failed_response(index, docs).await;
         }
 
         let mut summary = crate::processor::BatchResponse::aggregate();
         let mut batch = Vec::with_capacity(bulk_size);
-        let mut batch_bytes = 0usize;
 
         for doc in docs {
-            let doc_bytes = match bulk_bytes {
-                Some(_) => estimated_bulk_item_bytes(&index, &doc)?,
-                None => 0,
-            };
-
             let would_exceed_count = batch.len() >= bulk_size;
-            let would_exceed_bytes = bulk_bytes
-                .is_some_and(|max_bytes| !batch.is_empty() && batch_bytes.saturating_add(doc_bytes) > max_bytes);
 
-            if would_exceed_count || would_exceed_bytes {
+            if would_exceed_count {
                 summary.merge(
                     self.send_batch_with_failed_response(index.clone(), std::mem::take(&mut batch))
                         .await?,
                 );
                 batch = Vec::with_capacity(bulk_size);
-                batch_bytes = 0;
             }
 
-            batch_bytes = batch_bytes.saturating_add(doc_bytes);
             batch.push(doc);
         }
 
@@ -399,43 +382,6 @@ fn format_directory_label(value: &str) -> String {
         value.to_string()
     } else {
         format!("{value}{}", std::path::MAIN_SEPARATOR)
-    }
-}
-
-fn estimated_bulk_item_bytes<T: Serialize>(index: &str, doc: &T) -> Result<usize> {
-    const BULK_ACTION_OVERHEAD_BYTES: usize = 128;
-    let mut writer = CountingWriter::default();
-    serde_json::to_writer(&mut writer, doc)?;
-    let doc_bytes = writer.bytes;
-    Ok(doc_bytes
-        .saturating_add(index.len())
-        .saturating_add(BULK_ACTION_OVERHEAD_BYTES))
-}
-
-fn elasticsearch_bulk_bytes_limit() -> Option<usize> {
-    match std::env::var("ESDIAG_ES_BULK_BYTES") {
-        Ok(value) => match value.parse::<usize>() {
-            Ok(0) => None,
-            Ok(bytes) => Some(bytes),
-            Err(_) => Some(crate::env::ESDIAG_ES_BULK_BYTES),
-        },
-        Err(_) => Some(crate::env::ESDIAG_ES_BULK_BYTES),
-    }
-}
-
-#[derive(Default)]
-struct CountingWriter {
-    bytes: usize,
-}
-
-impl io::Write for CountingWriter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.bytes = self.bytes.saturating_add(buf.len());
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
     }
 }
 

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -194,7 +194,6 @@ impl Exporter {
                 .is_some_and(|max_bytes| !batch.is_empty() && batch_bytes.saturating_add(doc_bytes) > max_bytes);
 
             if would_exceed_count || would_exceed_bytes {
-                let doc_count = batch.len() as u32;
                 summary.merge(
                     self.send_batch_with_failed_response(index.clone(), std::mem::take(&mut batch))
                         .await?,

--- a/src/exporter/stream.rs
+++ b/src/exporter/stream.rs
@@ -46,6 +46,7 @@ impl Export for StreamExporter {
         let start_time = tokio::time::Instant::now();
         let doc_count = docs.len() as u32;
         let mut batch = BatchResponse::new(doc_count);
+        batch.status_code = 200;
         tracing::debug!("{} wrote {} docs to stdout", index, doc_count);
         for doc in docs {
             serde_json::to_writer(std::io::stdout(), &doc)?;

--- a/src/exporter/stream.rs
+++ b/src/exporter/stream.rs
@@ -63,6 +63,7 @@ impl Export for StreamExporter {
         T: Serialize + Sized + Send + Sync + 'static,
     {
         let (tx, rx) = oneshot::channel();
+        let doc_count = docs.len() as u32;
 
         // Stream exporter writes synchronously, so we just write and send the response
         match self.batch_send(index, docs).await {
@@ -71,7 +72,12 @@ impl Export for StreamExporter {
                     tracing::error!("Failed to send batch response");
                 }
             }
-            Err(e) => tracing::warn!("Stream write failed: {}", e),
+            Err(e) => {
+                tracing::warn!("Stream write failed: {}", e);
+                if tx.send(BatchResponse::failed(doc_count, 0)).is_err() {
+                    tracing::error!("Failed to send failed batch response");
+                }
+            }
         }
 
         Ok(rx)

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -404,12 +404,12 @@ impl BatchResponse {
         }
     }
 
-    pub fn failed(docs: u32, status_code: u16) -> Self {
+    pub fn failed(error_count: u32, status_code: u16) -> Self {
         Self {
             batch_count: 1,
             status_counts: HashMap::new(),
             docs: 0,
-            errors: docs,
+            errors: error_count,
             retries: 0,
             size: 0,
             status_code,

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -404,12 +404,12 @@ impl BatchResponse {
         }
     }
 
-    pub fn failed(error_count: u32, status_code: u16) -> Self {
+    pub fn failed(failed_doc_count: u32, status_code: u16) -> Self {
         Self {
             batch_count: 1,
             status_counts: HashMap::new(),
             docs: 0,
-            errors: error_count,
+            errors: failed_doc_count,
             retries: 0,
             size: 0,
             status_code,

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -587,6 +587,10 @@ impl ProcessorSummary {
     }
 
     pub fn add_batch(&mut self, batch: BatchResponse) {
+        if batch.batch_count == 0 && batch.docs == 0 && batch.errors == 0 {
+            return;
+        }
+
         self.batch.count += batch.batch_count;
         self.batch.retries += batch.retries;
         if batch.status_counts.is_empty() {
@@ -754,6 +758,20 @@ user: ada
         assert_eq!(value["batch"]["count"], 2);
         assert_eq!(value["batch"]["status_codes"]["200"], 2);
         assert_eq!(value["docs"], 5);
+    }
+
+    #[test]
+    fn processor_summary_ignores_empty_noop_batch_response() {
+        let mut empty = BatchResponse::aggregate();
+        empty.status_code = 200;
+
+        let mut summary = ProcessorSummary::new("metrics-ingest.pipeline-esdiag".to_string());
+        summary.add_batch(empty);
+
+        let value = serde_json::to_value(summary).expect("summary json");
+        assert_eq!(value["batch"]["count"], 0);
+        assert_eq!(value["batch"]["status_codes"], serde_json::json!({}));
+        assert_eq!(value["docs"], 0);
     }
 
     #[test]

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -270,8 +270,29 @@ impl<T> NestedStats<T> {
     }
 }
 
+#[cfg(test)]
+impl NestedStats<ProcessorSummary> {
+    fn stats(&self) -> &HashMap<String, ProcessorSummary> {
+        &self.stats
+    }
+
+    fn errors(&self) -> u32 {
+        self.errors
+    }
+
+    fn count(&self) -> u32 {
+        self.count
+    }
+}
+
 impl DiagnosticReport {
     pub fn add_processor_summary(&mut self, summary: ProcessorSummary) {
+        for summary in summary.into_summaries() {
+            self.add_single_processor_summary(summary);
+        }
+    }
+
+    fn add_single_processor_summary(&mut self, summary: ProcessorSummary) {
         if !summary.source.parsed {
             self.diagnostic.processor.errors += 1;
             self.diagnostic.processor.failures.push(summary.index.clone());
@@ -342,8 +363,12 @@ impl TryFrom<DiagnosticReportBuilder> for DiagnosticReport {
     }
 }
 
-#[derive(Serialize, Clone, Copy)]
+#[derive(Serialize, Clone)]
 pub struct BatchResponse {
+    #[serde(skip_serializing)]
+    pub batch_count: u32,
+    #[serde(skip_serializing)]
+    status_counts: HashMap<u16, u32>,
     pub docs: u32,
     pub errors: u32,
     pub retries: u16,
@@ -355,12 +380,76 @@ pub struct BatchResponse {
 impl BatchResponse {
     pub fn new(docs: u32) -> Self {
         Self {
+            batch_count: 1,
+            status_counts: HashMap::new(),
             docs,
             errors: 0,
             retries: 0,
             size: 0,
             status_code: 0,
             time: 0,
+        }
+    }
+
+    pub fn aggregate() -> Self {
+        Self {
+            batch_count: 0,
+            status_counts: HashMap::new(),
+            docs: 0,
+            errors: 0,
+            retries: 0,
+            size: 0,
+            status_code: 0,
+            time: 0,
+        }
+    }
+
+    pub fn failed(docs: u32, status_code: u16) -> Self {
+        Self {
+            batch_count: 1,
+            status_counts: HashMap::new(),
+            docs: 0,
+            errors: docs,
+            retries: 0,
+            size: 0,
+            status_code,
+            time: 0,
+        }
+    }
+
+    pub fn merge(&mut self, other: Self) {
+        let was_empty = self.batch_count == 0;
+        self.batch_count += other.batch_count;
+        self.docs += other.docs;
+        self.errors += other.errors;
+        self.retries += other.retries;
+        self.size += other.size;
+        self.time += other.time;
+        self.status_code = match (self.status_code, other.status_code) {
+            (0, status) if was_empty => status,
+            (status, 0) if other.errors == 0 => status,
+            (left, right) if left == right => left,
+            _ => 0,
+        };
+        self.merge_status_counts(&other);
+    }
+
+    fn merge_status_counts(&mut self, other: &Self) {
+        if other.status_counts.is_empty() {
+            if other.batch_count > 0 {
+                self.status_counts
+                    .entry(other.status_code)
+                    .and_modify(|count| *count += other.batch_count)
+                    .or_insert(other.batch_count);
+            }
+            return;
+        }
+
+        for (status, count) in &other.status_counts {
+            self.status_counts
+                .entry(*status)
+                .and_modify(|existing| *existing += count)
+                .or_insert(*count);
         }
     }
 }
@@ -390,6 +479,8 @@ pub struct ProcessorSummary {
     pub processor: String,
     pub index: String,
     pub source: Source,
+    #[serde(skip_serializing)]
+    children: Vec<ProcessorSummary>,
 }
 
 impl ProcessorSummary {
@@ -404,6 +495,25 @@ impl ProcessorSummary {
                 tracing::warn!("processor summary was err: {}", err);
             }
         }
+    }
+
+    pub fn add_child(&mut self, other: Result<ProcessorSummary>) {
+        match other {
+            Ok(other) => self.children.push(other),
+            Err(err) => {
+                tracing::warn!("processor summary was err: {}", err);
+            }
+        }
+    }
+
+    fn into_summaries(mut self) -> Vec<ProcessorSummary> {
+        let children = std::mem::take(&mut self.children);
+        let mut summaries = Vec::with_capacity(children.len() + 1);
+        summaries.push(self);
+        for child in children {
+            summaries.extend(child.into_summaries());
+        }
+        summaries
     }
 }
 
@@ -451,6 +561,13 @@ impl std::fmt::Display for Source {
     }
 }
 
+impl Source {
+    #[cfg(test)]
+    fn parsed(&self) -> bool {
+        self.parsed
+    }
+}
+
 impl ProcessorSummary {
     pub fn new(name: String) -> Self {
         Self {
@@ -465,27 +582,37 @@ impl ProcessorSummary {
             doc_errors: 0,
             processor: name,
             source: Source { parsed: false },
+            children: Vec::new(),
         }
     }
 
     pub fn add_batch(&mut self, batch: BatchResponse) {
-        self.batch.count += 1;
+        self.batch.count += batch.batch_count;
         self.batch.retries += batch.retries;
-        self.batch
-            .status_codes
-            .entry(batch.status_code)
-            .and_modify(|count| *count += 1)
-            .or_insert(1);
+        if batch.status_counts.is_empty() {
+            self.batch
+                .status_codes
+                .entry(batch.status_code)
+                .and_modify(|count| *count += batch.batch_count)
+                .or_insert(batch.batch_count);
+        } else {
+            for (status, count) in &batch.status_counts {
+                self.batch
+                    .status_codes
+                    .entry(*status)
+                    .and_modify(|existing| *existing += count)
+                    .or_insert(*count);
+            }
+        }
         self.docs += batch.docs;
         self.doc_errors += batch.errors;
         self.batch.responses.push(batch);
     }
 
-    pub fn was_parsed(self) -> Self {
-        Self {
-            source: Source { parsed: true },
-            ..self
-        }
+    pub fn was_parsed(mut self) -> Self {
+        self.source = Source { parsed: true };
+        self.children = self.children.into_iter().map(ProcessorSummary::was_parsed).collect();
+        self
     }
 
     pub fn rename(self, name: String) -> Self {
@@ -493,6 +620,11 @@ impl ProcessorSummary {
             processor: name,
             ..self
         }
+    }
+
+    #[cfg(test)]
+    fn doc_errors(&self) -> u32 {
+        self.doc_errors
     }
 }
 
@@ -603,5 +735,59 @@ user: ada
         assert!(!yaml.contains("account"));
         assert!(!yaml.contains("case_number"));
         assert!(yaml.contains("user: ada"));
+    }
+
+    #[test]
+    fn processor_summary_preserves_aggregated_batch_status_counts() {
+        let mut aggregate = BatchResponse::aggregate();
+        let mut first = BatchResponse::new(2);
+        first.status_code = 200;
+        let mut second = BatchResponse::new(3);
+        second.status_code = 200;
+        aggregate.merge(first);
+        aggregate.merge(second);
+
+        let mut summary = ProcessorSummary::new("metrics-task-esdiag".to_string());
+        summary.add_batch(aggregate);
+
+        let value = serde_json::to_value(summary).expect("summary json");
+        assert_eq!(value["batch"]["count"], 2);
+        assert_eq!(value["batch"]["status_codes"]["200"], 2);
+        assert_eq!(value["docs"], 5);
+    }
+
+    #[test]
+    fn diagnostic_report_flattens_child_processor_summaries() {
+        let metadata = DiagnosticMetadata {
+            id: "test".to_string(),
+            collection_date: 0,
+            runner: "test".to_string(),
+            uuid: "test".to_string(),
+        };
+        let mut report =
+            DiagnosticReport::try_from(DiagnosticReportBuilder::from(metadata).receiver("file path".to_string()))
+                .unwrap();
+
+        let mut parent = ProcessorSummary::new("metrics-node-esdiag".to_string());
+        let mut parent_batch = BatchResponse::new(4);
+        parent_batch.status_code = 200;
+        parent.add_batch(parent_batch);
+
+        let mut child = ProcessorSummary::new("metrics-node.http.clients-esdiag".to_string());
+        let mut child_batch = BatchResponse::failed(2, 400);
+        child_batch.status_code = 400;
+        child.add_batch(child_batch);
+
+        parent.add_child(Ok(child));
+        report.add_processor_summary(parent.was_parsed());
+
+        let stats = report.diagnostic.processor.stats();
+        assert_eq!(report.diagnostic.processor.count(), 2);
+        assert_eq!(report.diagnostic.processor.errors(), 0);
+        assert_eq!(report.diagnostic.docs.created, 4);
+        assert_eq!(report.diagnostic.docs.errors, 2);
+        assert!(stats["metrics-node-esdiag"].source.parsed());
+        assert!(stats["metrics-node.http.clients-esdiag"].source.parsed());
+        assert_eq!(stats["metrics-node.http.clients-esdiag"].doc_errors(), 2);
     }
 }

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -419,12 +419,12 @@ impl BatchResponse {
 
     pub fn merge(&mut self, other: Self) {
         let was_empty = self.batch_count == 0;
-        self.batch_count += other.batch_count;
-        self.docs += other.docs;
-        self.errors += other.errors;
-        self.retries += other.retries;
-        self.size += other.size;
-        self.time += other.time;
+        self.batch_count = self.batch_count.saturating_add(other.batch_count);
+        self.docs = self.docs.saturating_add(other.docs);
+        self.errors = self.errors.saturating_add(other.errors);
+        self.retries = self.retries.saturating_add(other.retries);
+        self.size = self.size.saturating_add(other.size);
+        self.time = self.time.saturating_add(other.time);
         self.status_code = match (self.status_code, other.status_code) {
             (0, status) if was_empty => status,
             (status, 0) if other.errors == 0 => status,
@@ -439,7 +439,7 @@ impl BatchResponse {
             if other.batch_count > 0 {
                 self.status_counts
                     .entry(other.status_code)
-                    .and_modify(|count| *count += other.batch_count)
+                    .and_modify(|count| *count = count.saturating_add(other.batch_count))
                     .or_insert(other.batch_count);
             }
             return;
@@ -448,7 +448,7 @@ impl BatchResponse {
         for (status, count) in &other.status_counts {
             self.status_counts
                 .entry(*status)
-                .and_modify(|existing| *existing += count)
+                .and_modify(|existing| *existing = existing.saturating_add(*count))
                 .or_insert(*count);
         }
     }
@@ -488,8 +488,8 @@ impl ProcessorSummary {
         match other {
             Ok(other) => {
                 self.batch.merge(other.batch);
-                self.docs += other.docs;
-                self.doc_errors += other.doc_errors;
+                self.docs = self.docs.saturating_add(other.docs);
+                self.doc_errors = self.doc_errors.saturating_add(other.doc_errors);
             }
             Err(err) => {
                 tracing::warn!("processor summary was err: {}", err);
@@ -538,12 +538,12 @@ pub struct BatchStats {
 
 impl BatchStats {
     pub fn merge(&mut self, other: BatchStats) {
-        self.count += other.count;
-        self.retries += other.retries;
+        self.count = self.count.saturating_add(other.count);
+        self.retries = self.retries.saturating_add(other.retries);
         for (code, count) in other.status_codes {
             self.status_codes
                 .entry(code)
-                .and_modify(|c| *c += count)
+                .and_modify(|c| *c = c.saturating_add(count))
                 .or_insert(count);
         }
         self.responses.extend(other.responses);
@@ -591,25 +591,25 @@ impl ProcessorSummary {
             return;
         }
 
-        self.batch.count += batch.batch_count;
-        self.batch.retries += batch.retries;
+        self.batch.count = self.batch.count.saturating_add(batch.batch_count);
+        self.batch.retries = self.batch.retries.saturating_add(batch.retries);
         if batch.status_counts.is_empty() {
             self.batch
                 .status_codes
                 .entry(batch.status_code)
-                .and_modify(|count| *count += batch.batch_count)
+                .and_modify(|count| *count = count.saturating_add(batch.batch_count))
                 .or_insert(batch.batch_count);
         } else {
             for (status, count) in &batch.status_counts {
                 self.batch
                     .status_codes
                     .entry(*status)
-                    .and_modify(|existing| *existing += count)
+                    .and_modify(|existing| *existing = existing.saturating_add(*count))
                     .or_insert(*count);
             }
         }
-        self.docs += batch.docs;
-        self.doc_errors += batch.errors;
+        self.docs = self.docs.saturating_add(batch.docs);
+        self.doc_errors = self.doc_errors.saturating_add(batch.errors);
         self.batch.responses.push(batch);
     }
 
@@ -758,6 +758,60 @@ user: ada
         assert_eq!(value["batch"]["count"], 2);
         assert_eq!(value["batch"]["status_codes"]["200"], 2);
         assert_eq!(value["docs"], 5);
+    }
+
+    #[test]
+    fn batch_response_merge_saturates_summary_counters() {
+        let mut left = BatchResponse {
+            batch_count: u32::MAX,
+            status_counts: std::collections::HashMap::from([(200, u32::MAX)]),
+            docs: u32::MAX,
+            errors: u32::MAX,
+            retries: u16::MAX,
+            size: u32::MAX,
+            status_code: 200,
+            time: u32::MAX,
+        };
+        let mut right = BatchResponse::new(1);
+        right.errors = 1;
+        right.retries = 1;
+        right.size = 1;
+        right.status_code = 200;
+        right.time = 1;
+        right.status_counts.insert(200, 1);
+
+        left.merge(right);
+
+        assert_eq!(left.batch_count, u32::MAX);
+        assert_eq!(left.docs, u32::MAX);
+        assert_eq!(left.errors, u32::MAX);
+        assert_eq!(left.retries, u16::MAX);
+        assert_eq!(left.size, u32::MAX);
+        assert_eq!(left.time, u32::MAX);
+        assert_eq!(left.status_counts[&200], u32::MAX);
+    }
+
+    #[test]
+    fn processor_summary_add_batch_saturates_summary_counters() {
+        let mut summary = ProcessorSummary::new("metrics-task-esdiag".to_string());
+        summary.batch.count = u32::MAX;
+        summary.batch.retries = u16::MAX;
+        summary.batch.status_codes.insert(200, u32::MAX);
+        summary.docs = u32::MAX;
+        summary.doc_errors = u32::MAX;
+
+        let mut batch = BatchResponse::new(1);
+        batch.errors = 1;
+        batch.retries = 1;
+        batch.status_code = 200;
+
+        summary.add_batch(batch);
+
+        assert_eq!(summary.batch.count, u32::MAX);
+        assert_eq!(summary.batch.retries, u16::MAX);
+        assert_eq!(summary.batch.status_codes[&200], u32::MAX);
+        assert_eq!(summary.docs, u32::MAX);
+        assert_eq!(summary.doc_errors, u32::MAX);
     }
 
     #[test]

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -761,6 +761,20 @@ user: ada
     }
 
     #[test]
+    fn processor_summary_records_successful_local_batch_as_status_200() {
+        let mut summary = ProcessorSummary::new("metrics-node-esdiag".to_string());
+        let mut batch = BatchResponse::new(3);
+        batch.status_code = 200;
+
+        summary.add_batch(batch);
+
+        let value = serde_json::to_value(summary).expect("summary json");
+        assert_eq!(value["batch"]["status_codes"]["200"], 1);
+        assert_eq!(value["batch"]["status_codes"].get("0"), None);
+        assert_eq!(value["docs"], 3);
+    }
+
+    #[test]
     fn batch_response_merge_saturates_summary_counters() {
         let mut left = BatchResponse {
             batch_count: u32::MAX,

--- a/src/processor/elasticsearch/nodes_stats/processor.rs
+++ b/src/processor/elasticsearch/nodes_stats/processor.rs
@@ -275,7 +275,7 @@ impl StreamingDocumentExporter<Lookups, ElasticsearchMetadata> for NodesStats {
         );
 
         let (processors_tx, processors_rx) = mpsc::channel::<ingest_pipelines::IngestDoc>(BUFFER_SIZE);
-        let processors_data_stream = "metrics-ingest.processors-esdiag".to_string();
+        let processors_data_stream = "metrics-ingest.processor-esdiag".to_string();
         let processors_processor = tokio::spawn(exporter.clone().document_channel::<ingest_pipelines::IngestDoc>(
             processors_rx,
             processors_data_stream,
@@ -337,12 +337,12 @@ impl StreamingDocumentExporter<Lookups, ElasticsearchMetadata> for NodesStats {
         );
 
         summary.merge(nodes_stats_result.map_err(|err| eyre::Report::new(err)));
-        summary.merge(actions_result.map_err(|err| eyre::Report::new(err)));
-        summary.merge(http_clients_result.map_err(|err| eyre::Report::new(err)));
-        summary.merge(applier_result.map_err(|err| eyre::Report::new(err)));
-        summary.merge(adaptive_result.map_err(|err| eyre::Report::new(err)));
-        summary.merge(pipelines_result.map_err(|err| eyre::Report::new(err)));
-        summary.merge(processors_result.map_err(|err| eyre::Report::new(err)));
+        summary.add_child(actions_result.map_err(|err| eyre::Report::new(err)));
+        summary.add_child(http_clients_result.map_err(|err| eyre::Report::new(err)));
+        summary.add_child(applier_result.map_err(|err| eyre::Report::new(err)));
+        summary.add_child(adaptive_result.map_err(|err| eyre::Report::new(err)));
+        summary.add_child(pipelines_result.map_err(|err| eyre::Report::new(err)));
+        summary.add_child(processors_result.map_err(|err| eyre::Report::new(err)));
 
         summary
     }

--- a/src/processor/elasticsearch/tasks/processor.rs
+++ b/src/processor/elasticsearch/tasks/processor.rs
@@ -44,9 +44,13 @@ impl DocumentExporter<Lookups, ElasticsearchMetadata> for Tasks {
 
         tracing::debug!("task docs: {}", tasks.len());
         let mut summary = ProcessorSummary::new(data_stream.clone());
+        let doc_count = tasks.len() as u32;
         match exporter.send(data_stream, tasks).await {
             Ok(batch) => summary.add_batch(batch),
-            Err(err) => tracing::error!("Failed to send tasks: {}", err),
+            Err(err) => {
+                tracing::error!("Failed to send tasks: {}", err);
+                summary.add_batch(crate::processor::BatchResponse::failed(doc_count, 0));
+            }
         }
         summary
     }

--- a/src/processor/logstash/node/data.rs
+++ b/src/processor/logstash/node/data.rs
@@ -30,15 +30,21 @@ impl Node {
 
 #[derive(Deserialize, Serialize)]
 pub struct Pipeline {
+    #[serde(skip_serializing_if = "Option::is_none")]
     ephemeral_id: Option<String>,
-    hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hash: Option<String>,
     workers: u32,
     batch_size: u32,
     batch_delay: u32,
-    config_reload_automatic: bool,
-    config_reload_interval: u64,
-    dead_letter_queue_enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    config_reload_automatic: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    config_reload_interval: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dead_letter_queue_enabled: Option<bool>,
     // Not in source file
+    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
 }
 

--- a/src/processor/logstash/node_stats/data.rs
+++ b/src/processor/logstash/node_stats/data.rs
@@ -12,12 +12,16 @@ pub struct NodeStats {
     jvm: JvmStats,
     process: ProcessStats,
     events: EventStats,
-    flow: HashMap<String, StatsHistory>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flow: Option<HashMap<String, StatsHistory>>,
     #[serde(skip_serializing)]
     pipelines: Option<HashMap<String, PipelineStats>>,
-    reloads: ReloadStats,
-    os: OsStats,
-    queue: QueueStats,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reloads: Option<ReloadStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    os: Option<OsStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    queue: Option<QueueStats>,
 }
 
 impl NodeStats {
@@ -121,12 +125,17 @@ struct EventStats {
 #[derive(Deserialize, Serialize)]
 pub struct PipelineStats {
     r#events: EventStats,
-    flow: HashMap<String, StatsHistory>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flow: Option<HashMap<String, StatsHistory>>,
     #[serde(skip_serializing)]
     plugins: Option<PipelinePlugins>,
-    reloads: PipelineReloadStats,
-    queue: PipelineQueueStats,
-    hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reloads: Option<PipelineReloadStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    queue: Option<PipelineQueueStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ephemeral_id: Option<String>,
 }
 
@@ -138,18 +147,24 @@ impl PipelineStats {
 
 #[derive(Deserialize, Serialize)]
 pub struct PipelinePlugins {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub inputs: Vec<InputPlugin>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub codecs: Vec<CodecPlugin>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub filters: Vec<FilterPlugin>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub outputs: Vec<OutputPlugin>,
 }
 
 #[derive(Deserialize, Serialize)]
 pub struct InputPlugin {
     id: String,
-    flow: HashMap<String, StatsHistory>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flow: Option<HashMap<String, StatsHistory>>,
     name: String,
     events: EventStats,
+    #[serde(skip_serializing_if = "Option::is_none")]
     address: Option<String>,
 }
 
@@ -170,7 +185,8 @@ struct CodecStats {
 #[derive(Deserialize, Serialize)]
 pub struct FilterPlugin {
     id: String,
-    flow: HashMap<String, StatsHistory>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flow: Option<HashMap<String, StatsHistory>>,
     name: String,
     r#events: EventStats,
 }
@@ -188,10 +204,13 @@ struct StatsHistory {
 #[derive(Deserialize, Serialize)]
 pub struct OutputPlugin {
     id: String,
-    flow: HashMap<String, StatsHistory>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flow: Option<HashMap<String, StatsHistory>>,
     name: String,
     r#events: EventStats,
+    #[serde(skip_serializing_if = "Option::is_none")]
     documents: Option<OutputDocumentsStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     bulk_requests: Option<OutputBulkRequestsStats>,
 }
 
@@ -219,13 +238,20 @@ struct PipelineReloadStats {
 
 #[derive(Deserialize, Serialize)]
 struct PipelineQueueStats {
-    r#type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    r#type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     capacity: Option<QueueCapacityStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     events: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     data: Option<QueueDataStats>,
-    events_count: usize,
-    queue_size_in_bytes: usize,
-    max_queue_size_in_bytes: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    events_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    queue_size_in_bytes: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_queue_size_in_bytes: Option<usize>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -283,7 +309,8 @@ struct CpuAcctStats {
 
 #[derive(Deserialize, Serialize)]
 struct QueueStats {
-    events_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    events_count: Option<usize>,
 }
 
 impl DataSource for NodeStats {

--- a/tests/elasticsearch_asset_templates_tests.rs
+++ b/tests/elasticsearch_asset_templates_tests.rs
@@ -1,0 +1,35 @@
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+fn template_dataset(file_name: &str) -> String {
+    let path = Path::new("assets/elasticsearch/index_templates").join(file_name);
+    let content = fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {}: {}", path.display(), err));
+    let template: Value =
+        serde_json::from_str(&content).unwrap_or_else(|err| panic!("parse {}: {}", path.display(), err));
+
+    template["template"]["mappings"]["properties"]["data_stream"]["properties"]["dataset"]["value"]
+        .as_str()
+        .unwrap_or_else(|| panic!("{} missing data_stream.dataset.value", path.display()))
+        .to_string()
+}
+
+#[test]
+fn node_derived_metrics_templates_use_matching_dataset_constants() {
+    let templates = [
+        ("metrics-node.transport.actions.json", "node.transport.actions"),
+        ("metrics-node.http.clients.json", "node.http.clients"),
+        (
+            "metrics-node.discovery.cluster_applier.json",
+            "node.discovery.cluster_applier",
+        ),
+        (
+            "metrics-node.discovery.cluster_adaptive.json",
+            "node.discovery.cluster_adaptive",
+        ),
+    ];
+
+    for (file_name, expected_dataset) in templates {
+        assert_eq!(template_dataset(file_name), expected_dataset);
+    }
+}

--- a/tests/elasticsearch_asset_templates_tests.rs
+++ b/tests/elasticsearch_asset_templates_tests.rs
@@ -3,7 +3,9 @@ use std::fs;
 use std::path::Path;
 
 fn template_dataset(file_name: &str) -> String {
-    let path = Path::new("assets/elasticsearch/index_templates").join(file_name);
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("assets/elasticsearch/index_templates")
+        .join(file_name);
     let content = fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {}: {}", path.display(), err));
     let template: Value =
         serde_json::from_str(&content).unwrap_or_else(|err| panic!("parse {}: {}", path.display(), err));

--- a/tests/elasticsearch_asset_templates_tests.rs
+++ b/tests/elasticsearch_asset_templates_tests.rs
@@ -16,6 +16,17 @@ fn template_dataset(file_name: &str) -> String {
         .to_string()
 }
 
+fn template_dataset_mapping(file_name: &str) -> Value {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("assets/elasticsearch/index_templates")
+        .join(file_name);
+    let content = fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {}: {}", path.display(), err));
+    let template: Value =
+        serde_json::from_str(&content).unwrap_or_else(|err| panic!("parse {}: {}", path.display(), err));
+
+    template["template"]["mappings"]["properties"]["data_stream"]["properties"]["dataset"].clone()
+}
+
 #[test]
 fn node_derived_metrics_templates_use_matching_dataset_constants() {
     let templates = [
@@ -33,5 +44,17 @@ fn node_derived_metrics_templates_use_matching_dataset_constants() {
 
     for (file_name, expected_dataset) in templates {
         assert_eq!(template_dataset(file_name), expected_dataset);
+    }
+}
+
+#[test]
+fn logstash_templates_allow_concrete_logstash_datasets() {
+    for file_name in ["settings-logstash.json", "metrics-logstash.json"] {
+        let dataset = template_dataset_mapping(file_name);
+        assert_eq!(dataset["type"].as_str(), Some("constant_keyword"));
+        assert!(
+            dataset.get("value").is_none(),
+            "{file_name} must not pin all logstash sub-streams to data_stream.dataset=logstash"
+        );
     }
 }

--- a/tests/logstash_archive_processing_tests.rs
+++ b/tests/logstash_archive_processing_tests.rs
@@ -1,0 +1,134 @@
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::{TempDir, tempdir};
+
+fn logstash_archive_fixtures() -> Vec<PathBuf> {
+    let archives_dir = Path::new("tests/archives");
+    let mut archives = Vec::new();
+    for entry in fs::read_dir(archives_dir).expect("read tests/archives") {
+        let entry = entry.expect("archive dir entry");
+        let path = entry.path();
+        let filename = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
+        if filename.starts_with("logstash-api-diagnostics-") && filename.ends_with(".zip") {
+            archives.push(path);
+        }
+    }
+    archives.sort();
+    assert!(!archives.is_empty(), "no logstash archive fixtures found");
+    archives
+}
+
+fn process_archive(archive: &Path, output: &Path, home: &Path) {
+    let process = Command::new(env!("CARGO_BIN_EXE_esdiag"))
+        .args([
+            "process",
+            archive.to_str().expect("archive path"),
+            output.to_str().expect("output path"),
+        ])
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .output()
+        .expect("run esdiag process");
+
+    assert!(
+        process.status.success(),
+        "process failed for {}\nstdout:\n{}\nstderr:\n{}",
+        archive.display(),
+        String::from_utf8_lossy(&process.stdout),
+        String::from_utf8_lossy(&process.stderr)
+    );
+}
+
+fn read_docs(output_dir: &Path, file_name: &str) -> Vec<Value> {
+    let path = output_dir.join(file_name);
+    let content = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {} failed: {}", path.display(), e));
+    let docs: Vec<Value> = content
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str::<Value>(line)
+                .unwrap_or_else(|e| panic!("failed parsing document from {}: {}", path.display(), e))
+        })
+        .collect();
+    assert!(!docs.is_empty(), "{} had no documents", path.display());
+    docs
+}
+
+fn assert_has_dataset(docs: &[Value], expected_dataset: &str, archive: &Path, stream: &str) {
+    assert!(
+        docs.iter()
+            .any(|doc| doc["data_stream"]["dataset"].as_str() == Some(expected_dataset)),
+        "{} in {} did not contain data_stream.dataset={}",
+        stream,
+        archive.display(),
+        expected_dataset
+    );
+}
+
+fn assert_no_base_logstash_dataset(docs: &[Value], archive: &Path, stream: &str) {
+    assert!(
+        docs.iter()
+            .all(|doc| doc["data_stream"]["dataset"].as_str() != Some("logstash")),
+        "{} in {} unexpectedly used broad data_stream.dataset=logstash",
+        stream,
+        archive.display()
+    );
+}
+
+#[test]
+fn logstash_archive_fixtures_process_across_supported_versions() {
+    let home = tempdir().expect("temp HOME");
+    let output_root = TempDir::new().expect("temp output");
+
+    for archive in logstash_archive_fixtures() {
+        let archive_output = output_root.path().join(
+            archive
+                .file_stem()
+                .and_then(|name| name.to_str())
+                .expect("archive file stem"),
+        );
+        fs::create_dir(&archive_output).expect("archive output dir");
+        process_archive(&archive, &archive_output, home.path());
+
+        let settings_node = read_docs(&archive_output, "settings-logstash.node-esdiag.ndjson");
+        let metrics_node = read_docs(&archive_output, "metrics-logstash.node-esdiag.ndjson");
+        let settings_plugin = read_docs(&archive_output, "settings-logstash.plugin-esdiag.ndjson");
+
+        assert_has_dataset(
+            &settings_node,
+            "logstash.node",
+            &archive,
+            "settings-logstash.node-esdiag",
+        );
+        assert_has_dataset(
+            &settings_node,
+            "logstash.pipeline",
+            &archive,
+            "settings-logstash.node-esdiag",
+        );
+        assert_has_dataset(&metrics_node, "logstash.node", &archive, "metrics-logstash.node-esdiag");
+        assert_has_dataset(
+            &metrics_node,
+            "logstash.pipeline",
+            &archive,
+            "metrics-logstash.node-esdiag",
+        );
+        assert_has_dataset(
+            &metrics_node,
+            "logstash.plugin",
+            &archive,
+            "metrics-logstash.node-esdiag",
+        );
+        assert_has_dataset(
+            &settings_plugin,
+            "logstash.plugin",
+            &archive,
+            "settings-logstash.plugin-esdiag",
+        );
+        assert_no_base_logstash_dataset(&settings_node, &archive, "settings-logstash.node-esdiag");
+        assert_no_base_logstash_dataset(&metrics_node, &archive, "metrics-logstash.node-esdiag");
+        assert_no_base_logstash_dataset(&settings_plugin, &archive, "settings-logstash.plugin-esdiag");
+    }
+}

--- a/tests/logstash_archive_processing_tests.rs
+++ b/tests/logstash_archive_processing_tests.rs
@@ -5,9 +5,9 @@ use std::process::Command;
 use tempfile::{TempDir, tempdir};
 
 fn logstash_archive_fixtures() -> Vec<PathBuf> {
-    let archives_dir = Path::new("tests/archives");
+    let archives_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/archives");
     let mut archives = Vec::new();
-    for entry in fs::read_dir(archives_dir).expect("read tests/archives") {
+    for entry in fs::read_dir(&archives_dir).expect("read tests/archives") {
         let entry = entry.expect("archive dir entry");
         let path = entry.path();
         let filename = path.file_name().and_then(|f| f.to_str()).unwrap_or("");


### PR DESCRIPTION
## Summary

- Move Elasticsearch bulk chunking into the exporter with document and byte caps.
- Preserve failed send accounting in processor reports instead of losing failed batches.
- Report node-stats child streams separately and add matching node-derived metrics templates.
- Fix ingest processor stats to use `metrics-ingest.processor-esdiag`.

## Validation

- `cargo test`: 399 passed, 23 ignored
- `cargo check`
- `git diff --check`
- Processed the large diagnostic bundle against local Elasticsearch: 104283 created, 0 errors
