### PR TITLE
Add OKF metadata and docs tag filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ published release notes, maintenance branches, and tagged history.
 - Improved saved host authentication persistence.
 - Improved agentic CLI summaries and viewer-aware Kibana links.
 - Changed Kibana collection and setup to use the shared `kibana-sync` client and bundled asset layout (#341).
+- Made embedded documentation minimally Open Knowledge Format compliant while preserving clean docs viewer rendering (#345).
+- Added documentation viewer tag filtering with debug-mode visibility for developer-only docs (#345).
 
 ### Fixed
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,3 +1,10 @@
+---
+type: Reference
+title: ESDiag API Documentation
+description: Overview of the ESDiag service API for processing Elastic Stack diagnostic bundles.
+tags: [api, reference]
+---
+
 ESDiag API Documentation
 ========================
 

--- a/docs/api/examples.md
+++ b/docs/api/examples.md
@@ -1,3 +1,10 @@
+---
+type: Reference
+title: API Usage Examples
+description: Practical request and response examples for the ESDiag service API.
+tags: [api, examples, reference]
+---
+
 # API Usage Examples
 
 This document provides practical examples of how to use the ESDiag API endpoints.

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -1,3 +1,10 @@
+---
+type: Reference
+title: Data Types
+description: Data type definitions used by the ESDiag service API.
+tags: [api, types, reference]
+---
+
 # Data Types
 
 This document defines the data types used by the ESDiag API.

--- a/docs/bin/esdiag-control.md
+++ b/docs/bin/esdiag-control.md
@@ -1,3 +1,10 @@
+---
+type: Guide
+title: Elastic Stack Diagnostics Control
+description: Guide to building, configuring, and deploying ESDiag with the esdiag-control helper script.
+tags: [bin, containers, deployment]
+---
+
 Elastic Stack Diagnostics Control
 =================================
 

--- a/docs/bin/min-diag.md
+++ b/docs/bin/min-diag.md
@@ -1,3 +1,10 @@
+---
+type: Guide
+title: min-diag.sh
+description: Guide to collecting minimal Elasticsearch diagnostic bundles with the min-diag helper script.
+tags: [bin, collection, diagnostics]
+---
+
 
 min-diag.sh
 ------------

--- a/docs/build/desktop-packaging.md
+++ b/docs/build/desktop-packaging.md
@@ -1,3 +1,10 @@
+---
+type: Guide
+title: Desktop Packaging
+description: Guide to local and CI desktop packaging workflows for macOS, Windows, and Linux.
+tags: [repository, desktop, packaging, build]
+---
+
 # Desktop Packaging
 
 This project supports desktop packaging for:

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -1,3 +1,10 @@
+---
+type: Reference
+title: Command-Line Interface Reference
+description: Primary command-line reference for esdiag commands, options, and runtime behavior.
+tags: [cli, reference]
+---
+
 # Command-Line Interface Reference
 
 This document is the primary command-line reference for `esdiag`.
@@ -88,6 +95,7 @@ These environment variables change where local state is read and written:
 - `ESDIAG_KIBANA_URL`: Kibana URL used by `serve`, processing metadata, and host-omitted setup flows
 - `ESDIAG_KIBANA_SPACE`: optional Kibana space appended to generated Kibana links
 - `ESDIAG_MODE`: runtime mode for `serve` when `--mode` is omitted; valid values are `user` and `service`
+- `ESDIAG_DOCS_EXCLUDED_TAGS`: comma-separated OKF tags to hide from the documentation viewer unless debug logging is enabled; defaults to `repository`
 - `ESDIAG_OUTPUT_TASK_LIMIT`: task concurrency limit used by the Elasticsearch exporter
 
 ## Output Resolution Rules

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,3 +1,10 @@
+---
+type: Guide
+title: ESDiag Documentation
+description: Entry point for ESDiag user and maintainer documentation.
+tags: [docs, overview]
+---
+
 # ESDiag Documentation
 
 Welcome to the documentation for ESDiag.

--- a/docs/hosts-keystore.md
+++ b/docs/hosts-keystore.md
@@ -1,3 +1,10 @@
+---
+type: Guide
+title: Host Keystore Migration
+description: Guide to migrating saved host credentials into the encrypted esdiag keystore.
+tags: [hosts, keystore, migration]
+---
+
 # Host Keystore Migration
 
 `esdiag` supports two host auth models:

--- a/docs/repository/branch-management.md
+++ b/docs/repository/branch-management.md
@@ -1,3 +1,10 @@
+---
+type: Maintainer Guide
+title: Branch Management
+description: Maintainer guide to long-lived branch strategy and release flow.
+tags: [repository, branching, release]
+---
+
 Branch Management
 =================
 

--- a/docs/repository/organization.md
+++ b/docs/repository/organization.md
@@ -1,3 +1,10 @@
+---
+type: Maintainer Guide
+title: Repository Organization
+description: Maintainer guide to the repository layout and major source directories.
+tags: [repository, maintainers]
+---
+
 Repository Organization
 =======================
 

--- a/src/server/docs.rs
+++ b/src/server/docs.rs
@@ -98,10 +98,6 @@ impl DocsVisibility {
         }
     }
 
-    fn is_visible(&self, markdown: &str) -> bool {
-        self.is_tag_set_visible(&doc_tags(markdown))
-    }
-
     fn is_path_visible(&self, path: &str) -> bool {
         doc_tag_cache()
             .get(path)
@@ -389,7 +385,7 @@ fn split_okf_frontmatter(markdown: &str) -> Option<(&str, &str)> {
         .strip_prefix("---\r\n")
         .or_else(|| markdown.strip_prefix("---\n"))?;
 
-    for delimiter in ["\r\n---\r\n", "\n---\n", "\r\n---\n", "\n---\r\n"] {
+    for delimiter in ["---\r\n", "---\n", "\r\n---\r\n", "\n---\n", "\r\n---\n", "\n---\r\n"] {
         if let Some(frontmatter_end) = body_start.find(delimiter) {
             let frontmatter = &body_start[..frontmatter_end];
             let body = &body_start[frontmatter_end + delimiter.len()..];
@@ -599,6 +595,15 @@ mod tests {
 
         assert!(frontmatter.contains("type: Reference"));
         assert_eq!(body, "\r\n# Example\r\n");
+    }
+
+    #[test]
+    fn okf_frontmatter_supports_empty_blocks() {
+        let markdown = "---\n---\n# Example\n";
+        let (frontmatter, body) = split_okf_frontmatter(markdown).expect("frontmatter should split");
+
+        assert_eq!(frontmatter, "");
+        assert_eq!(body, "# Example\n");
     }
 
     #[test]

--- a/src/server/docs.rs
+++ b/src/server/docs.rs
@@ -11,7 +11,11 @@ use axum::{
 };
 use pulldown_cmark::{Event, Options, Parser, html};
 use regex::Regex;
+use serde::Deserialize;
 use std::{collections::BTreeMap, collections::HashSet, path::PathBuf, sync::OnceLock};
+
+const DOCS_EXCLUDED_TAGS_ENV: &str = "ESDIAG_DOCS_EXCLUDED_TAGS";
+const DEFAULT_EXCLUDED_DOC_TAGS: &[&str] = &["repository"];
 
 #[derive(Template)]
 #[template(path = "docs.html")]
@@ -67,6 +71,38 @@ pub struct TocEntry {
     pub is_dir: bool,
 }
 
+#[derive(Default, Deserialize)]
+struct OkfFrontmatter {
+    #[serde(default)]
+    tags: Vec<String>,
+}
+
+struct DocsVisibility {
+    excluded_tags: HashSet<String>,
+    include_excluded: bool,
+}
+
+impl DocsVisibility {
+    fn current() -> Self {
+        Self {
+            excluded_tags: configured_excluded_doc_tags(),
+            include_excluded: tracing::enabled!(tracing::Level::DEBUG),
+        }
+    }
+
+    #[cfg(test)]
+    fn new(excluded_tags: HashSet<String>, include_excluded: bool) -> Self {
+        Self {
+            excluded_tags,
+            include_excluded,
+        }
+    }
+
+    fn is_visible(&self, markdown: &str) -> bool {
+        self.include_excluded || self.excluded_tags.is_empty() || doc_tags(markdown).is_disjoint(&self.excluded_tags)
+    }
+}
+
 pub async fn handler_index(
     headers: HeaderMap,
     state: axum::extract::State<std::sync::Arc<crate::server::ServerState>>,
@@ -91,10 +127,16 @@ pub async fn handler(
     };
 
     let is_datastar = headers.contains_key("datastar-request");
+    let docs_visibility = DocsVisibility::current();
 
     match DocsAssets::get(&file_path) {
         Some(content) => {
             let markdown_content = String::from_utf8_lossy(&content.data);
+            if !docs_visibility.is_visible(&markdown_content) {
+                return (StatusCode::NOT_FOUND, "Document not found").into_response();
+            }
+
+            let markdown_body = strip_okf_frontmatter(&markdown_content);
 
             // Set up pulldown-cmark parser with options
             let mut options = Options::empty();
@@ -105,7 +147,7 @@ pub async fn handler(
             options.insert(Options::ENABLE_HEADING_ATTRIBUTES);
             options.insert(Options::ENABLE_GFM); // GitHub Flavored Markdown
 
-            let parser = Parser::new_ext(&markdown_content, options).map(|event| match event {
+            let parser = Parser::new_ext(markdown_body, options).map(|event| match event {
                 // Do not allow raw HTML from markdown input in rendered docs.
                 Event::Html(text) | Event::InlineHtml(text) => Event::Text(text),
                 _ => event,
@@ -116,7 +158,7 @@ pub async fn handler(
             html::push_html(&mut html_content, parser);
             html_content = inject_heading_ids(&html_content);
 
-            let toc = generate_toc();
+            let toc = generate_toc(&docs_visibility);
 
             // Remove .md suffix for the current_path comparison
             let current_path = if path.ends_with(".md") {
@@ -239,13 +281,20 @@ fn build_nav(entries: &[TocEntry], current_path: &str) -> (Vec<DocsNavLink>, Vec
     (root_items, sections)
 }
 
-fn generate_toc() -> Vec<TocEntry> {
+fn generate_toc(docs_visibility: &DocsVisibility) -> Vec<TocEntry> {
     let mut sections: BTreeMap<String, Vec<String>> = BTreeMap::new();
     let mut root_files = Vec::new();
 
     for file in DocsAssets::iter().map(|p| p.into_owned()) {
         if !file.ends_with(".md") {
             continue;
+        }
+
+        if let Some(content) = DocsAssets::get(&file) {
+            let markdown = String::from_utf8_lossy(&content.data);
+            if !docs_visibility.is_visible(&markdown) {
+                continue;
+            }
         }
 
         let path = PathBuf::from(&file);
@@ -328,6 +377,47 @@ fn slugify(s: &str) -> String {
         .join("-")
 }
 
+fn split_okf_frontmatter(markdown: &str) -> Option<(&str, &str)> {
+    let body_start = markdown.strip_prefix("---\n")?;
+    let delimiter = "\n---\n";
+    let frontmatter_end = body_start.find(delimiter)?;
+    let frontmatter = &body_start[..frontmatter_end];
+    let body = &body_start[frontmatter_end + delimiter.len()..];
+    Some((frontmatter, body))
+}
+
+fn strip_okf_frontmatter(markdown: &str) -> &str {
+    split_okf_frontmatter(markdown).map_or(markdown, |(_, body)| body)
+}
+
+fn parse_tag_list(tags: &str) -> HashSet<String> {
+    tags.split(',')
+        .map(|tag| tag.trim().to_ascii_lowercase())
+        .filter(|tag| !tag.is_empty())
+        .collect()
+}
+
+fn configured_excluded_doc_tags() -> HashSet<String> {
+    match std::env::var(DOCS_EXCLUDED_TAGS_ENV) {
+        Ok(tags) => parse_tag_list(&tags),
+        Err(_) => DEFAULT_EXCLUDED_DOC_TAGS.iter().map(|tag| tag.to_string()).collect(),
+    }
+}
+
+fn doc_tags(markdown: &str) -> HashSet<String> {
+    split_okf_frontmatter(markdown)
+        .and_then(|(frontmatter, _)| serde_yaml::from_str::<OkfFrontmatter>(frontmatter).ok())
+        .map(|frontmatter| {
+            frontmatter
+                .tags
+                .into_iter()
+                .map(|tag| tag.trim().to_ascii_lowercase())
+                .filter(|tag| !tag.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn extract_existing_ids(html: &str) -> HashSet<String> {
     static ID_ATTR_RE: OnceLock<Regex> = OnceLock::new();
     let re = ID_ATTR_RE
@@ -395,13 +485,18 @@ fn inject_heading_ids(html: &str) -> String {
 #[cfg(test)]
 #[allow(clippy::await_holding_lock)]
 mod tests {
-    use super::handler_index;
+    use super::{
+        DocsVisibility, generate_toc, handler, handler_index, parse_tag_list, split_okf_frontmatter,
+        strip_okf_frontmatter,
+    };
+    use crate::embeds::DocsAssets;
     use crate::server::{RuntimeMode, ServerPolicy, test_server_state};
     use axum::{
-        extract::State,
+        extract::{Path, State},
         http::{HeaderMap, HeaderValue, StatusCode},
         response::IntoResponse,
     };
+    use serde_yaml::Value;
     use std::{sync::Arc, sync::Mutex};
     use tempfile::TempDir;
 
@@ -421,6 +516,98 @@ mod tests {
             std::env::set_var("ESDIAG_SETTINGS", &settings_path);
         }
         (tmp, hosts_path, settings_path)
+    }
+
+    #[test]
+    fn embedded_docs_are_minimally_okf_compliant() {
+        for file in DocsAssets::iter().map(|p| p.into_owned()) {
+            if !file.ends_with(".md") {
+                continue;
+            }
+
+            let filename = std::path::Path::new(&file)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .expect("embedded docs path should have a filename");
+
+            if matches!(filename, "index.md" | "log.md") {
+                continue;
+            }
+
+            let content = DocsAssets::get(&file).unwrap_or_else(|| panic!("embedded docs file should exist: {file}"));
+            let markdown = String::from_utf8_lossy(&content.data);
+            let (frontmatter, body) =
+                split_okf_frontmatter(&markdown).unwrap_or_else(|| panic!("{file} should start with OKF frontmatter"));
+            let frontmatter: Value = serde_yaml::from_str(frontmatter)
+                .unwrap_or_else(|err| panic!("{file} has invalid YAML frontmatter: {err}"));
+            let doc_type = frontmatter
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .trim();
+
+            assert!(!doc_type.is_empty(), "{file} should have a non-empty OKF type");
+            assert!(!body.trim().is_empty(), "{file} should have markdown body content");
+        }
+    }
+
+    #[test]
+    fn okf_frontmatter_is_not_rendered_as_markdown_body() {
+        let markdown = "---\ntype: Reference\ntitle: Example\n---\n\n# Example\n";
+
+        assert_eq!(strip_okf_frontmatter(markdown), "\n# Example\n");
+    }
+
+    #[test]
+    fn docs_navigation_excludes_documents_with_configured_tags() {
+        let visibility = DocsVisibility::new(parse_tag_list("repository"), false);
+        let toc = generate_toc(&visibility);
+
+        assert!(
+            toc.iter().all(|entry| !entry.path.starts_with("repository/")),
+            "repository-tagged docs should be hidden from navigation"
+        );
+        assert!(
+            toc.iter().any(|entry| entry.path == "command-line"),
+            "untagged-by-filter docs should remain in navigation"
+        );
+    }
+
+    #[test]
+    fn docs_navigation_includes_filtered_tags_when_debug_visible() {
+        let visibility = DocsVisibility::new(parse_tag_list("repository"), true);
+        let toc = generate_toc(&visibility);
+
+        assert!(
+            toc.iter().any(|entry| entry.path == "repository/organization"),
+            "debug visibility should include otherwise filtered docs"
+        );
+    }
+
+    #[tokio::test]
+    async fn direct_docs_request_returns_not_found_for_filtered_tags() {
+        let _guard = env_lock().lock().expect("env lock");
+        let (_tmp, _hosts_path, _settings_path) = setup_env();
+        unsafe {
+            std::env::set_var("ESDIAG_DOCS_EXCLUDED_TAGS", "repository");
+        }
+
+        let state = test_server_state();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Goog-Authenticated-User-Email",
+            HeaderValue::from_static("accounts.google.com:test@example.com"),
+        );
+
+        let response = handler(headers, State(state), Path("repository/organization".to_string()))
+            .await
+            .into_response();
+
+        unsafe {
+            std::env::remove_var("ESDIAG_DOCS_EXCLUDED_TAGS");
+        }
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/src/server/docs.rs
+++ b/src/server/docs.rs
@@ -385,7 +385,13 @@ fn split_okf_frontmatter(markdown: &str) -> Option<(&str, &str)> {
         .strip_prefix("---\r\n")
         .or_else(|| markdown.strip_prefix("---\n"))?;
 
-    for delimiter in ["---\r\n", "---\n", "\r\n---\r\n", "\n---\n", "\r\n---\n", "\n---\r\n"] {
+    for delimiter in ["---\r\n", "---\n"] {
+        if let Some(body) = body_start.strip_prefix(delimiter) {
+            return Some(("", body));
+        }
+    }
+
+    for delimiter in ["\r\n---\r\n", "\n---\n", "\r\n---\n", "\n---\r\n"] {
         if let Some(frontmatter_end) = body_start.find(delimiter) {
             let frontmatter = &body_start[..frontmatter_end];
             let body = &body_start[frontmatter_end + delimiter.len()..];
@@ -603,6 +609,15 @@ mod tests {
         let (frontmatter, body) = split_okf_frontmatter(markdown).expect("frontmatter should split");
 
         assert_eq!(frontmatter, "");
+        assert_eq!(body, "# Example\n");
+    }
+
+    #[test]
+    fn okf_frontmatter_ignores_mid_line_delimiters() {
+        let markdown = "---\ntype: Reference\ndescription: contains --- marker\n---\n# Example\n";
+        let (frontmatter, body) = split_okf_frontmatter(markdown).expect("frontmatter should split");
+
+        assert!(frontmatter.contains("contains --- marker"));
         assert_eq!(body, "# Example\n");
     }
 

--- a/src/server/docs.rs
+++ b/src/server/docs.rs
@@ -135,13 +135,13 @@ pub async fn handler(
     let is_datastar = headers.contains_key("datastar-request");
     let docs_visibility = DocsVisibility::current();
 
+    if !docs_visibility.is_path_visible(&file_path) {
+        return (StatusCode::NOT_FOUND, "Document not found").into_response();
+    }
+
     match DocsAssets::get(&file_path) {
         Some(content) => {
             let markdown_content = String::from_utf8_lossy(&content.data);
-            if !docs_visibility.is_path_visible(&file_path) {
-                return (StatusCode::NOT_FOUND, "Document not found").into_response();
-            }
-
             let markdown_body = strip_okf_frontmatter(&markdown_content);
 
             // Set up pulldown-cmark parser with options
@@ -522,8 +522,8 @@ fn inject_heading_ids(html: &str) -> String {
 #[allow(clippy::await_holding_lock)]
 mod tests {
     use super::{
-        DocsVisibility, generate_toc, handler, handler_index, parse_tag_list, split_okf_frontmatter,
-        strip_okf_frontmatter,
+        DOCS_EXCLUDED_TAGS_ENV, DocsVisibility, generate_toc, handler, handler_index, parse_tag_list,
+        split_okf_frontmatter, strip_okf_frontmatter,
     };
     use crate::embeds::DocsAssets;
     use crate::server::{RuntimeMode, ServerPolicy, test_server_state};
@@ -652,7 +652,7 @@ mod tests {
         let _guard = env_lock().lock().expect("env lock");
         let (_tmp, _hosts_path, _settings_path) = setup_env();
         unsafe {
-            std::env::set_var("ESDIAG_DOCS_EXCLUDED_TAGS", "repository");
+            std::env::set_var(DOCS_EXCLUDED_TAGS_ENV, "repository");
         }
 
         let state = test_server_state();
@@ -667,7 +667,7 @@ mod tests {
             .into_response();
 
         unsafe {
-            std::env::remove_var("ESDIAG_DOCS_EXCLUDED_TAGS");
+            std::env::remove_var(DOCS_EXCLUDED_TAGS_ENV);
         }
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);

--- a/src/server/docs.rs
+++ b/src/server/docs.rs
@@ -99,7 +99,17 @@ impl DocsVisibility {
     }
 
     fn is_visible(&self, markdown: &str) -> bool {
-        self.include_excluded || self.excluded_tags.is_empty() || doc_tags(markdown).is_disjoint(&self.excluded_tags)
+        self.is_tag_set_visible(&doc_tags(markdown))
+    }
+
+    fn is_path_visible(&self, path: &str) -> bool {
+        doc_tag_cache()
+            .get(path)
+            .is_none_or(|tags| self.is_tag_set_visible(tags))
+    }
+
+    fn is_tag_set_visible(&self, tags: &HashSet<String>) -> bool {
+        self.include_excluded || self.excluded_tags.is_empty() || tags.is_disjoint(&self.excluded_tags)
     }
 }
 
@@ -132,7 +142,7 @@ pub async fn handler(
     match DocsAssets::get(&file_path) {
         Some(content) => {
             let markdown_content = String::from_utf8_lossy(&content.data);
-            if !docs_visibility.is_visible(&markdown_content) {
+            if !docs_visibility.is_path_visible(&file_path) {
                 return (StatusCode::NOT_FOUND, "Document not found").into_response();
             }
 
@@ -290,11 +300,8 @@ fn generate_toc(docs_visibility: &DocsVisibility) -> Vec<TocEntry> {
             continue;
         }
 
-        if let Some(content) = DocsAssets::get(&file) {
-            let markdown = String::from_utf8_lossy(&content.data);
-            if !docs_visibility.is_visible(&markdown) {
-                continue;
-            }
+        if !docs_visibility.is_path_visible(&file) {
+            continue;
         }
 
         let path = PathBuf::from(&file);
@@ -378,12 +385,19 @@ fn slugify(s: &str) -> String {
 }
 
 fn split_okf_frontmatter(markdown: &str) -> Option<(&str, &str)> {
-    let body_start = markdown.strip_prefix("---\n")?;
-    let delimiter = "\n---\n";
-    let frontmatter_end = body_start.find(delimiter)?;
-    let frontmatter = &body_start[..frontmatter_end];
-    let body = &body_start[frontmatter_end + delimiter.len()..];
-    Some((frontmatter, body))
+    let body_start = markdown
+        .strip_prefix("---\r\n")
+        .or_else(|| markdown.strip_prefix("---\n"))?;
+
+    for delimiter in ["\r\n---\r\n", "\n---\n", "\r\n---\n", "\n---\r\n"] {
+        if let Some(frontmatter_end) = body_start.find(delimiter) {
+            let frontmatter = &body_start[..frontmatter_end];
+            let body = &body_start[frontmatter_end + delimiter.len()..];
+            return Some((frontmatter, body));
+        }
+    }
+
+    None
 }
 
 fn strip_okf_frontmatter(markdown: &str) -> &str {
@@ -400,8 +414,28 @@ fn parse_tag_list(tags: &str) -> HashSet<String> {
 fn configured_excluded_doc_tags() -> HashSet<String> {
     match std::env::var(DOCS_EXCLUDED_TAGS_ENV) {
         Ok(tags) => parse_tag_list(&tags),
-        Err(_) => DEFAULT_EXCLUDED_DOC_TAGS.iter().map(|tag| tag.to_string()).collect(),
+        Err(_) => DEFAULT_EXCLUDED_DOC_TAGS
+            .iter()
+            .map(|tag| tag.trim().to_ascii_lowercase())
+            .filter(|tag| !tag.is_empty())
+            .collect(),
     }
+}
+
+fn doc_tag_cache() -> &'static BTreeMap<String, HashSet<String>> {
+    static DOC_TAGS: OnceLock<BTreeMap<String, HashSet<String>>> = OnceLock::new();
+    DOC_TAGS.get_or_init(|| {
+        DocsAssets::iter()
+            .map(|path| path.into_owned())
+            .filter(|path| path.ends_with(".md"))
+            .filter_map(|path| {
+                DocsAssets::get(&path).map(|content| {
+                    let markdown = String::from_utf8_lossy(&content.data);
+                    (path, doc_tags(&markdown))
+                })
+            })
+            .collect()
+    })
 }
 
 fn doc_tags(markdown: &str) -> HashSet<String> {
@@ -556,6 +590,15 @@ mod tests {
         let markdown = "---\ntype: Reference\ntitle: Example\n---\n\n# Example\n";
 
         assert_eq!(strip_okf_frontmatter(markdown), "\n# Example\n");
+    }
+
+    #[test]
+    fn okf_frontmatter_supports_crlf_line_endings() {
+        let markdown = "---\r\ntype: Reference\r\ntitle: Example\r\n---\r\n\r\n# Example\r\n";
+        let (frontmatter, body) = split_okf_frontmatter(markdown).expect("frontmatter should split");
+
+        assert!(frontmatter.contains("type: Reference"));
+        assert_eq!(body, "\r\n# Example\r\n");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds OKF frontmatter metadata to the embedded docs bundle.
- Strips OKF frontmatter before rendering docs pages.
- Adds tag-based docs filtering with `repository` hidden by default and visible when debug logging is enabled.

## Test plan
- [x] cargo test --features server docs

Resolves #345.

Made with [Cursor](https://cursor.com)