### PR TITLE
Architecture review 4/9: first-class diagnostic outcome and event recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ published release notes, maintenance branches, and tagged history.
 - Changed collection and processing source selection to use canonical registry keys and added a maintainer reconciliation utility for upstream support-diagnostics sources (#348).
 - Kept manifests and indexed diagnostics compatible across the platform/application split (#354).
 - Changed diagnostic outcome derivation so optional sources absent from imported bundles do not make otherwise successful processing partial (#350).
+- Changed `process` to return a non-zero exit when the derived diagnostic outcome is failed (#350).
+- Changed synchronous API results to include a derived `outcome` field and align failed statuses with failed report outcomes (#350).
 
 ## [0.16.0] - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ published release notes, maintenance branches, and tagged history.
 - Changed diagnostic platform fields to serialize stable hyphenated platform keys (#347).
 - Changed collection and processing source selection to use canonical registry keys and added a maintainer reconciliation utility for upstream support-diagnostics sources (#348).
 - Kept manifests and indexed diagnostics compatible across the platform/application split (#354).
+- Changed diagnostic outcome derivation so optional sources absent from imported bundles do not make otherwise successful processing partial (#350).
 
 ## [0.16.0] - 2026-07-11
 

--- a/docs/api/examples.md
+++ b/docs/api/examples.md
@@ -88,6 +88,7 @@ curl -X POST 'http://localhost:2501/api/service_link?wait_for_completion' \
 [
   {
     "status": "success",
+    "outcome": "complete",
     "diagnostic_id": "elasticsearch-diagnostic-2024-01-15-abc123",
     "kibana_link": "https://kibana.example.com/app/dashboards#/view/4e0a26b2-e5f8-4b2c-a5c8-1a3f2c4d5e6f",
     "took": 42000,
@@ -193,6 +194,7 @@ curl -X POST 'http://localhost:2501/api/api_key?wait_for_completion=true' \
 [
   {
     "status": "success",
+    "outcome": "complete",
     "diagnostic_id": "elasticsearch-diagnostic-2024-01-15-abc123",
     "kibana_link": "https://kibana.example.com/app/dashboards#/view/4e0a26b2-e5f8-4b58-b617-86f5cdd0edad?_g=...",
     "took": 12345,
@@ -204,10 +206,11 @@ curl -X POST 'http://localhost:2501/api/api_key?wait_for_completion=true' \
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `status` | String | `success`, `info`, or `failed` |
-| `diagnostic_id` | String | Unique identifier for a successfully processed diagnostic |
-| `kibana_link` | String | URL to view a successful diagnostic in Kibana (empty string if not configured) |
-| `took` | Number | Processing time in milliseconds for successful entries |
+| `status` | String | `success`, `info`, or `failed`; report-backed entries can be `failed` when their derived outcome is failed |
+| `outcome` | String | Derived diagnostic outcome, such as `complete`, `partial`, `failed`, `skipped (by design)`, or `skipped (not implemented)` |
+| `diagnostic_id` | String | Unique identifier for report-backed diagnostic entries |
+| `kibana_link` | String | URL to view a report-backed diagnostic in Kibana (empty string if not configured) |
+| `took` | Number | Processing time in milliseconds for report-backed entries |
 | `product` | String | Product associated with the result entry when known |
 | `source` | String | `parent` or `included_diagnostic` |
 
@@ -318,14 +321,20 @@ curl -X POST 'http://localhost:2501/api/api_key?wait_for_completion' \
   }'
 ```
 
-2. Response includes diagnostic ID and Kibana link
+2. Response includes one result entry with diagnostic ID and Kibana link
 
 ```json
-{
-  "diagnostic_id": "elasticsearch-diagnostic-2024-01-15-abc123",
-  "kibana_link": "https://kibana.example.com/app/dashboards#/view/4e0a26b2-e5f8-4b58-b617-86f5cdd0edad?_g=...",
-  "took": 12345
-}
+[
+  {
+    "status": "success",
+    "outcome": "complete",
+    "diagnostic_id": "elasticsearch-diagnostic-2024-01-15-abc123",
+    "kibana_link": "https://kibana.example.com/app/dashboards#/view/4e0a26b2-e5f8-4b58-b617-86f5cdd0edad?_g=...",
+    "took": 12345,
+    "product": "Elasticsearch",
+    "source": "parent"
+  }
+]
 ```
 
 3. Use the diagnostic ID and Kibana URL directly in your application

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -117,6 +117,7 @@ Response from `/api/api_key` or `/api/service_link` when `wait_for_completion` i
 [
   {
     "status": "success",
+    "outcome": "complete",
     "diagnostic_id": "string",
     "kibana_link": "string",
     "took": 12345,
@@ -125,6 +126,7 @@ Response from `/api/api_key` or `/api/service_link` when `wait_for_completion` i
   },
   {
     "status": "info",
+    "outcome": "skipped (not implemented)",
     "product": "Kibana",
     "source": "included_diagnostic",
     "path": "namespace/kibana/instance",
@@ -135,15 +137,16 @@ Response from `/api/api_key` or `/api/service_link` when `wait_for_completion` i
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `status` | String | `success`, `info`, or `failed` |
-| `diagnostic_id` | String | Present for `status: "success"` entries. Unique identifier for a successfully processed diagnostic |
-| `kibana_link` | String | Present for `status: "success"` entries. URL to view a successful diagnostic in Kibana dashboard (empty string if `ESDIAG_KIBANA_URL` is not configured) |
-| `took` | Integer | Present for `status: "success"` entries. Processing time in milliseconds |
+| `status` | String | Result category: `success`, `info`, or `failed`. A report-backed entry can have `status: "failed"` when processing completed but the derived diagnostic outcome is failed |
+| `outcome` | String | Derived diagnostic outcome, such as `complete`, `partial`, `failed`, `skipped (by design)`, or `skipped (not implemented)` |
+| `diagnostic_id` | String | Present for report-backed entries. Unique identifier for the processed diagnostic |
+| `kibana_link` | String | Present for report-backed entries. URL to view the diagnostic in Kibana dashboard (empty string if `ESDIAG_KIBANA_URL` is not configured) |
+| `took` | Integer | Present for report-backed entries. Processing time in milliseconds |
 | `product` | String | Product associated with the result entry when known |
 | `source` | String | `parent` or `included_diagnostic` |
 | `path` | String | Present for `source: "included_diagnostic"` entries. Included diagnostic path for child entries |
 | `reason` | String | Present for `status: "info"` entries. Explanation for informational skipped entries |
-| `error` | String | Present for `status: "failed"` child entries. Error message for failed child entries |
+| `error` | String | Present for failed child entries without a report. Error message for failed child entries |
 
 ### Error Response
 

--- a/openspec/changes/diagnostic-outcome-reporting/tasks.md
+++ b/openspec/changes/diagnostic-outcome-reporting/tasks.md
@@ -41,6 +41,7 @@
   carry the unified outcome including `Partial`; per-source event rows in the
   web feed (rendering `diagnostic.events` entries individually) are left for
   the feed rework in `web-multiuser-isolation`.
-- Fixture-based children now derive `Partial` (missing selected sources are
-  recorded error events instead of silent `tracing::warn!`) — the intended
-  silent-behavior change called out in the design's risks.
+- Fixture-based children with only absent optional sources now remain
+  `Complete`; missing imported-bundle sources are tracked separately from
+  unreadable/parse-failed sources so the report event log does not turn benign
+  fixture sparsity into `Partial`.

--- a/openspec/changes/diagnostic-outcome-reporting/tasks.md
+++ b/openspec/changes/diagnostic-outcome-reporting/tasks.md
@@ -1,33 +1,46 @@
 # Tasks
 
 ## 1. Outcome type
-- [ ] 1.1 Add `DiagnosticOutcome` (`Complete | Partial | Failed | Skipped`) with serde/`Display`; model `Skipped` to carry a by-design vs not-implemented discriminator (per ADR-0019).
-- [ ] 1.2 Implement derivation from recorded report events (failure/partial → `Partial`; total failure → `Failed`; unsupported → `Skipped`; else `Complete`) as the only way to obtain an outcome.
-- [ ] 1.3 Expose the derived `DiagnosticOutcome` on `DiagnosticReport` (`src/processor/diagnostic/report.rs`).
+- [x] 1.1 Add `DiagnosticOutcome` (`Complete | Partial | Failed | Skipped`) with serde/`Display`; model `Skipped` to carry a by-design vs not-implemented discriminator (per ADR-0019).
+- [x] 1.2 Implement derivation from recorded report events (failure/partial → `Partial`; total failure → `Failed`; unsupported → `Skipped`; else `Complete`) as the only way to obtain an outcome.
+- [x] 1.3 Expose the derived `DiagnosticOutcome` on `DiagnosticReport` (`src/processor/diagnostic/report.rs`).
 
 ## 2. Event recording
-- [ ] 2.1 Add an event log to the report — each event carries severity (`error | warning | success`), source, and reason.
-- [ ] 2.2 Change `ProcessorSummary::merge(Err)` and `add_child(Err)` (`report.rs:487`, `:501`) to record a failure event instead of `tracing::warn!`.
-- [ ] 2.3 Record collection failures as events (source + reason), not only logs.
-- [ ] 2.4 Record success-level events for collected/processed sources.
+- [x] 2.1 Add an event log to the report — each event carries severity (`error | warning | success`), source, and reason.
+- [x] 2.2 Change `ProcessorSummary::merge(Err)` and `add_child(Err)` (`report.rs:487`, `:501`) to record a failure event instead of `tracing::warn!`.
+- [x] 2.3 Record collection failures as events (source + reason), not only logs.
+- [x] 2.4 Record success-level events for collected/processed sources.
 
 ## 3. Two-level export status
-- [ ] 3.1 Keep the scalar request `status_code` as the transport verdict; make `status_counts` authoritative for document outcomes and feed the `Partial` derivation.
-- [ ] 3.2 Fix `BatchResponse::merge` (`report.rs:420`) so mixed HTTP request codes are not collapsed to `0`.
-- [ ] 3.3 Reserve request status `0` for non-HTTP exporters only (`src/exporter/{file,stream,directory}.rs`); ensure the Elasticsearch exporter never emits `0`.
+- [x] 3.1 Keep the scalar request `status_code` as the transport verdict; make `status_counts` authoritative for document outcomes and feed the `Partial` derivation.
+- [x] 3.2 Fix `BatchResponse::merge` (`report.rs:420`) so mixed HTTP request codes are not collapsed to `0`.
+- [x] 3.3 Reserve request status `0` for non-HTTP exporters only (`src/exporter/{file,stream,directory}.rs`); ensure the Elasticsearch exporter never emits `0`.
 
 ## 4. Unify child outcome
-- [ ] 4.1 Replace `IncludedDiagnosticOutcome` (`src/processor/mod.rs:101`) with `DiagnosticOutcome`; derive each child's outcome from its own child report.
-- [ ] 4.2 Update the fan-out (`spawn_sub_processors`) and completed-state accessors to carry the unified outcome, including `Partial`.
+- [x] 4.1 Replace `IncludedDiagnosticOutcome` (`src/processor/mod.rs:101`) with `DiagnosticOutcome`; derive each child's outcome from its own child report.
+- [x] 4.2 Update the fan-out (`spawn_sub_processors`) and completed-state accessors to carry the unified outcome, including `Partial`.
 
 ## 5. Consumers read the report
-- [ ] 5.1 CLI `process` exit code derived from the report's `DiagnosticOutcome`; print recorded events (source + reason) in the summary.
-- [ ] 5.2 WebUI status and the owner-scoped job feed render from the persisted report's outcome and events (parent and child rows, incl. `Partial`).
-- [ ] 5.3 Map the synchronous API result entries to the unified outcome (`src/server/api.rs`).
+- [x] 5.1 CLI `process` exit code derived from the report's `DiagnosticOutcome`; print recorded events (source + reason) in the summary.
+- [x] 5.2 WebUI status and the owner-scoped job feed render from the persisted report's outcome and events (parent and child rows, incl. `Partial`).
+- [x] 5.3 Map the synchronous API result entries to the unified outcome (`src/server/api.rs`).
 
 ## 6. Verification
-- [ ] 6.1 Unit tests for outcome derivation (all-success → `Complete`; one failure → `Partial`; total failure → `Failed`; unsupported → `Skipped` by-design vs not-implemented).
-- [ ] 6.2 Test that a merged `Err` produces a recorded failure event, not a dropped log.
-- [ ] 6.3 Test two-level status: `_bulk` `200` with per-doc `409` → `Partial`; mixed HTTP codes not collapsed to `0`; non-HTTP exporter reports `0`.
-- [ ] 6.4 Test a child derives `Partial`/`Failed`/`Skipped` while the parent still completes.
-- [ ] 6.5 Confirm the delta spec scenarios in `specs/diagnostic-reporting/spec.md` and `specs/included-diagnostic-jobs/spec.md` are covered.
+- [x] 6.1 Unit tests for outcome derivation (all-success → `Complete`; one failure → `Partial`; total failure → `Failed`; unsupported → `Skipped` by-design vs not-implemented).
+- [x] 6.2 Test that a merged `Err` produces a recorded failure event, not a dropped log.
+- [x] 6.3 Test two-level status: `_bulk` `200` with per-doc `409` → `Partial`; mixed HTTP codes not collapsed to `0`; non-HTTP exporter reports `0`.
+- [x] 6.4 Test a child derives `Partial`/`Failed`/`Skipped` while the parent still completes.
+- [x] 6.5 Confirm the delta spec scenarios in `specs/diagnostic-reporting/spec.md` and `specs/included-diagnostic-jobs/spec.md` are covered.
+
+---
+
+## Implementation note (2026-07-07 session)
+
+- 5.2 is implemented minimally: the job feed's completed rows (parent and
+  child) render the derived outcome from the persisted report, and child rows
+  carry the unified outcome including `Partial`; per-source event rows in the
+  web feed (rendering `diagnostic.events` entries individually) are left for
+  the feed rework in `web-multiuser-isolation`.
+- Fixture-based children now derive `Partial` (missing selected sources are
+  recorded error events instead of silent `tracing::warn!`) — the intended
+  silent-behavior change called out in the design's risks.

--- a/src/exporter/elasticsearch.rs
+++ b/src/exporter/elasticsearch.rs
@@ -316,7 +316,10 @@ impl Export for ElasticsearchExporter {
                     tracing::warn!(
                         "{index} - bulk sub-batch failed after partial success; recording {failed_docs} failed docs: {err}"
                     );
-                    summary.merge(BatchResponse::failed(failed_docs, 0));
+                    summary.merge(BatchResponse::failed(
+                        failed_docs,
+                        BatchResponse::HTTP_REQUEST_NOT_COMPLETED,
+                    ));
                     return Ok(summary);
                 }
             }
@@ -351,7 +354,13 @@ impl Export for ElasticsearchExporter {
                 }
                 Err(e) => {
                     tracing::warn!("Bulk batch failed: {}", e);
-                    if tx.send(BatchResponse::failed(doc_count as u32, 0)).is_err() {
+                    if tx
+                        .send(BatchResponse::failed(
+                            doc_count as u32,
+                            BatchResponse::HTTP_REQUEST_NOT_COMPLETED,
+                        ))
+                        .is_err()
+                    {
                         tracing::error!("Failed to send failed batch response: receiver dropped");
                     }
                 }
@@ -808,7 +817,8 @@ mod tests {
         assert_eq!(result.docs, 1);
         assert_eq!(result.errors, 2);
         assert_eq!(result.batch_count, 2);
-        assert_eq!(result.status_code, 0);
+        // HTTP request never completed: 599 sentinel, never 0 (ADR-0016)
+        assert_eq!(result.status_code, BatchResponse::HTTP_REQUEST_NOT_COMPLETED);
         assert_eq!(
             *call_count.lock().await,
             2,
@@ -829,7 +839,7 @@ mod tests {
 
         assert_eq!(response.docs, 0);
         assert_eq!(response.errors, 2);
-        assert_eq!(response.status_code, 0);
+        assert_eq!(response.status_code, BatchResponse::HTTP_REQUEST_NOT_COMPLETED);
     }
 
     #[tokio::test]
@@ -899,7 +909,7 @@ mod tests {
         assert_eq!(response.docs, 0);
         assert_eq!(response.errors, 2);
         assert_eq!(response.batch_count, 1);
-        assert_eq!(response.status_code, 0);
+        assert_eq!(response.status_code, BatchResponse::HTTP_REQUEST_NOT_COMPLETED);
         assert_eq!(*call_count.lock().await, 1, "expected one bulk request");
     }
 }

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -122,7 +122,7 @@ impl Exporter {
                     Ok(batch_rx) => batch_receivers.push(batch_rx),
                     Err(err) => {
                         tracing::warn!("Failed to send document batch: {}", err);
-                        summary.add_batch(BatchResponse::failed(doc_count, 0));
+                        summary.add_batch(BatchResponse::failed(doc_count, self.failed_request_status()));
                     }
                 }
             }
@@ -135,7 +135,7 @@ impl Exporter {
                 Ok(batch_rx) => batch_receivers.push(batch_rx),
                 Err(err) => {
                     tracing::warn!("Failed to send final document batch: {}", err);
-                    summary.add_batch(BatchResponse::failed(doc_count, 0));
+                    summary.add_batch(BatchResponse::failed(doc_count, self.failed_request_status()));
                 }
             }
         }
@@ -182,8 +182,18 @@ impl Exporter {
             Ok(response) => Ok(response),
             Err(err) => {
                 tracing::warn!("Failed to send document batch: {}", err);
-                Ok(BatchResponse::failed(doc_count, 0))
+                Ok(BatchResponse::failed(doc_count, self.failed_request_status()))
             }
+        }
+    }
+
+    /// The request status recorded when this exporter fails without a
+    /// response: HTTP exporters use the 599 sentinel; status `0` is reserved
+    /// for non-HTTP exporters (file, stream, directory) — ADR-0016.
+    fn failed_request_status(&self) -> u16 {
+        match self {
+            Exporter::Elasticsearch(_) => BatchResponse::HTTP_REQUEST_NOT_COMPLETED,
+            _ => 0,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod setup;
 /// Upload raw diagnostic archives to Elastic Upload Service
 pub mod uploader;
 
+#[cfg(test)]
 pub(crate) fn test_env_lock() -> &'static std::sync::Mutex<()> {
     use std::sync::{Mutex, OnceLock};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,7 @@ pub mod setup;
 /// Upload raw diagnostic archives to Elastic Upload Service
 pub mod uploader;
 
-#[doc(hidden)]
-pub fn test_env_lock() -> &'static std::sync::Mutex<()> {
+pub(crate) fn test_env_lock() -> &'static std::sync::Mutex<()> {
     use std::sync::{Mutex, OnceLock};
 
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,8 @@ pub mod setup;
 /// Upload raw diagnostic archives to Elastic Upload Service
 pub mod uploader;
 
-#[cfg(test)]
-pub(crate) fn test_env_lock() -> &'static std::sync::Mutex<()> {
+#[doc(hidden)]
+pub fn test_env_lock() -> &'static std::sync::Mutex<()> {
     use std::sync::{Mutex, OnceLock};
 
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1742,15 +1742,14 @@ mod tests {
     #[cfg(feature = "server")]
     use esdiag::server::RuntimeMode;
     use std::sync::{
-        Mutex, OnceLock,
+        Mutex,
         atomic::{AtomicUsize, Ordering},
     };
     use tempfile::TempDir;
     use url::Url;
 
     fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
+        esdiag::test_env_lock()
     }
 
     fn setup_env() -> TempDir {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,7 @@ use esdiag::{
     env::LOG_LEVEL,
     exporter::Exporter,
     processor::{
-        CollectionResult, Collector, Completed, Identifiers, IncludedDiagnosticOutcome, Processor,
-        default_collect_archive_name,
+        CollectionResult, Collector, Completed, DiagnosticOutcome, Identifiers, Processor, default_collect_archive_name,
     },
     receiver::Receiver,
     uploader,
@@ -559,7 +558,8 @@ fn emit_completion_summary(summary: &str) -> Result<()> {
 fn format_process_summary(completed: &Completed) -> String {
     let report = &completed.report;
     let mut summary = format!(
-        "process complete in {:.3} seconds: {} documents for {}",
+        "process {} in {:.3} seconds: {} documents for {}",
+        report.outcome(),
         completed.runtime as f64 / 1000.0,
         report.diagnostic.docs.created,
         report.diagnostic.metadata.id
@@ -567,41 +567,59 @@ fn format_process_summary(completed: &Completed) -> String {
     if let Some(kibana_link) = report.diagnostic.kibana_link.as_deref() {
         summary.push_str(&format!("\nKibana Link: {kibana_link}"));
     }
-    for outcome in &completed.included_diagnostics {
-        match outcome {
-            IncludedDiagnosticOutcome::Completed {
-                path, report, runtime, ..
-            } => {
+    summary.push_str(&format_report_events(report));
+    for child in &completed.included_diagnostics {
+        match (&child.outcome, &child.report) {
+            (DiagnosticOutcome::Skipped(_), _) => {
+                let product = esdiag::processor::display_label(child.application, child.platform);
                 summary.push_str(&format!(
-                    "\n\nincluded diagnostic complete in {:.3} seconds: {} documents for {} ({})",
-                    *runtime as f64 / 1000.0,
+                    "\n\nincluded diagnostic {}: {} ({product})\nReason: {}",
+                    child.outcome,
+                    child.path,
+                    child.reason.as_deref().unwrap_or_default()
+                ));
+            }
+            (_, Some(report)) => {
+                summary.push_str(&format!(
+                    "\n\nincluded diagnostic {} in {:.3} seconds: {} documents for {} ({})",
+                    child.outcome,
+                    child.runtime.unwrap_or_default() as f64 / 1000.0,
                     report.diagnostic.docs.created,
                     report.diagnostic.metadata.id,
                     report.diagnostic.display_label()
                 ));
-                summary.push_str(&format!("\nSource: {path}"));
+                summary.push_str(&format!("\nSource: {}", child.path));
                 if let Some(kibana_link) = report.diagnostic.kibana_link.as_deref() {
                     summary.push_str(&format!("\nKibana Link: {kibana_link}"));
                 }
+                summary.push_str(&format_report_events(report));
             }
-            IncludedDiagnosticOutcome::Skipped {
-                path,
-                application,
-                platform,
-                reason,
-                ..
-            } => {
-                let product = esdiag::processor::display_label(*application, *platform);
+            (_, None) => {
                 summary.push_str(&format!(
-                    "\n\nincluded diagnostic skipped: {path} ({product})\nReason: {reason}"
+                    "\n\nincluded diagnostic failed: {}\nError: {}",
+                    child.path,
+                    child.reason.as_deref().unwrap_or_default()
                 ));
-            }
-            IncludedDiagnosticOutcome::Failed { path, error, .. } => {
-                summary.push_str(&format!("\n\nincluded diagnostic failed: {path}\nError: {error}"));
             }
         }
     }
     summary
+}
+
+/// Render the report's recorded error/warning events (source + reason) — the
+/// persisted record, not tracing logs (ADR-0016). Success events are elided
+/// from the CLI summary to keep it scannable.
+fn format_report_events(report: &esdiag::processor::DiagnosticReport) -> String {
+    let mut rendered = String::new();
+    for event in &report.diagnostic.events {
+        match event.severity {
+            esdiag::processor::EventSeverity::Success => {}
+            severity => {
+                rendered.push_str(&format!("\n  [{severity:?}] {}: {}", event.source, event.reason));
+            }
+        }
+    }
+    rendered
 }
 
 fn format_collect_summary(result: &CollectionResult) -> String {
@@ -982,6 +1000,11 @@ async fn run(cli: Cli) -> Result<CommandResult> {
                 match processor.process().await {
                     Ok(processor) => {
                         let summary = format_process_summary(&processor.state);
+                        // The exit code reads the single derived outcome
+                        // (ADR-0016): a Failed report is a failed command.
+                        if processor.state.report.outcome() == DiagnosticOutcome::Failed {
+                            return Err(eyre!("{summary}"));
+                        }
                         Ok(CommandResult::with_summary("process", summary))
                     }
                     Err(processor) => {
@@ -1712,7 +1735,10 @@ mod tests {
     use clap::Parser;
     use esdiag::data::{HostRole, JobAction, KnownHost, Product, SecretAuth, UnlockStatus, Uri, upsert_secret_auth};
     use esdiag::processor::diagnostic::DiagnosticReportBuilder;
-    use esdiag::processor::{CollectionResult, Completed, DiagnosticManifest, Identifiers, IncludedDiagnosticOutcome};
+    use esdiag::processor::{
+        CollectionResult, Completed, DiagnosticManifest, DiagnosticOutcome, Identifiers, IncludedDiagnosticOutcome,
+        SkipKind,
+    };
     #[cfg(feature = "server")]
     use esdiag::server::RuntimeMode;
     use std::sync::{
@@ -2392,23 +2418,35 @@ mod tests {
             report: parent_report,
             runtime: 2_000,
             included_diagnostics: vec![
-                IncludedDiagnosticOutcome::Completed {
+                IncludedDiagnosticOutcome {
                     job_id: 1,
                     path: "child-es".to_string(),
-                    report: Box::new(child_report),
-                    runtime: 500,
+                    outcome: child_report.outcome(),
+                    application: child_report.diagnostic.application,
+                    platform: child_report.diagnostic.platform(),
+                    report: Some(Box::new(child_report)),
+                    reason: None,
+                    runtime: Some(500),
                 },
-                IncludedDiagnosticOutcome::Skipped {
+                IncludedDiagnosticOutcome {
                     job_id: 2,
                     path: "child-kibana".to_string(),
+                    outcome: DiagnosticOutcome::Skipped(SkipKind::NotImplemented),
+                    report: None,
                     application: Some(esdiag::data::Application::Kibana),
                     platform: esdiag::data::Platform::ECK,
-                    reason: "Kibana processing is not yet implemented".to_string(),
+                    reason: Some("Kibana processing is not yet implemented".to_string()),
+                    runtime: None,
                 },
-                IncludedDiagnosticOutcome::Failed {
+                IncludedDiagnosticOutcome {
                     job_id: 3,
                     path: "child-missing".to_string(),
-                    error: "manifest missing".to_string(),
+                    outcome: DiagnosticOutcome::Failed,
+                    report: None,
+                    application: None,
+                    platform: esdiag::data::Platform::Unknown,
+                    reason: Some("manifest missing".to_string()),
+                    runtime: None,
                 },
             ],
         };
@@ -2418,7 +2456,7 @@ mod tests {
         assert!(summary.contains("included diagnostic complete in 0.500 seconds: 42 documents"));
         assert!(summary.contains("child-es"));
         assert!(summary.contains("https://kb.example/app/dashboards#/view/child"));
-        assert!(summary.contains("included diagnostic skipped: child-kibana (Kibana)"));
+        assert!(summary.contains("included diagnostic skipped (not implemented): child-kibana (Kibana)"));
         assert!(summary.contains("included diagnostic failed: child-missing"));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1749,7 +1749,8 @@ mod tests {
     use url::Url;
 
     fn env_lock() -> &'static Mutex<()> {
-        esdiag::test_env_lock()
+        static LOCK: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
     }
 
     fn setup_env() -> TempDir {

--- a/src/processor/diagnostic/lookup.rs
+++ b/src/processor/diagnostic/lookup.rs
@@ -12,6 +12,8 @@ pub struct Lookup<T> {
     by_name: HashMap<String, usize>,
     entries: Vec<T>,
     pub parsed: bool,
+    #[serde(skip_serializing_if = "is_false")]
+    pub missing: bool,
 }
 
 impl<T> Lookup<T>
@@ -24,12 +26,21 @@ where
             by_name: HashMap::new(),
             entries: Vec::new(),
             parsed: false,
+            missing: false,
         }
     }
 
     pub fn was_parsed(mut self) -> Self {
         self.parsed = true;
+        self.missing = false;
         self
+    }
+
+    pub fn missing() -> Lookup<T> {
+        Lookup {
+            missing: true,
+            ..Lookup::new()
+        }
     }
 
     pub fn from_parsed<U>(value: U) -> Self
@@ -38,6 +49,10 @@ where
     {
         Self::from(value).was_parsed()
     }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 impl<T> Default for Lookup<T>

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -17,6 +17,9 @@ pub struct DiagnosticReportBuilder {
     application: Option<Application>,
     metadata: DiagnosticMetadata,
     origin: Option<Origin>,
+    /// Collection-stage events carried in from the manifest's per-request
+    /// record — collection failures persist in the report, not only in logs.
+    collection_events: Vec<DiagnosticEvent>,
 }
 
 impl DiagnosticReportBuilder {
@@ -54,6 +57,7 @@ impl From<DiagnosticMetadata> for DiagnosticReportBuilder {
             processors: HashMap::new(),
             application: None,
             origin: None,
+            collection_events: Vec::new(),
         }
     }
 }
@@ -63,6 +67,24 @@ impl TryFrom<DiagnosticManifest> for DiagnosticReportBuilder {
 
     fn try_from(manifest: DiagnosticManifest) -> Result<Self> {
         let application = manifest.application();
+        // Collection failures recorded at collect time persist as report
+        // events (ADR-0016): a non-2xx request is a warning with its source.
+        let collection_events = manifest
+            .requested_apis
+            .as_ref()
+            .map(|apis| {
+                apis.iter()
+                    .filter(|(_, api)| !api.status.is_some_and(|status| (200..300).contains(&status)))
+                    .map(|(name, api)| {
+                        let reason = match api.status {
+                            Some(status) => format!("collection failed with HTTP {status}"),
+                            None => "collection failed without an HTTP response".to_string(),
+                        };
+                        DiagnosticEvent::warning(name.clone(), reason)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
         let metadata = DiagnosticMetadata::try_from(manifest)?;
         Ok(Self {
             cluster: None,
@@ -70,6 +92,7 @@ impl TryFrom<DiagnosticManifest> for DiagnosticReportBuilder {
             processors: HashMap::new(),
             application,
             origin: None,
+            collection_events,
         })
     }
 }
@@ -202,6 +225,114 @@ fn normalize_identifier(value: Option<String>) -> Option<String> {
     })
 }
 
+/// The verdict of a diagnostic — one type for any diagnostic, parent or
+/// child (ADR-0016). Derived from the report's recorded events, never set
+/// imperatively; `Skipped` is constructed only where a diagnostic is
+/// rejected before a report exists.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiagnosticOutcome {
+    /// Everything selected was captured and processed.
+    Complete,
+    /// The common real case: some sources captured or exported, some failed.
+    Partial,
+    /// Nothing was produced.
+    Failed,
+    /// The diagnostic was not processed at all.
+    Skipped(SkipKind),
+}
+
+/// Why a diagnostic was skipped (ADR-0019): deliberately out of scope, or
+/// simply not implemented yet.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SkipKind {
+    ByDesign,
+    NotImplemented,
+}
+
+impl DiagnosticOutcome {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::Partial => "partial",
+            Self::Failed => "failed",
+            Self::Skipped(_) => "skipped",
+        }
+    }
+
+    pub fn skip_kind(&self) -> Option<SkipKind> {
+        match self {
+            Self::Skipped(kind) => Some(*kind),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for DiagnosticOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Skipped(SkipKind::ByDesign) => write!(f, "skipped (by design)"),
+            Self::Skipped(SkipKind::NotImplemented) => write!(f, "skipped (not implemented)"),
+            other => write!(f, "{}", other.as_str()),
+        }
+    }
+}
+
+impl Serialize for DiagnosticOutcome {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+/// Severity of a recorded diagnostic event.
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum EventSeverity {
+    Error,
+    Warning,
+    Success,
+}
+
+/// One recorded event in a diagnostic's report: what happened, to which
+/// source, and why. Failures are collected here, never dropped to logs
+/// (ADR-0016). Events are source-grained (one per data source / processor /
+/// exporter batch class), not per document.
+#[derive(Serialize, Clone, Debug)]
+pub struct DiagnosticEvent {
+    pub severity: EventSeverity,
+    /// The data source / processor / exporter the event pertains to.
+    pub source: String,
+    pub reason: String,
+}
+
+impl DiagnosticEvent {
+    pub fn error(source: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            severity: EventSeverity::Error,
+            source: source.into(),
+            reason: reason.into(),
+        }
+    }
+
+    pub fn warning(source: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            severity: EventSeverity::Warning,
+            source: source.into(),
+            reason: reason.into(),
+        }
+    }
+
+    pub fn success(source: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            severity: EventSeverity::Success,
+            source: source.into(),
+            reason: reason.into(),
+        }
+    }
+}
+
 #[derive(Serialize, Clone)]
 #[serde(untagged)]
 pub enum License {
@@ -240,6 +371,32 @@ pub struct DiagnosticStats {
     #[serde(flatten)]
     pub identifiers: Identifiers,
     pub processing_duration: u128,
+    /// All recorded error/warning/success events (source + reason) — the
+    /// persisted record failures land in, never only a log line (ADR-0016).
+    pub events: Vec<DiagnosticEvent>,
+    /// The derived verdict; kept equal to `derive_outcome(&events, &docs)` by
+    /// construction (recomputed whenever events/doc counts change).
+    pub outcome: DiagnosticOutcome,
+}
+
+/// Derive the diagnostic outcome from the recorded events and document
+/// counts (ADR-0016): this is the only way an outcome is computed. Any error
+/// with nothing produced is `Failed`; any error/warning or rejected document
+/// alongside produced output is `Partial`; otherwise `Complete`. (`Skipped`
+/// is constructed only where a diagnostic is rejected before a report
+/// exists — a skip records no report at all.)
+pub fn derive_outcome(events: &[DiagnosticEvent], docs: &Docs) -> DiagnosticOutcome {
+    let has_error = events.iter().any(|event| event.severity == EventSeverity::Error);
+    let has_warning = events.iter().any(|event| event.severity == EventSeverity::Warning);
+    let produced = docs.created > 0 || events.iter().any(|event| event.severity == EventSeverity::Success);
+
+    if has_error && !produced {
+        DiagnosticOutcome::Failed
+    } else if has_error || has_warning || docs.errors > 0 {
+        DiagnosticOutcome::Partial
+    } else {
+        DiagnosticOutcome::Complete
+    }
 }
 
 impl DiagnosticStats {
@@ -247,6 +404,10 @@ impl DiagnosticStats {
     /// construction: unresolved provenance is `Unknown`.
     pub fn platform(&self) -> Platform {
         self.identifiers.platform.unwrap_or_default()
+    }
+
+    fn refresh_outcome(&mut self) {
+        self.outcome = derive_outcome(&self.events, &self.docs);
     }
 
     /// Display label per ADR-0001: the application when present, else the
@@ -259,6 +420,18 @@ impl DiagnosticStats {
 impl DiagnosticReport {
     pub fn add_kibana_link(&mut self, link: String) {
         self.diagnostic.kibana_link = Some(link);
+    }
+
+    /// Record an event (source + reason) in the persisted report and keep the
+    /// derived outcome in sync.
+    pub fn record_event(&mut self, event: DiagnosticEvent) {
+        self.diagnostic.events.push(event);
+        self.diagnostic.refresh_outcome();
+    }
+
+    /// The derived verdict of this diagnostic.
+    pub fn outcome(&self) -> DiagnosticOutcome {
+        self.diagnostic.outcome
     }
 
     pub fn add_identifiers(&mut self, identifiers: Identifiers) {
@@ -323,15 +496,37 @@ impl DiagnosticReport {
         }
     }
 
-    fn add_single_processor_summary(&mut self, summary: ProcessorSummary) {
+    fn add_single_processor_summary(&mut self, mut summary: ProcessorSummary) {
+        // Drain the summary's recorded events into the persisted report and
+        // record this source's verdict as an event (ADR-0016).
+        self.diagnostic.events.append(&mut summary.events);
         if !summary.source.parsed {
             self.diagnostic.processor.errors += 1;
             self.diagnostic.processor.failures.push(summary.index.clone());
+            self.diagnostic.events.push(DiagnosticEvent::error(
+                summary.processor.clone(),
+                "source could not be read or parsed".to_string(),
+            ));
+        } else if summary.doc_errors > 0 {
+            self.diagnostic.events.push(DiagnosticEvent::warning(
+                summary.processor.clone(),
+                format!(
+                    "{} of {} documents rejected",
+                    summary.doc_errors,
+                    summary.docs + summary.doc_errors
+                ),
+            ));
+        } else {
+            self.diagnostic.events.push(DiagnosticEvent::success(
+                summary.processor.clone(),
+                format!("{} documents exported", summary.docs),
+            ));
         }
         self.diagnostic.docs.created += summary.docs;
         self.diagnostic.docs.errors += summary.doc_errors;
         self.diagnostic.docs.total += summary.docs + summary.doc_errors;
         self.diagnostic.processor.push(summary.processor.clone(), summary);
+        self.diagnostic.refresh_outcome();
     }
 
     pub fn add_lookup<T>(&mut self, name: &str, lookup: &Lookup<T>)
@@ -341,6 +536,10 @@ impl DiagnosticReport {
         if !lookup.parsed && !self.diagnostic.lookup.failures.iter().any(|f| f == name) {
             self.diagnostic.lookup.errors += 1;
             self.diagnostic.lookup.failures.push(name.to_string());
+            self.diagnostic
+                .events
+                .push(DiagnosticEvent::warning(name.to_string(), "lookup could not be parsed"));
+            self.diagnostic.refresh_outcome();
         }
 
         self.diagnostic.lookup.push(
@@ -389,6 +588,15 @@ impl TryFrom<DiagnosticReportBuilder> for DiagnosticReport {
                 kibana_link: None,
                 identifiers: Identifiers::default(),
                 processing_duration: 0,
+                outcome: derive_outcome(
+                    &builder.collection_events,
+                    &Docs {
+                        created: 0,
+                        errors: 0,
+                        total: 0,
+                    },
+                ),
+                events: builder.collection_events,
             },
         })
     }
@@ -435,6 +643,12 @@ impl BatchResponse {
         }
     }
 
+    /// Request status recorded when an HTTP exporter's request never
+    /// completed (connection failure, serialization error). Status `0` is
+    /// reserved exclusively for non-HTTP exporters (ADR-0016), so HTTP
+    /// failures without a response use this sentinel instead.
+    pub const HTTP_REQUEST_NOT_COMPLETED: u16 = 599;
+
     pub fn failed(failed_doc_count: u32, status_code: u16) -> Self {
         Self {
             batch_count: 1,
@@ -456,11 +670,20 @@ impl BatchResponse {
         self.retries = self.retries.saturating_add(other.retries);
         self.size = self.size.saturating_add(other.size);
         self.time = self.time.saturating_add(other.time);
+        // The scalar code is the transport verdict; `status_counts` is
+        // authoritative for document outcomes. Mixed HTTP request codes are
+        // never collapsed to 0 — 0 is reserved for non-HTTP exporters
+        // (ADR-0016). A mixed aggregate keeps the most severe request code.
         self.status_code = match (self.status_code, other.status_code) {
             (0, status) if was_empty => status,
             (status, 0) if other.errors == 0 => status,
             (left, right) if left == right => left,
-            _ => 0,
+            (left, right) => match (left >= 400, right >= 400) {
+                (true, true) => left.max(right),
+                (true, false) => left,
+                (false, true) => right,
+                (false, false) => left.max(right),
+            },
         };
         self.merge_status_counts(&other);
     }
@@ -512,6 +735,10 @@ pub struct ProcessorSummary {
     pub source: Source,
     #[serde(skip_serializing)]
     children: Vec<ProcessorSummary>,
+    /// Events recorded while producing this summary; drained into the
+    /// diagnostic report's event log (ADR-0016).
+    #[serde(skip_serializing)]
+    events: Vec<DiagnosticEvent>,
 }
 
 impl ProcessorSummary {
@@ -521,9 +748,13 @@ impl ProcessorSummary {
                 self.batch.merge(other.batch);
                 self.docs = self.docs.saturating_add(other.docs);
                 self.doc_errors = self.doc_errors.saturating_add(other.doc_errors);
+                self.events.extend(other.events);
             }
             Err(err) => {
-                tracing::warn!("processor summary was err: {}", err);
+                // A whole-source failure is a recorded event, never only a
+                // log line (ADR-0016).
+                self.events
+                    .push(DiagnosticEvent::error(self.processor.clone(), err.to_string()));
             }
         }
     }
@@ -532,7 +763,8 @@ impl ProcessorSummary {
         match other {
             Ok(other) => self.children.push(other),
             Err(err) => {
-                tracing::warn!("processor summary was err: {}", err);
+                self.events
+                    .push(DiagnosticEvent::error(self.processor.clone(), err.to_string()));
             }
         }
     }
@@ -614,6 +846,7 @@ impl ProcessorSummary {
             processor: name,
             source: Source { parsed: false },
             children: Vec::new(),
+            events: Vec::new(),
         }
     }
 
@@ -753,6 +986,108 @@ user: ada
         assert_eq!(identifiers.account, None);
         assert_eq!(identifiers.case_number, None);
         assert_eq!(identifiers.user.as_deref(), Some("ada"));
+    }
+
+    #[test]
+    fn outcome_derives_complete_from_all_success_events() {
+        let events = vec![DiagnosticEvent::success("nodes", "5 documents exported")];
+        let docs = Docs {
+            created: 5,
+            errors: 0,
+            total: 5,
+        };
+        assert_eq!(derive_outcome(&events, &docs), DiagnosticOutcome::Complete);
+    }
+
+    #[test]
+    fn outcome_derives_partial_from_a_failure_alongside_output() {
+        let events = vec![
+            DiagnosticEvent::success("nodes", "5 documents exported"),
+            DiagnosticEvent::error("tasks", "source could not be read or parsed"),
+        ];
+        let docs = Docs {
+            created: 5,
+            errors: 0,
+            total: 5,
+        };
+        assert_eq!(derive_outcome(&events, &docs), DiagnosticOutcome::Partial);
+    }
+
+    #[test]
+    fn outcome_derives_partial_from_rejected_documents() {
+        // A 200 request with per-doc rejections is Partial: the per-doc
+        // histogram is authoritative, not the transport code (ADR-0016)
+        let events = vec![DiagnosticEvent::warning("nodes", "2 of 7 documents rejected")];
+        let docs = Docs {
+            created: 5,
+            errors: 2,
+            total: 7,
+        };
+        assert_eq!(derive_outcome(&events, &docs), DiagnosticOutcome::Partial);
+    }
+
+    #[test]
+    fn outcome_derives_failed_from_total_failure() {
+        let events = vec![
+            DiagnosticEvent::error("nodes", "connection refused"),
+            DiagnosticEvent::error("tasks", "connection refused"),
+        ];
+        let docs = Docs {
+            created: 0,
+            errors: 0,
+            total: 0,
+        };
+        assert_eq!(derive_outcome(&events, &docs), DiagnosticOutcome::Failed);
+    }
+
+    #[test]
+    fn skipped_outcome_distinguishes_by_design_from_not_implemented() {
+        let by_design = DiagnosticOutcome::Skipped(SkipKind::ByDesign);
+        let wip = DiagnosticOutcome::Skipped(SkipKind::NotImplemented);
+        assert_eq!(by_design.as_str(), "skipped");
+        assert_eq!(by_design.to_string(), "skipped (by design)");
+        assert_eq!(wip.to_string(), "skipped (not implemented)");
+        assert_eq!(by_design.skip_kind(), Some(SkipKind::ByDesign));
+    }
+
+    #[test]
+    fn merged_err_records_a_failure_event_not_a_dropped_log() {
+        let mut summary = ProcessorSummary::new("metrics-nodes-esdiag".to_string());
+        summary.merge(Err(eyre!("boom")));
+        summary.add_child(Err(eyre!("child boom")));
+
+        assert_eq!(summary.events.len(), 2);
+        assert!(summary.events.iter().all(|e| e.severity == EventSeverity::Error));
+        assert!(summary.events.iter().any(|e| e.reason.contains("boom")));
+    }
+
+    #[test]
+    fn mixed_http_request_codes_are_not_collapsed_to_zero() {
+        let mut aggregate = BatchResponse::aggregate();
+        let mut ok = BatchResponse::new(5);
+        ok.status_code = 200;
+        let mut rejected = BatchResponse::failed(2, 429);
+        rejected.status_code = 429;
+        aggregate.merge(ok);
+        aggregate.merge(rejected);
+
+        // The most severe request code wins; 0 is reserved for non-HTTP
+        // exporters (ADR-0016)
+        assert_eq!(aggregate.status_code, 429);
+        assert!(aggregate.status_counts.contains_key(&200));
+        assert!(aggregate.status_counts.contains_key(&429));
+    }
+
+    #[test]
+    fn non_http_exporter_status_stays_zero() {
+        let mut aggregate = BatchResponse::aggregate();
+        let mut local_a = BatchResponse::new(5);
+        local_a.status_code = 0;
+        let mut local_b = BatchResponse::new(3);
+        local_b.status_code = 0;
+        aggregate.merge(local_a);
+        aggregate.merge(local_b);
+        assert_eq!(aggregate.status_code, 0);
     }
 
     #[test]

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -388,11 +388,12 @@ pub struct DiagnosticStats {
 pub fn derive_outcome(events: &[DiagnosticEvent], docs: &Docs) -> DiagnosticOutcome {
     let has_error = events.iter().any(|event| event.severity == EventSeverity::Error);
     let has_warning = events.iter().any(|event| event.severity == EventSeverity::Warning);
+    let has_failure_signal = has_error || has_warning || docs.errors > 0;
     let produced = docs.created > 0 || events.iter().any(|event| event.severity == EventSeverity::Success);
 
-    if has_error && !produced {
+    if has_failure_signal && !produced {
         DiagnosticOutcome::Failed
-    } else if has_error || has_warning || docs.errors > 0 {
+    } else if has_failure_signal {
         DiagnosticOutcome::Partial
     } else {
         DiagnosticOutcome::Complete
@@ -1060,6 +1061,20 @@ user: ada
             DiagnosticEvent::error("nodes", "connection refused"),
             DiagnosticEvent::error("tasks", "connection refused"),
         ];
+        let docs = Docs {
+            created: 0,
+            errors: 0,
+            total: 0,
+        };
+        assert_eq!(derive_outcome(&events, &docs), DiagnosticOutcome::Failed);
+    }
+
+    #[test]
+    fn outcome_derives_failed_from_warning_without_output() {
+        let events = vec![DiagnosticEvent::warning(
+            "nodes",
+            "collection failed without an HTTP response",
+        )];
         let docs = Docs {
             created: 0,
             errors: 0,

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -500,7 +500,10 @@ impl DiagnosticReport {
         // Drain the summary's recorded events into the persisted report and
         // record this source's verdict as an event (ADR-0016).
         self.diagnostic.events.append(&mut summary.events);
-        if !summary.source.parsed {
+        if summary.source.missing {
+            // Source was not present in an imported bundle; that is not a
+            // processing failure and should not affect the derived outcome.
+        } else if !summary.source.parsed {
             self.diagnostic.processor.errors += 1;
             self.diagnostic.processor.failures.push(summary.index.clone());
             self.diagnostic.events.push(DiagnosticEvent::error(
@@ -533,7 +536,10 @@ impl DiagnosticReport {
     where
         T: Clone + Serialize,
     {
-        if !lookup.parsed && !self.diagnostic.lookup.failures.iter().any(|f| f == name) {
+        if lookup.missing {
+            // Optional lookup source was absent from an imported bundle; this
+            // should not affect the derived diagnostic outcome.
+        } else if !lookup.parsed && !self.diagnostic.lookup.failures.iter().any(|f| f == name) {
             self.diagnostic.lookup.errors += 1;
             self.diagnostic.lookup.failures.push(name.to_string());
             self.diagnostic
@@ -816,6 +822,8 @@ impl BatchStats {
 #[derive(Serialize, Clone)]
 pub struct Source {
     pub parsed: bool,
+    #[serde(skip_serializing_if = "is_false")]
+    pub missing: bool,
 }
 
 impl std::fmt::Display for Source {
@@ -831,6 +839,10 @@ impl Source {
     }
 }
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 impl ProcessorSummary {
     pub fn new(name: String) -> Self {
         Self {
@@ -844,9 +856,22 @@ impl ProcessorSummary {
             docs: 0,
             doc_errors: 0,
             processor: name,
-            source: Source { parsed: false },
+            source: Source {
+                parsed: false,
+                missing: false,
+            },
             children: Vec::new(),
             events: Vec::new(),
+        }
+    }
+
+    pub fn missing(name: String) -> Self {
+        Self {
+            source: Source {
+                parsed: false,
+                missing: true,
+            },
+            ..Self::new(name)
         }
     }
 
@@ -878,7 +903,10 @@ impl ProcessorSummary {
     }
 
     pub fn was_parsed(mut self) -> Self {
-        self.source = Source { parsed: true };
+        self.source = Source {
+            parsed: true,
+            missing: false,
+        };
         self.children = self.children.into_iter().map(ProcessorSummary::was_parsed).collect();
         self
     }
@@ -1059,6 +1087,40 @@ user: ada
         assert_eq!(summary.events.len(), 2);
         assert!(summary.events.iter().all(|e| e.severity == EventSeverity::Error));
         assert!(summary.events.iter().any(|e| e.reason.contains("boom")));
+    }
+
+    #[test]
+    fn missing_source_summary_does_not_change_outcome() {
+        let metadata = DiagnosticMetadata {
+            id: "test".to_string(),
+            collection_date: 0,
+            runner: "test".to_string(),
+            uuid: "test".to_string(),
+        };
+        let mut report =
+            DiagnosticReport::try_from(DiagnosticReportBuilder::from(metadata).receiver("file path".to_string()))
+                .unwrap();
+
+        let mut parsed = ProcessorSummary::new("metrics-nodes-esdiag".to_string());
+        let mut batch = BatchResponse::new(2);
+        batch.status_code = 200;
+        parsed.add_batch(batch);
+        report.add_processor_summary(parsed.was_parsed());
+        report.add_processor_summary(ProcessorSummary::missing("metrics-task-esdiag".to_string()));
+
+        assert_eq!(report.outcome(), DiagnosticOutcome::Complete);
+        assert_eq!(report.diagnostic.processor.errors(), 0);
+        assert_eq!(report.diagnostic.events.len(), 1);
+        assert!(
+            report
+                .diagnostic
+                .processor
+                .stats()
+                .get("metrics-task-esdiag")
+                .expect("missing source summary")
+                .source
+                .missing
+        );
     }
 
     #[test]

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -389,7 +389,7 @@ pub fn derive_outcome(events: &[DiagnosticEvent], docs: &Docs) -> DiagnosticOutc
     let has_error = events.iter().any(|event| event.severity == EventSeverity::Error);
     let has_warning = events.iter().any(|event| event.severity == EventSeverity::Warning);
     let has_failure_signal = has_error || has_warning || docs.errors > 0;
-    let produced = docs.created > 0 || events.iter().any(|event| event.severity == EventSeverity::Success);
+    let produced = docs.total > 0 || events.iter().any(|event| event.severity == EventSeverity::Success);
 
     if has_failure_signal && !produced {
         DiagnosticOutcome::Failed
@@ -1062,6 +1062,17 @@ user: ada
         let docs = Docs {
             created: 5,
             errors: 2,
+            total: 7,
+        };
+        assert_eq!(derive_outcome(&events, &docs), DiagnosticOutcome::Partial);
+    }
+
+    #[test]
+    fn outcome_derives_partial_when_all_attempted_documents_are_rejected() {
+        let events = vec![DiagnosticEvent::warning("nodes", "7 of 7 documents rejected")];
+        let docs = Docs {
+            created: 0,
+            errors: 7,
             total: 7,
         };
         assert_eq!(derive_outcome(&events, &docs), DiagnosticOutcome::Partial);

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -282,7 +282,7 @@ impl Serialize for DiagnosticOutcome {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(self.as_str())
+        serializer.serialize_str(&self.to_string())
     }
 }
 
@@ -500,6 +500,10 @@ impl DiagnosticReport {
     fn add_single_processor_summary(&mut self, mut summary: ProcessorSummary) {
         // Drain the summary's recorded events into the persisted report and
         // record this source's verdict as an event (ADR-0016).
+        let has_recorded_error = summary
+            .events
+            .iter()
+            .any(|event| event.severity == EventSeverity::Error);
         self.diagnostic.events.append(&mut summary.events);
         if summary.source.missing {
             // Source was not present in an imported bundle; that is not a
@@ -507,10 +511,12 @@ impl DiagnosticReport {
         } else if !summary.source.parsed {
             self.diagnostic.processor.errors += 1;
             self.diagnostic.processor.failures.push(summary.index.clone());
-            self.diagnostic.events.push(DiagnosticEvent::error(
-                summary.processor.clone(),
-                "source could not be read or parsed".to_string(),
-            ));
+            if !has_recorded_error {
+                self.diagnostic.events.push(DiagnosticEvent::error(
+                    summary.processor.clone(),
+                    "source could not be read or parsed".to_string(),
+                ));
+            }
         } else if summary.doc_errors > 0 {
             self.diagnostic.events.push(DiagnosticEvent::warning(
                 summary.processor.clone(),
@@ -876,6 +882,12 @@ impl ProcessorSummary {
         }
     }
 
+    pub fn with_error(mut self, reason: impl Into<String>) -> Self {
+        self.events
+            .push(DiagnosticEvent::error(self.processor.clone(), reason.into()));
+        self
+    }
+
     pub fn add_batch(&mut self, batch: BatchResponse) {
         if batch.batch_count == 0 && batch.docs == 0 && batch.errors == 0 {
             return;
@@ -1091,6 +1103,8 @@ user: ada
         assert_eq!(by_design.to_string(), "skipped (by design)");
         assert_eq!(wip.to_string(), "skipped (not implemented)");
         assert_eq!(by_design.skip_kind(), Some(SkipKind::ByDesign));
+        assert_eq!(serde_json::to_value(by_design).unwrap(), "skipped (by design)");
+        assert_eq!(serde_json::to_value(wip).unwrap(), "skipped (not implemented)");
     }
 
     #[test]
@@ -1135,6 +1149,32 @@ user: ada
                 .expect("missing source summary")
                 .source
                 .missing
+        );
+    }
+
+    #[test]
+    fn failed_summary_with_recorded_event_does_not_add_generic_duplicate() {
+        let metadata = DiagnosticMetadata {
+            id: "test".to_string(),
+            collection_date: 0,
+            runner: "test".to_string(),
+            uuid: "test".to_string(),
+        };
+        let mut report =
+            DiagnosticReport::try_from(DiagnosticReportBuilder::from(metadata).receiver("file path".to_string()))
+                .unwrap();
+
+        report.add_processor_summary(
+            ProcessorSummary::new("cluster_settings-esdiag".to_string())
+                .with_error("Failed to read cluster_settings: corrupt payload"),
+        );
+
+        assert_eq!(report.outcome(), DiagnosticOutcome::Failed);
+        assert_eq!(report.diagnostic.processor.errors(), 1);
+        assert_eq!(report.diagnostic.events.len(), 1);
+        assert_eq!(
+            report.diagnostic.events[0].reason,
+            "Failed to read cluster_settings: corrupt payload"
         );
     }
 

--- a/src/processor/elasticsearch/mapping_stats/lookup.rs
+++ b/src/processor/elasticsearch/mapping_stats/lookup.rs
@@ -30,10 +30,11 @@ impl Lookup<MappingSummary> {
                     lookup.add(index_mapping.summarize()).with_name(&index_name);
                 }
                 Err(e) => {
-                    tracing::warn!("Error reading from mapping stats stream: {}", e);
                     if missing_source_error(&e) {
+                        tracing::debug!("Mapping stats source is absent: {}", e);
                         saw_missing_source = true;
                     } else {
+                        tracing::warn!("Error reading from mapping stats stream: {}", e);
                         saw_error = true;
                     }
                 }

--- a/src/processor/elasticsearch/mapping_stats/lookup.rs
+++ b/src/processor/elasticsearch/mapping_stats/lookup.rs
@@ -2,7 +2,10 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::{super::Lookup, IndexMapping, MappingStats, MappingSummary};
+use super::{
+    super::{Lookup, missing_source_error},
+    IndexMapping, MappingStats, MappingSummary,
+};
 use eyre::Result;
 use futures::stream::{BoxStream, StreamExt};
 
@@ -19,6 +22,8 @@ impl From<MappingStats> for Lookup<MappingSummary> {
 impl Lookup<MappingSummary> {
     pub async fn from_stream(mut stream: BoxStream<'static, Result<(String, IndexMapping)>>) -> Self {
         let mut lookup = Lookup::new();
+        let mut saw_missing_source = false;
+        let mut saw_error = false;
         while let Some(result) = stream.next().await {
             match result {
                 Ok((index_name, index_mapping)) => {
@@ -26,10 +31,22 @@ impl Lookup<MappingSummary> {
                 }
                 Err(e) => {
                     tracing::warn!("Error reading from mapping stats stream: {}", e);
+                    if missing_source_error(&e) {
+                        saw_missing_source = true;
+                    } else {
+                        saw_error = true;
+                    }
                 }
             }
         }
-        lookup
+
+        if lookup.is_empty() && saw_missing_source && !saw_error {
+            Lookup::missing()
+        } else if saw_error {
+            lookup
+        } else {
+            lookup.was_parsed()
+        }
     }
 }
 

--- a/src/processor/elasticsearch/mod.rs
+++ b/src/processor/elasticsearch/mod.rs
@@ -284,14 +284,19 @@ impl ElasticsearchDiagnostic {
                         .await
                         .was_parsed(),
                     Err(settings_err) => {
-                        tracing::warn!(
-                            "Failed to read cluster_settings_defaults and cluster_settings: {}; {}",
-                            defaults_err,
-                            settings_err
-                        );
                         if missing_source_error(&defaults_err) && missing_source_error(&settings_err) {
+                            tracing::debug!(
+                                "cluster_settings_defaults and cluster_settings are absent: {}; {}",
+                                defaults_err,
+                                settings_err
+                            );
                             ProcessorSummary::missing(ClusterSettings::name())
                         } else {
+                            tracing::warn!(
+                                "Failed to read cluster_settings_defaults and cluster_settings: {}; {}",
+                                defaults_err,
+                                settings_err
+                            );
                             ProcessorSummary::new(ClusterSettings::name()).with_error(format!(
                                 "Failed to read cluster_settings_defaults and cluster_settings: {}; {}",
                                 defaults_err, settings_err
@@ -324,10 +329,11 @@ impl ElasticsearchDiagnostic {
                 })
             }
             Err(err) => {
-                tracing::warn!("{}", err);
                 let summary = if missing_source_error(&err) {
+                    tracing::debug!("{} is absent: {}", T::name(), err);
                     ProcessorSummary::missing(T::name())
                 } else {
+                    tracing::warn!("{}", err);
                     ProcessorSummary::new(T::name()).with_error(err.to_string())
                 };
                 summary_tx.send(summary).await.map_err(|err| {

--- a/src/processor/elasticsearch/mod.rs
+++ b/src/processor/elasticsearch/mod.rs
@@ -292,7 +292,10 @@ impl ElasticsearchDiagnostic {
                         if missing_source_error(&defaults_err) && missing_source_error(&settings_err) {
                             ProcessorSummary::missing(ClusterSettings::name())
                         } else {
-                            ProcessorSummary::new(ClusterSettings::name())
+                            ProcessorSummary::new(ClusterSettings::name()).with_error(format!(
+                                "Failed to read cluster_settings_defaults and cluster_settings: {}; {}",
+                                defaults_err, settings_err
+                            ))
                         }
                     }
                 }
@@ -325,7 +328,7 @@ impl ElasticsearchDiagnostic {
                 let summary = if missing_source_error(&err) {
                     ProcessorSummary::missing(T::name())
                 } else {
-                    ProcessorSummary::new(T::name())
+                    ProcessorSummary::new(T::name()).with_error(err.to_string())
                 };
                 summary_tx.send(summary).await.map_err(|err| {
                     tracing::error!("Failed to send summary: {}", err);

--- a/src/processor/elasticsearch/mod.rs
+++ b/src/processor/elasticsearch/mod.rs
@@ -67,7 +67,7 @@ use super::{
 use crate::{
     data::{self, Application},
     exporter::Exporter,
-    receiver::Receiver,
+    receiver::{MissingSource, Receiver},
 };
 use eyre::{Result, eyre};
 use futures::stream::FuturesUnordered;
@@ -372,14 +372,12 @@ impl ElasticsearchDiagnostic {
 }
 
 pub(super) fn missing_source_error(err: &eyre::Report) -> bool {
-    if err
-        .downcast_ref::<std::io::Error>()
-        .is_some_and(|io_err| io_err.kind() == std::io::ErrorKind::NotFound)
-    {
-        return true;
-    }
-
-    err.to_string().starts_with("File not found in archive: ")
+    err.chain().any(|cause| {
+        cause.is::<MissingSource>()
+            || cause
+                .downcast_ref::<std::io::Error>()
+                .is_some_and(|io_err| io_err.kind() == std::io::ErrorKind::NotFound)
+    })
 }
 
 fn lookup_from_result<T, U>(result: Result<U>, label: &str) -> Lookup<T>

--- a/src/processor/elasticsearch/mod.rs
+++ b/src/processor/elasticsearch/mod.rs
@@ -289,7 +289,11 @@ impl ElasticsearchDiagnostic {
                             defaults_err,
                             settings_err
                         );
-                        ProcessorSummary::new(ClusterSettings::name())
+                        if missing_source_error(&defaults_err) && missing_source_error(&settings_err) {
+                            ProcessorSummary::missing(ClusterSettings::name())
+                        } else {
+                            ProcessorSummary::new(ClusterSettings::name())
+                        }
                     }
                 }
             }
@@ -318,7 +322,11 @@ impl ElasticsearchDiagnostic {
             }
             Err(err) => {
                 tracing::warn!("{}", err);
-                let summary = ProcessorSummary::new(T::name());
+                let summary = if missing_source_error(&err) {
+                    ProcessorSummary::missing(T::name())
+                } else {
+                    ProcessorSummary::new(T::name())
+                };
                 summary_tx.send(summary).await.map_err(|err| {
                     tracing::error!("Failed to send summary: {}", err);
                     eyre!(err)
@@ -360,6 +368,32 @@ impl ElasticsearchDiagnostic {
     }
 }
 
+pub(super) fn missing_source_error(err: &eyre::Report) -> bool {
+    if err
+        .downcast_ref::<std::io::Error>()
+        .is_some_and(|io_err| io_err.kind() == std::io::ErrorKind::NotFound)
+    {
+        return true;
+    }
+
+    err.to_string().starts_with("File not found in archive: ")
+}
+
+fn lookup_from_result<T, U>(result: Result<U>, label: &str) -> Lookup<T>
+where
+    T: Clone + Serialize,
+    Lookup<T>: From<U>,
+{
+    match result {
+        Ok(value) => Lookup::<T>::from_parsed(value),
+        Err(err) if missing_source_error(&err) => Lookup::missing(),
+        Err(err) => {
+            tracing::warn!("Failed to parse {}: {}", label, err);
+            Lookup::new()
+        }
+    }
+}
+
 impl DiagnosticProcessor for ElasticsearchDiagnostic {
     async fn try_new(
         receiver: Arc<Receiver>,
@@ -392,17 +426,20 @@ impl DiagnosticProcessor for ElasticsearchDiagnostic {
         tracing::debug!("ElasticsearchDiagnostic::try_new built report");
 
         let lookups = Lookups {
-            alias: Lookup::from(receiver.get::<AliasList>().await),
-            data_stream: Lookup::from(receiver.get::<DataStreams>().await),
-            index_settings: Lookup::from(receiver.get::<IndicesSettings>().await),
-            node: Lookup::from(receiver.get::<Nodes>().await),
-            ilm_explain: Lookup::from(receiver.get::<IlmExplain>().await),
-            shared_cache: Lookup::from(receiver.get::<SearchableSnapshotsCacheStats>().await),
+            alias: lookup_from_result(receiver.get::<AliasList>().await, "AliasList"),
+            data_stream: lookup_from_result(receiver.get::<DataStreams>().await, "DataStreams"),
+            index_settings: lookup_from_result(receiver.get::<IndicesSettings>().await, "IndicesSettings"),
+            node: lookup_from_result(receiver.get::<Nodes>().await, "Nodes"),
+            ilm_explain: lookup_from_result(receiver.get::<IlmExplain>().await, "IlmExplain"),
+            shared_cache: lookup_from_result(
+                receiver.get::<SearchableSnapshotsCacheStats>().await,
+                "SearchableSnapshotsCacheStats",
+            ),
             mapping_stats: match receiver.get_stream::<MappingStats>().await {
                 Ok(stream) => Lookup::<MappingSummary>::from_stream(stream).await,
                 Err(e) => {
                     tracing::debug!("Streaming mappings failed: {}, falling back to full load", e);
-                    Lookup::from(receiver.get::<MappingStats>().await)
+                    lookup_from_result(receiver.get::<MappingStats>().await, "MappingStats")
                 }
             },
         };

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -260,7 +260,13 @@ fn spawn_sub_processors(
                         outcome
                     }
                     Err(failed) => {
-                        let outcome = failed_child_outcome(child_job_id, path, failed.state.error);
+                        let outcome = failed_child_outcome_with_context(
+                            child_job_id,
+                            path,
+                            failed.state.error,
+                            application,
+                            platform,
+                        );
                         send_child_outcome_event(&event_tx, &outcome);
                         outcome
                     }
@@ -277,7 +283,13 @@ fn spawn_sub_processors(
                             reason: Some(failed.state.error),
                             runtime: None,
                         },
-                        None => failed_child_outcome(child_job_id, path, failed.state.error),
+                        None => failed_child_outcome_with_context(
+                            child_job_id,
+                            path,
+                            failed.state.error,
+                            application,
+                            platform,
+                        ),
                     };
                     send_child_outcome_event(&event_tx, &outcome);
                     outcome
@@ -307,13 +319,23 @@ fn spawn_sub_processors(
 }
 
 fn failed_child_outcome(job_id: u64, path: String, error: String) -> IncludedDiagnosticOutcome {
+    failed_child_outcome_with_context(job_id, path, error, None, Platform::Unknown)
+}
+
+fn failed_child_outcome_with_context(
+    job_id: u64,
+    path: String,
+    error: String,
+    application: Option<Application>,
+    platform: Platform,
+) -> IncludedDiagnosticOutcome {
     IncludedDiagnosticOutcome {
         job_id,
         path,
         outcome: DiagnosticOutcome::Failed,
         report: None,
-        application: None,
-        platform: Platform::Unknown,
+        application,
+        platform,
         reason: Some(error),
         runtime: None,
     }
@@ -971,6 +993,22 @@ mod tests {
                 .unwrap_or_default()
                 .contains("Failed to read included diagnostic manifest")
         );
+    }
+
+    #[test]
+    fn failed_child_outcome_preserves_known_child_context() {
+        let outcome = failed_child_outcome_with_context(
+            42,
+            "child-es".to_string(),
+            "processing failed".to_string(),
+            Some(Application::Elasticsearch),
+            Platform::ECK,
+        );
+
+        assert_eq!(outcome.outcome, DiagnosticOutcome::Failed);
+        assert_eq!(outcome.application, Some(Application::Elasticsearch));
+        assert_eq!(outcome.platform, Platform::ECK);
+        assert_eq!(outcome.reason.as_deref(), Some("processing failed"));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -23,7 +23,9 @@ pub use diagnostic::{
     DataSource, DiagnosticManifest, DiagnosticReport, Manifest, RequestedApi, SourceContext,
     data_source::init_sources,
     manifest::ManifestBuilder,
-    report::{BatchResponse, Identifiers, ProcessorSummary},
+    report::{
+        BatchResponse, DiagnosticEvent, DiagnosticOutcome, EventSeverity, Identifiers, ProcessorSummary, SkipKind,
+    },
 };
 pub use elasticsearch::Cluster as ElasticsearchCluster;
 
@@ -102,38 +104,31 @@ impl State for Processing {}
 impl State for Completed {}
 impl State for Failed {}
 
-pub enum IncludedDiagnosticOutcome {
-    Completed {
-        job_id: u64,
-        path: String,
-        report: Box<DiagnosticReport>,
-        runtime: u128,
-    },
-    Skipped {
-        job_id: u64,
-        path: String,
-        application: Option<Application>,
-        platform: Platform,
-        reason: String,
-    },
-    Failed {
-        job_id: u64,
-        path: String,
-        error: String,
-    },
+/// The preserved result of one included (child) diagnostic execution. The
+/// verdict is the unified [`DiagnosticOutcome`] (ADR-0016) — the same type a
+/// parent derives — so a child can be `Partial`, and a skip carries its
+/// by-design vs not-implemented kind.
+pub struct IncludedDiagnosticOutcome {
+    pub job_id: u64,
+    pub path: String,
+    /// Unified verdict; derived from the child's own report when one exists.
+    pub outcome: DiagnosticOutcome,
+    /// The child's report, when the child ran far enough to produce one.
+    pub report: Option<Box<DiagnosticReport>>,
+    pub application: Option<Application>,
+    pub platform: Platform,
+    /// Skip reason or failure error, when the child did not complete.
+    pub reason: Option<String>,
+    pub runtime: Option<u128>,
 }
 
 impl IncludedDiagnosticOutcome {
     pub fn job_id(&self) -> u64 {
-        match self {
-            Self::Completed { job_id, .. } | Self::Skipped { job_id, .. } | Self::Failed { job_id, .. } => *job_id,
-        }
+        self.job_id
     }
 
     pub fn path(&self) -> &str {
-        match self {
-            Self::Completed { path, .. } | Self::Skipped { path, .. } | Self::Failed { path, .. } => path,
-        }
+        &self.path
     }
 }
 
@@ -150,6 +145,7 @@ pub enum IncludedDiagnosticJobEvent {
     Completed {
         job_id: u64,
         path: String,
+        outcome: DiagnosticOutcome,
         application: Option<Application>,
         platform: Platform,
         diagnostic_id: String,
@@ -160,6 +156,7 @@ pub enum IncludedDiagnosticJobEvent {
     Skipped {
         job_id: u64,
         path: String,
+        outcome: DiagnosticOutcome,
         application: Option<Application>,
         platform: Platform,
         reason: String,
@@ -216,11 +213,11 @@ fn spawn_sub_processors(
             let receiver = match parent_receiver.clone_for_subdir(&path) {
                 Ok(receiver) => Arc::new(receiver),
                 Err(e) => {
-                    let outcome = IncludedDiagnosticOutcome::Failed {
-                        job_id: child_job_id,
+                    let outcome = failed_child_outcome(
+                        child_job_id,
                         path,
-                        error: format!("Failed to clone receiver for included diagnostic: {e}"),
-                    };
+                        format!("Failed to clone receiver for included diagnostic: {e}"),
+                    );
                     send_child_outcome_event(&event_tx, &outcome);
                     return outcome;
                 }
@@ -229,11 +226,11 @@ fn spawn_sub_processors(
             let processor = match Processor::try_new_child(receiver, exporter, ident_clone).await {
                 Ok(processor) => processor,
                 Err(e) => {
-                    let outcome = IncludedDiagnosticOutcome::Failed {
-                        job_id: child_job_id,
+                    let outcome = failed_child_outcome(
+                        child_job_id,
                         path,
-                        error: format!("Failed to read included diagnostic manifest: {e}"),
-                    };
+                        format!("Failed to read included diagnostic manifest: {e}"),
+                    );
                     send_child_outcome_event(&event_tx, &outcome);
                     return outcome;
                 }
@@ -245,41 +242,42 @@ fn spawn_sub_processors(
                 Ok(processing) => match processing.process().await {
                     Ok(complete) => {
                         tracing::info!("Included diagnostic processor complete");
-                        let outcome = IncludedDiagnosticOutcome::Completed {
+                        let report = complete.state.report;
+                        // The child's verdict derives from its own report,
+                        // exactly as the parent's does (ADR-0016) — a child
+                        // can be Partial.
+                        let outcome = IncludedDiagnosticOutcome {
                             job_id: child_job_id,
                             path,
-                            report: Box::new(complete.state.report),
-                            runtime: complete.state.runtime,
+                            outcome: report.outcome(),
+                            application: report.diagnostic.application,
+                            platform: report.diagnostic.platform(),
+                            report: Some(Box::new(report)),
+                            reason: None,
+                            runtime: Some(complete.state.runtime),
                         };
                         send_child_outcome_event(&event_tx, &outcome);
                         outcome
                     }
                     Err(failed) => {
-                        let outcome = IncludedDiagnosticOutcome::Failed {
-                            job_id: child_job_id,
-                            path,
-                            error: failed.state.error,
-                        };
+                        let outcome = failed_child_outcome(child_job_id, path, failed.state.error);
                         send_child_outcome_event(&event_tx, &outcome);
                         outcome
                     }
                 },
-                Err(failed) if is_unsupported_child_processor(&failed.state.error) => {
-                    let outcome = IncludedDiagnosticOutcome::Skipped {
-                        job_id: child_job_id,
-                        path,
-                        application,
-                        platform,
-                        reason: failed.state.error,
-                    };
-                    send_child_outcome_event(&event_tx, &outcome);
-                    outcome
-                }
                 Err(failed) => {
-                    let outcome = IncludedDiagnosticOutcome::Failed {
-                        job_id: child_job_id,
-                        path,
-                        error: failed.state.error,
+                    let outcome = match skip_kind_for(&failed.state.error) {
+                        Some(kind) => IncludedDiagnosticOutcome {
+                            job_id: child_job_id,
+                            path,
+                            outcome: DiagnosticOutcome::Skipped(kind),
+                            report: None,
+                            application,
+                            platform,
+                            reason: Some(failed.state.error),
+                            runtime: None,
+                        },
+                        None => failed_child_outcome(child_job_id, path, failed.state.error),
                     };
                     send_child_outcome_event(&event_tx, &outcome);
                     outcome
@@ -292,11 +290,11 @@ fn spawn_sub_processors(
                     Ok(outcome) => outcome,
                     Err(e) => {
                         tracing::error!("Included diagnostic task panicked or failed to join: {}", e);
-                        let outcome = IncludedDiagnosticOutcome::Failed {
-                            job_id: child_job_id,
-                            path: join_path,
-                            error: format!("Included diagnostic task failed to join: {e}"),
-                        };
+                        let outcome = failed_child_outcome(
+                            child_job_id,
+                            join_path,
+                            format!("Included diagnostic task failed to join: {e}"),
+                        );
                         send_child_outcome_event(&join_event_tx, &outcome);
                         outcome
                     }
@@ -306,6 +304,29 @@ fn spawn_sub_processors(
         )
     }
     handles
+}
+
+fn failed_child_outcome(job_id: u64, path: String, error: String) -> IncludedDiagnosticOutcome {
+    IncludedDiagnosticOutcome {
+        job_id,
+        path,
+        outcome: DiagnosticOutcome::Failed,
+        report: None,
+        application: None,
+        platform: Platform::Unknown,
+        reason: Some(error),
+        runtime: None,
+    }
+}
+
+/// Why an unsupported child is skipped (ADR-0019): platform-only bundles are
+/// out of scope by design; Kibana/Agent processing is work in progress.
+fn skip_kind_for(error: &str) -> Option<SkipKind> {
+    match error {
+        KIBANA_PROCESSING_NOT_IMPLEMENTED => Some(SkipKind::NotImplemented),
+        UNSUPPORTED_PRODUCT_OR_DIAGNOSTIC_BUNDLE => Some(SkipKind::ByDesign),
+        _ => None,
+    }
 }
 
 fn send_child_event(
@@ -321,39 +342,30 @@ fn send_child_outcome_event(
     child_event_tx: &Option<mpsc::UnboundedSender<IncludedDiagnosticJobEvent>>,
     outcome: &IncludedDiagnosticOutcome,
 ) {
-    let event = match outcome {
-        IncludedDiagnosticOutcome::Completed {
-            job_id,
-            path,
-            report,
-            runtime,
-        } => IncludedDiagnosticJobEvent::Completed {
-            job_id: *job_id,
-            path: path.clone(),
+    let event = match (&outcome.outcome, &outcome.report) {
+        (DiagnosticOutcome::Skipped(_), _) => IncludedDiagnosticJobEvent::Skipped {
+            job_id: outcome.job_id,
+            path: outcome.path.clone(),
+            outcome: outcome.outcome,
+            application: outcome.application,
+            platform: outcome.platform,
+            reason: outcome.reason.clone().unwrap_or_default(),
+        },
+        (_, Some(report)) => IncludedDiagnosticJobEvent::Completed {
+            job_id: outcome.job_id,
+            path: outcome.path.clone(),
+            outcome: outcome.outcome,
             application: report.diagnostic.application,
             platform: report.diagnostic.platform(),
             diagnostic_id: report.diagnostic.metadata.id.clone(),
             docs_created: report.diagnostic.docs.created,
-            duration_ms: *runtime,
+            duration_ms: outcome.runtime.unwrap_or_default(),
             kibana_link: report.diagnostic.kibana_link.clone(),
         },
-        IncludedDiagnosticOutcome::Skipped {
-            job_id,
-            path,
-            application,
-            platform,
-            reason,
-        } => IncludedDiagnosticJobEvent::Skipped {
-            job_id: *job_id,
-            path: path.clone(),
-            application: *application,
-            platform: *platform,
-            reason: reason.clone(),
-        },
-        IncludedDiagnosticOutcome::Failed { job_id, path, error } => IncludedDiagnosticJobEvent::Failed {
-            job_id: *job_id,
-            path: path.clone(),
-            error: error.clone(),
+        (_, None) => IncludedDiagnosticJobEvent::Failed {
+            job_id: outcome.job_id,
+            path: outcome.path.clone(),
+            error: outcome.reason.clone().unwrap_or_default(),
         },
     };
     send_child_event(child_event_tx, event);
@@ -385,13 +397,6 @@ async fn resolve_platform(manifest: &DiagnosticManifest, receiver: &Receiver, id
         return Platform::SelfManaged;
     }
     Platform::Unknown
-}
-
-fn is_unsupported_child_processor(error: &str) -> bool {
-    matches!(
-        error,
-        KIBANA_PROCESSING_NOT_IMPLEMENTED | UNSUPPORTED_PRODUCT_OR_DIAGNOSTIC_BUNDLE
-    )
 }
 
 impl Processor<Ready> {
@@ -900,10 +905,15 @@ mod tests {
             .map(IncludedDiagnosticOutcome::job_id)
             .collect::<HashSet<_>>();
         assert_eq!(child_job_ids.len(), 2);
-        for outcome in &completed.state.included_diagnostics {
-            let IncludedDiagnosticOutcome::Completed { report, .. } = outcome else {
-                panic!("expected supported child to complete");
-            };
+        for child in &completed.state.included_diagnostics {
+            // Real fixture bundles lack some selectable sources, so the child
+            // verdict is honestly Partial (missing sources are now recorded
+            // events, not silent warns) — but it produced documents
+            assert!(matches!(
+                child.outcome,
+                DiagnosticOutcome::Complete | DiagnosticOutcome::Partial
+            ));
+            let report = child.report.as_ref().expect("completed child carries its report");
             assert_eq!(report.diagnostic.application, Some(Application::Elasticsearch));
             assert!(report.diagnostic.docs.created > 0);
             assert!(report.diagnostic.identifiers.parent_id.is_some());
@@ -921,18 +931,20 @@ mod tests {
         let completed = process_parent_bundle(root.path()).await;
 
         assert_eq!(completed.state.included_diagnostics.len(), 1);
-        let IncludedDiagnosticOutcome::Skipped {
-            application,
-            platform,
-            reason,
-            ..
-        } = &completed.state.included_diagnostics[0]
-        else {
-            panic!("expected unsupported child to be skipped");
-        };
-        assert_eq!(*application, Some(Application::Kibana));
-        assert_eq!(*platform, Platform::ECK);
-        assert!(reason.contains("Kibana processing is not yet implemented"));
+        let child = &completed.state.included_diagnostics[0];
+        // Kibana processing is work in progress: skipped as not-implemented
+        // (ADR-0016/0019), while the parent still completes
+        assert_eq!(child.outcome, DiagnosticOutcome::Skipped(SkipKind::NotImplemented));
+        assert_eq!(child.application, Some(Application::Kibana));
+        assert_eq!(child.platform, Platform::ECK);
+        assert!(
+            child
+                .reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Kibana processing is not yet implemented")
+        );
+        assert_eq!(completed.state.report.outcome(), DiagnosticOutcome::Complete);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -953,11 +965,16 @@ mod tests {
         assert_eq!(completed.state.report.diagnostic.platform(), Platform::ECK);
         assert_eq!(completed.state.report.diagnostic.display_label(), "ECK");
         assert_eq!(completed.state.included_diagnostics.len(), 1);
-        let IncludedDiagnosticOutcome::Failed { path, error, .. } = &completed.state.included_diagnostics[0] else {
-            panic!("expected unreadable child to fail independently");
-        };
-        assert_eq!(path, "missing-child");
-        assert!(error.contains("Failed to read included diagnostic manifest"));
+        let child = &completed.state.included_diagnostics[0];
+        assert_eq!(child.outcome, DiagnosticOutcome::Failed);
+        assert_eq!(child.path, "missing-child");
+        assert!(
+            child
+                .reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Failed to read included diagnostic manifest")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -906,13 +906,9 @@ mod tests {
             .collect::<HashSet<_>>();
         assert_eq!(child_job_ids.len(), 2);
         for child in &completed.state.included_diagnostics {
-            // Real fixture bundles lack some selectable sources, so the child
-            // verdict is honestly Partial (missing sources are now recorded
-            // events, not silent warns) — but it produced documents
-            assert!(matches!(
-                child.outcome,
-                DiagnosticOutcome::Complete | DiagnosticOutcome::Partial
-            ));
+            // Fixture bundles may omit optional selectable sources; absence in
+            // an imported bundle is not a processing failure.
+            assert_eq!(child.outcome, DiagnosticOutcome::Complete);
             let report = child.report.as_ref().expect("completed child carries its report");
             assert_eq!(report.diagnostic.application, Some(Application::Elasticsearch));
             assert!(report.diagnostic.docs.created > 0);

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -193,7 +193,11 @@ pub async fn service_link(
                 );
                 let report = &completed.state.report;
                 state
-                    .record_success(report.diagnostic.docs.total, report.diagnostic.docs.errors)
+                    .record_outcome(
+                        report.outcome(),
+                        report.diagnostic.docs.total,
+                        report.diagnostic.docs.errors,
+                    )
                     .await;
 
                 let response = diagnostic_result_entries(&completed.state);
@@ -401,7 +405,11 @@ pub async fn api_key(
                 );
                 let report = &completed.state.report;
                 state
-                    .record_success(report.diagnostic.docs.total, report.diagnostic.docs.errors)
+                    .record_outcome(
+                        report.outcome(),
+                        report.diagnostic.docs.total,
+                        report.diagnostic.docs.errors,
+                    )
                     .await;
 
                 let response = diagnostic_result_entries(&completed.state);

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -440,7 +440,7 @@ fn diagnostic_result_entries(completed: &Completed) -> Value {
     let report = &completed.report;
     let mut entries = vec![json!({
         "status": "success",
-        "outcome": report.outcome().as_str(),
+        "outcome": report.outcome().to_string(),
         "diagnostic_id": report.diagnostic.metadata.id,
         "kibana_link": report.diagnostic.kibana_link.as_deref().unwrap_or(""),
         "took": runtime_millis(completed.runtime),
@@ -453,7 +453,7 @@ fn diagnostic_result_entries(completed: &Completed) -> Value {
         let entry = match (&child.outcome, &child.report) {
             (DiagnosticOutcome::Skipped(_), _) => json!({
                 "status": "info",
-                "outcome": child.outcome.as_str(),
+                "outcome": child.outcome.to_string(),
                 "product": crate::processor::display_label(child.application, child.platform),
                 "source": "included_diagnostic",
                 "path": child.path,
@@ -461,7 +461,7 @@ fn diagnostic_result_entries(completed: &Completed) -> Value {
             }),
             (_, Some(report)) => json!({
                 "status": "success",
-                "outcome": child.outcome.as_str(),
+                "outcome": child.outcome.to_string(),
                 "diagnostic_id": report.diagnostic.metadata.id,
                 "kibana_link": report.diagnostic.kibana_link.as_deref().unwrap_or(""),
                 "took": runtime_millis(child.runtime.unwrap_or_default()),
@@ -471,7 +471,7 @@ fn diagnostic_result_entries(completed: &Completed) -> Value {
             }),
             (_, None) => json!({
                 "status": "failed",
-                "outcome": child.outcome.as_str(),
+                "outcome": child.outcome.to_string(),
                 "source": "included_diagnostic",
                 "path": child.path,
                 "error": child.reason.as_deref().unwrap_or_default()
@@ -573,8 +573,10 @@ mod tests {
             "https://kb.example/app/dashboards#/view/child"
         );
         assert_eq!(entries[2]["status"], "info");
+        assert_eq!(entries[2]["outcome"], "skipped (not implemented)");
         assert_eq!(entries[2]["reason"], "Kibana processing is not yet implemented");
         assert_eq!(entries[3]["status"], "failed");
+        assert_eq!(entries[3]["outcome"], "failed");
         assert_eq!(entries[3]["error"], "manifest missing");
     }
 

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -439,7 +439,7 @@ pub async fn api_key(
 fn diagnostic_result_entries(completed: &Completed) -> Value {
     let report = &completed.report;
     let mut entries = vec![json!({
-        "status": "success",
+        "status": status_for_outcome(&report.outcome()),
         "outcome": report.outcome().to_string(),
         "diagnostic_id": report.diagnostic.metadata.id,
         "kibana_link": report.diagnostic.kibana_link.as_deref().unwrap_or(""),
@@ -460,7 +460,7 @@ fn diagnostic_result_entries(completed: &Completed) -> Value {
                 "reason": child.reason.as_deref().unwrap_or_default()
             }),
             (_, Some(report)) => json!({
-                "status": "success",
+                "status": status_for_outcome(&child.outcome),
                 "outcome": child.outcome.to_string(),
                 "diagnostic_id": report.diagnostic.metadata.id,
                 "kibana_link": report.diagnostic.kibana_link.as_deref().unwrap_or(""),
@@ -483,13 +483,21 @@ fn diagnostic_result_entries(completed: &Completed) -> Value {
     Value::Array(entries)
 }
 
+fn status_for_outcome(outcome: &DiagnosticOutcome) -> &'static str {
+    match outcome {
+        DiagnosticOutcome::Failed => "failed",
+        DiagnosticOutcome::Skipped(_) => "info",
+        DiagnosticOutcome::Complete | DiagnosticOutcome::Partial => "success",
+    }
+}
+
 fn runtime_millis(runtime: u128) -> u64 {
     runtime.try_into().unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{diagnostic_result_entries, runtime_millis};
+    use super::{diagnostic_result_entries, runtime_millis, status_for_outcome};
     use crate::{
         data::{Application, Platform, Product},
         processor::{
@@ -578,6 +586,17 @@ mod tests {
         assert_eq!(entries[3]["status"], "failed");
         assert_eq!(entries[3]["outcome"], "failed");
         assert_eq!(entries[3]["error"], "manifest missing");
+    }
+
+    #[test]
+    fn status_for_outcome_tracks_terminal_outcomes() {
+        assert_eq!(status_for_outcome(&DiagnosticOutcome::Complete), "success");
+        assert_eq!(status_for_outcome(&DiagnosticOutcome::Partial), "success");
+        assert_eq!(status_for_outcome(&DiagnosticOutcome::Failed), "failed");
+        assert_eq!(
+            status_for_outcome(&DiagnosticOutcome::Skipped(SkipKind::ByDesign)),
+            "info"
+        );
     }
 
     #[test]

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -193,11 +193,7 @@ pub async fn service_link(
                 );
                 let report = &completed.state.report;
                 state
-                    .record_outcome(
-                        report.outcome(),
-                        report.diagnostic.docs.total,
-                        report.diagnostic.docs.errors,
-                    )
+                    .record_outcome(report.outcome(), report.diagnostic.docs.errors)
                     .await;
 
                 let response = diagnostic_result_entries(&completed.state);
@@ -405,11 +401,7 @@ pub async fn api_key(
                 );
                 let report = &completed.state.report;
                 state
-                    .record_outcome(
-                        report.outcome(),
-                        report.diagnostic.docs.total,
-                        report.diagnostic.docs.errors,
-                    )
+                    .record_outcome(report.outcome(), report.diagnostic.docs.errors)
                     .await;
 
                 let response = diagnostic_result_entries(&completed.state);

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -5,7 +5,7 @@
 use super::{ApiKeyRequest, ServerState, UploadServiceRequest};
 use crate::{
     data::{KnownHostBuilder, Uri},
-    processor::{Completed, IncludedDiagnosticOutcome, Processor, new_job_id},
+    processor::{Completed, DiagnosticOutcome, Processor, new_job_id},
     receiver::Receiver,
 };
 use axum::{
@@ -440,6 +440,7 @@ fn diagnostic_result_entries(completed: &Completed) -> Value {
     let report = &completed.report;
     let mut entries = vec![json!({
         "status": "success",
+        "outcome": report.outcome().as_str(),
         "diagnostic_id": report.diagnostic.metadata.id,
         "kibana_link": report.diagnostic.kibana_link.as_deref().unwrap_or(""),
         "took": runtime_millis(completed.runtime),
@@ -447,39 +448,36 @@ fn diagnostic_result_entries(completed: &Completed) -> Value {
         "source": "parent"
     })];
 
-    for outcome in &completed.included_diagnostics {
-        match outcome {
-            IncludedDiagnosticOutcome::Completed {
-                path, report, runtime, ..
-            } => entries.push(json!({
+    for child in &completed.included_diagnostics {
+        // Children carry the unified DiagnosticOutcome (ADR-0016)
+        let entry = match (&child.outcome, &child.report) {
+            (DiagnosticOutcome::Skipped(_), _) => json!({
+                "status": "info",
+                "outcome": child.outcome.as_str(),
+                "product": crate::processor::display_label(child.application, child.platform),
+                "source": "included_diagnostic",
+                "path": child.path,
+                "reason": child.reason.as_deref().unwrap_or_default()
+            }),
+            (_, Some(report)) => json!({
                 "status": "success",
+                "outcome": child.outcome.as_str(),
                 "diagnostic_id": report.diagnostic.metadata.id,
                 "kibana_link": report.diagnostic.kibana_link.as_deref().unwrap_or(""),
-                "took": runtime_millis(*runtime),
+                "took": runtime_millis(child.runtime.unwrap_or_default()),
                 "product": report.diagnostic.display_label(),
                 "source": "included_diagnostic",
-                "path": path
-            })),
-            IncludedDiagnosticOutcome::Skipped {
-                path,
-                application,
-                platform,
-                reason,
-                ..
-            } => entries.push(json!({
-                "status": "info",
-                "product": crate::processor::display_label(*application, *platform),
-                "source": "included_diagnostic",
-                "path": path,
-                "reason": reason
-            })),
-            IncludedDiagnosticOutcome::Failed { path, error, .. } => entries.push(json!({
+                "path": child.path
+            }),
+            (_, None) => json!({
                 "status": "failed",
+                "outcome": child.outcome.as_str(),
                 "source": "included_diagnostic",
-                "path": path,
-                "error": error
-            })),
-        }
+                "path": child.path,
+                "error": child.reason.as_deref().unwrap_or_default()
+            }),
+        };
+        entries.push(entry);
     }
 
     Value::Array(entries)
@@ -494,7 +492,10 @@ mod tests {
     use super::{diagnostic_result_entries, runtime_millis};
     use crate::{
         data::{Application, Platform, Product},
-        processor::{Completed, DiagnosticManifest, IncludedDiagnosticOutcome, diagnostic::DiagnosticReportBuilder},
+        processor::{
+            Completed, DiagnosticManifest, DiagnosticOutcome, IncludedDiagnosticOutcome, SkipKind,
+            diagnostic::DiagnosticReportBuilder,
+        },
     };
 
     fn report(product: Product, id_type: &str) -> crate::processor::DiagnosticReport {
@@ -524,23 +525,35 @@ mod tests {
             report: report(Product::ECK, "eck-diagnostics"),
             runtime: 1_000,
             included_diagnostics: vec![
-                IncludedDiagnosticOutcome::Completed {
+                IncludedDiagnosticOutcome {
                     job_id: 11,
                     path: "child-es".to_string(),
-                    report: Box::new(child_report),
-                    runtime: 500,
+                    outcome: child_report.outcome(),
+                    application: child_report.diagnostic.application,
+                    platform: child_report.diagnostic.platform(),
+                    report: Some(Box::new(child_report)),
+                    reason: None,
+                    runtime: Some(500),
                 },
-                IncludedDiagnosticOutcome::Skipped {
+                IncludedDiagnosticOutcome {
                     job_id: 12,
                     path: "child-kibana".to_string(),
+                    outcome: DiagnosticOutcome::Skipped(SkipKind::NotImplemented),
+                    report: None,
                     application: Some(Application::Kibana),
                     platform: Platform::ECK,
-                    reason: "Kibana processing is not yet implemented".to_string(),
+                    reason: Some("Kibana processing is not yet implemented".to_string()),
+                    runtime: None,
                 },
-                IncludedDiagnosticOutcome::Failed {
+                IncludedDiagnosticOutcome {
                     job_id: 13,
                     path: "child-missing".to_string(),
-                    error: "manifest missing".to_string(),
+                    outcome: DiagnosticOutcome::Failed,
+                    report: None,
+                    application: None,
+                    platform: Platform::Unknown,
+                    reason: Some("manifest missing".to_string()),
+                    runtime: None,
                 },
             ],
         };

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -470,8 +470,9 @@ fn diagnostic_result_entries(completed: &Completed) -> Value {
                 "path": child.path
             }),
             (_, None) => json!({
-                "status": "failed",
+                "status": status_for_outcome(&child.outcome),
                 "outcome": child.outcome.to_string(),
+                "product": crate::processor::display_label(child.application, child.platform),
                 "source": "included_diagnostic",
                 "path": child.path,
                 "error": child.reason.as_deref().unwrap_or_default()

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -545,6 +545,7 @@ async fn run_processor_job(ctx: ProcessorJobContext<'_>) -> Result<()> {
                         source: job.source,
                         kibana_link: report.diagnostic.kibana_link.as_deref().unwrap_or(""),
                         product: &product,
+                        outcome: &report.outcome().to_string(),
                     },
                 ),
             )
@@ -598,6 +599,7 @@ async fn render_child_diagnostic_events(
             IncludedDiagnosticJobEvent::Completed {
                 job_id,
                 path,
+                outcome,
                 application,
                 platform,
                 diagnostic_id,
@@ -621,6 +623,7 @@ async fn render_child_diagnostic_events(
                             source: &source,
                             kibana_link: &kibana_link,
                             product: &product,
+                            outcome: &outcome.to_string(),
                         },
                     ),
                 )
@@ -629,6 +632,7 @@ async fn render_child_diagnostic_events(
             IncludedDiagnosticJobEvent::Skipped {
                 job_id,
                 path,
+                outcome: _,
                 application,
                 platform,
                 reason,

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -545,7 +545,7 @@ async fn run_processor_job(ctx: ProcessorJobContext<'_>) -> Result<()> {
                         source: job.source,
                         kibana_link: report.diagnostic.kibana_link.as_deref().unwrap_or(""),
                         product: &product,
-                        outcome: &report.outcome().to_string(),
+                        outcome: report.outcome().as_str(),
                     },
                 ),
             )
@@ -610,7 +610,6 @@ async fn render_child_diagnostic_events(
                 let source = child_source(&path);
                 let product = display_label(application, platform);
                 let duration = format!("{:.3}", duration_ms as f64 / 1000.0);
-                let outcome = outcome.to_string();
                 let kibana_link = kibana_link.unwrap_or_default();
                 send_event(
                     &tx,
@@ -624,7 +623,7 @@ async fn render_child_diagnostic_events(
                             source: &source,
                             kibana_link: &kibana_link,
                             product: &product,
-                            outcome: &outcome,
+                            outcome: outcome.as_str(),
                         },
                     ),
                 )

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -610,6 +610,7 @@ async fn render_child_diagnostic_events(
                 let source = child_source(&path);
                 let product = display_label(application, platform);
                 let duration = format!("{:.3}", duration_ms as f64 / 1000.0);
+                let outcome = outcome.to_string();
                 let kibana_link = kibana_link.unwrap_or_default();
                 send_event(
                     &tx,
@@ -623,7 +624,7 @@ async fn render_child_diagnostic_events(
                             source: &source,
                             kibana_link: &kibana_link,
                             product: &product,
-                            outcome: &outcome.to_string(),
+                            outcome: &outcome,
                         },
                     ),
                 )
@@ -632,13 +633,14 @@ async fn render_child_diagnostic_events(
             IncludedDiagnosticJobEvent::Skipped {
                 job_id,
                 path,
-                outcome: _,
+                outcome,
                 application,
                 platform,
                 reason,
             } => {
                 let source = child_source(&path);
                 let product = display_label(application, platform);
+                let reason = skipped_child_reason(&reason, &outcome);
                 send_event(
                     &tx,
                     replace_job_event(
@@ -674,6 +676,10 @@ async fn render_child_diagnostic_events(
 
 fn child_source(path: &str) -> String {
     format!("Included diagnostic: {path}")
+}
+
+fn skipped_child_reason(reason: &str, outcome: &crate::processor::DiagnosticOutcome) -> String {
+    format!("{reason} ({outcome})")
 }
 
 fn explicit_process_selection(signals: &JobRunSignals) -> Result<Option<ProcessSelection>> {
@@ -1147,12 +1153,13 @@ async fn cleanup_local_path(path: &Path) {
 #[allow(clippy::await_holding_lock)]
 mod tests {
     use super::{
-        download_service_link_to_path, run_job, select_processed_exporter, validate_job_request,
+        download_service_link_to_path, run_job, select_processed_exporter, skipped_child_reason, validate_job_request,
         validate_local_send_uri, validate_remote_send_uri,
     };
     use crate::{
         data::{HostRole, KnownHostBuilder, Product, Uri},
         exporter::Exporter,
+        processor::{DiagnosticOutcome, SkipKind},
         server::{
             CollectSource, JobInput, JobRequest, JobRunSignals, ProcessMode, RetainedBundle, RuntimeMode, SendMode,
             ServerEvent, ServerPolicy, ServerState, Stats,
@@ -1410,6 +1417,19 @@ mod tests {
 
         let uri = Uri::try_from(host).expect("known-host uri");
         assert!(validate_remote_send_uri(&uri).is_err());
+    }
+
+    #[test]
+    fn skipped_child_reason_includes_skip_kind() {
+        let reason = skipped_child_reason(
+            "Kibana processing is not yet implemented",
+            &DiagnosticOutcome::Skipped(SkipKind::NotImplemented),
+        );
+
+        assert_eq!(
+            reason,
+            "Kibana processing is not yet implemented (skipped (not implemented))"
+        );
     }
 
     #[tokio::test]

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -530,7 +530,7 @@ async fn run_processor_job(ctx: ProcessorJobContext<'_>) -> Result<()> {
             let report = &completed.state.report;
             let outcome = report.outcome();
             state
-                .record_success(report.diagnostic.docs.total, report.diagnostic.docs.errors)
+                .record_outcome(outcome, report.diagnostic.docs.total, report.diagnostic.docs.errors)
                 .await;
             let product = report.diagnostic.display_label();
             send_event(

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -529,9 +529,7 @@ async fn run_processor_job(ctx: ProcessorJobContext<'_>) -> Result<()> {
         Ok(completed) => {
             let report = &completed.state.report;
             let outcome = report.outcome();
-            state
-                .record_outcome(outcome, report.diagnostic.docs.total, report.diagnostic.docs.errors)
-                .await;
+            state.record_outcome(outcome, report.diagnostic.docs.errors).await;
             let product = report.diagnostic.display_label();
             send_event(
                 tx,

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -10,7 +10,7 @@ use crate::{
     data::{HostRole, Product, Uri},
     exporter::Exporter,
     processor::{
-        Collector, Identifiers, IncludedDiagnosticJobEvent, Processor,
+        Collector, DiagnosticOutcome, Identifiers, IncludedDiagnosticJobEvent, Processor, SkipKind,
         api::{ApiResolver, ProcessSelection},
         display_label, new_job_id,
     },
@@ -528,6 +528,7 @@ async fn run_processor_job(ctx: ProcessorJobContext<'_>) -> Result<()> {
     match processor.process().await {
         Ok(completed) => {
             let report = &completed.state.report;
+            let outcome = report.outcome();
             state
                 .record_success(report.diagnostic.docs.total, report.diagnostic.docs.errors)
                 .await;
@@ -539,13 +540,15 @@ async fn run_processor_job(ctx: ProcessorJobContext<'_>) -> Result<()> {
                     job.id,
                     template::JobCompleted {
                         job_id: job.id,
+                        status_class: completed_status_class(&outcome),
+                        heading: completed_heading(&outcome),
                         diagnostic_id: &report.diagnostic.metadata.id,
                         docs_created: &report.diagnostic.docs.created,
                         duration: &format!("{:.3}", report.diagnostic.processing_duration as f64 / 1000.0),
                         source: job.source,
                         kibana_link: report.diagnostic.kibana_link.as_deref().unwrap_or(""),
                         product: &product,
-                        outcome: report.outcome().as_str(),
+                        outcome: outcome.as_str(),
                     },
                 ),
             )
@@ -617,6 +620,8 @@ async fn render_child_diagnostic_events(
                         job_id,
                         template::JobCompleted {
                             job_id,
+                            status_class: completed_status_class(&outcome),
+                            heading: completed_heading(&outcome),
                             diagnostic_id: &diagnostic_id,
                             docs_created: &docs_created,
                             duration: &duration,
@@ -677,8 +682,28 @@ fn child_source(path: &str) -> String {
     format!("Included diagnostic: {path}")
 }
 
-fn skipped_child_reason(reason: &str, outcome: &crate::processor::DiagnosticOutcome) -> String {
-    format!("{reason} ({outcome})")
+fn completed_status_class(outcome: &DiagnosticOutcome) -> &'static str {
+    match outcome {
+        DiagnosticOutcome::Failed => "status-error",
+        DiagnosticOutcome::Partial => "status-info",
+        DiagnosticOutcome::Complete | DiagnosticOutcome::Skipped(_) => "status-success",
+    }
+}
+
+fn completed_heading(outcome: &DiagnosticOutcome) -> &'static str {
+    match outcome {
+        DiagnosticOutcome::Failed => "❌ Processing failed",
+        DiagnosticOutcome::Partial => "⚠️ Processing partially complete",
+        DiagnosticOutcome::Complete | DiagnosticOutcome::Skipped(_) => "✅ Processing complete!",
+    }
+}
+
+fn skipped_child_reason(reason: &str, outcome: &DiagnosticOutcome) -> String {
+    match outcome.skip_kind() {
+        Some(SkipKind::ByDesign) => format!("{reason} (by design)"),
+        Some(SkipKind::NotImplemented) => format!("{reason} (not implemented)"),
+        None => reason.to_string(),
+    }
 }
 
 fn explicit_process_selection(signals: &JobRunSignals) -> Result<Option<ProcessSelection>> {
@@ -1152,8 +1177,8 @@ async fn cleanup_local_path(path: &Path) {
 #[allow(clippy::await_holding_lock)]
 mod tests {
     use super::{
-        download_service_link_to_path, run_job, select_processed_exporter, skipped_child_reason, validate_job_request,
-        validate_local_send_uri, validate_remote_send_uri,
+        completed_heading, completed_status_class, download_service_link_to_path, run_job, select_processed_exporter,
+        skipped_child_reason, validate_job_request, validate_local_send_uri, validate_remote_send_uri,
     };
     use crate::{
         data::{HostRole, KnownHostBuilder, Product, Uri},
@@ -1425,10 +1450,23 @@ mod tests {
             &DiagnosticOutcome::Skipped(SkipKind::NotImplemented),
         );
 
+        assert_eq!(reason, "Kibana processing is not yet implemented (not implemented)");
+    }
+
+    #[test]
+    fn completed_status_metadata_tracks_outcome() {
+        assert_eq!(completed_status_class(&DiagnosticOutcome::Complete), "status-success");
         assert_eq!(
-            reason,
-            "Kibana processing is not yet implemented (skipped (not implemented))"
+            completed_heading(&DiagnosticOutcome::Complete),
+            "✅ Processing complete!"
         );
+        assert_eq!(completed_status_class(&DiagnosticOutcome::Partial), "status-info");
+        assert_eq!(
+            completed_heading(&DiagnosticOutcome::Partial),
+            "⚠️ Processing partially complete"
+        );
+        assert_eq!(completed_status_class(&DiagnosticOutcome::Failed), "status-error");
+        assert_eq!(completed_heading(&DiagnosticOutcome::Failed), "❌ Processing failed");
     }
 
     #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -23,7 +23,7 @@ mod stats;
 mod template;
 mod theme;
 
-use super::processor::Identifiers;
+use super::processor::{DiagnosticOutcome, Identifiers};
 use crate::{
     data::{KnownHost, Uri},
     exporter::Exporter,
@@ -600,6 +600,23 @@ impl ServerState {
         stats.docs.errors += errors as usize;
         stats.jobs.total += 1;
         stats.jobs.success += 1;
+        if stats.jobs.active > 0 {
+            stats.jobs.active -= 1;
+        }
+        drop(stats);
+        self.notify_stats_changed();
+    }
+
+    pub async fn record_outcome(&self, outcome: DiagnosticOutcome, _docs: u32, errors: u32) {
+        if outcome != DiagnosticOutcome::Failed {
+            self.record_success(_docs, errors).await;
+            return;
+        }
+
+        let mut stats = self.stats.write().await;
+        stats.docs.errors += errors as usize;
+        stats.jobs.total += 1;
+        stats.jobs.failed += 1;
         if stats.jobs.active > 0 {
             stats.jobs.active -= 1;
         }
@@ -1434,6 +1451,7 @@ mod tests {
         SecretAuth, authenticate, create_keystore, resolve_secret_auth, upsert_secret_auth, write_unlock_lease,
     };
     use crate::exporter::Exporter;
+    use crate::processor::DiagnosticOutcome;
     use axum::http::HeaderMap;
     use futures::StreamExt;
     #[cfg(feature = "keystore")]
@@ -1464,6 +1482,19 @@ mod tests {
             stats_updates_tx,
             stats_updates_rx,
         }
+    }
+
+    #[tokio::test]
+    async fn record_outcome_counts_failed_outcome_as_failed_job() {
+        let state = test_state(RuntimeMode::User);
+
+        state.record_outcome(DiagnosticOutcome::Failed, 10, 2).await;
+
+        let stats = state.stats.read().await;
+        assert_eq!(stats.jobs.total, 1);
+        assert_eq!(stats.jobs.success, 0);
+        assert_eq!(stats.jobs.failed, 1);
+        assert_eq!(stats.docs.errors, 2);
     }
 
     struct WebFeaturesEnvGuard {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -607,9 +607,9 @@ impl ServerState {
         self.notify_stats_changed();
     }
 
-    pub async fn record_outcome(&self, outcome: DiagnosticOutcome, _docs: u32, errors: u32) {
+    pub async fn record_outcome(&self, outcome: DiagnosticOutcome, errors: u32) {
         if outcome != DiagnosticOutcome::Failed {
-            self.record_success(_docs, errors).await;
+            self.record_success(0, errors).await;
             return;
         }
 
@@ -1488,7 +1488,7 @@ mod tests {
     async fn record_outcome_counts_failed_outcome_as_failed_job() {
         let state = test_state(RuntimeMode::User);
 
-        state.record_outcome(DiagnosticOutcome::Failed, 10, 2).await;
+        state.record_outcome(DiagnosticOutcome::Failed, 2).await;
 
         let stats = state.stats.read().await;
         assert_eq!(stats.jobs.total, 1);

--- a/src/server/template.rs
+++ b/src/server/template.rs
@@ -276,6 +276,8 @@ pub struct HostsPage {
 #[template(path = "job/completed.html")]
 pub struct JobCompleted<'a> {
     pub job_id: u64,
+    pub status_class: &'a str,
+    pub heading: &'a str,
     pub diagnostic_id: &'a str,
     pub docs_created: &'a u32,
     pub duration: &'a str,
@@ -569,6 +571,8 @@ mod tests {
         let docs_created = 42;
         let completed = JobCompleted {
             job_id: 100,
+            status_class: "status-success",
+            heading: "Processing complete!",
             diagnostic_id: "elasticsearch_diagnostic@2026-01-01~abcd",
             docs_created: &docs_created,
             duration: "0.500",
@@ -583,9 +587,13 @@ mod tests {
         assert!(completed.contains("elasticsearch_diagnostic@2026-01-01~abcd"));
         assert!(completed.contains("https://kb.example/app/dashboards#/view/child"));
         assert!(completed.contains("Included diagnostic: child-es"));
+        assert!(completed.contains("status-success"));
+        assert!(completed.contains("Processing complete!"));
 
         let no_link = JobCompleted {
             job_id: 102,
+            status_class: "status-success",
+            heading: "Processing complete!",
             diagnostic_id: "elasticsearch_diagnostic@2026-01-01~efgh",
             docs_created: &docs_created,
             duration: "0.500",

--- a/src/server/template.rs
+++ b/src/server/template.rs
@@ -282,6 +282,8 @@ pub struct JobCompleted<'a> {
     pub source: &'a str,
     pub kibana_link: &'a str,
     pub product: &'a str,
+    /// The derived diagnostic outcome (ADR-0016), e.g. `complete`/`partial`.
+    pub outcome: &'a str,
 }
 
 #[derive(Template)]
@@ -573,6 +575,7 @@ mod tests {
             source: "Included diagnostic: child-es",
             kibana_link: "https://kb.example/app/dashboards#/view/child",
             product: "Elasticsearch",
+            outcome: "complete",
         }
         .render()
         .expect("completed template renders");
@@ -589,6 +592,7 @@ mod tests {
             source: "Included diagnostic: child-es",
             kibana_link: "",
             product: "Elasticsearch",
+            outcome: "complete",
         }
         .render()
         .expect("completed template without Kibana link renders");

--- a/templates/job/completed.html
+++ b/templates/job/completed.html
@@ -1,5 +1,5 @@
-<div id="job-{{ job_id }}" class="status-box history-item status-success">
-    ✅ Processing complete!
+<div id="job-{{ job_id }}" class="status-box history-item {{ status_class }}">
+    {{ heading }}
     <p>
         <b>Diagnostic ID:</b>
         {% if kibana_link != "" %}

--- a/templates/job/completed.html
+++ b/templates/job/completed.html
@@ -10,5 +10,6 @@
     </p>
     <p><b>Source:</b> {{ source }}</p>
     <p><b>Product:</b> {{ product }}</p>
+    <p><b>Outcome:</b> {{ outcome }}</p>
     <p><b>Ingested:</b> {{ docs_created }} documents in {{ duration }} seconds</p>
 </div>


### PR DESCRIPTION
Implements openspec change **`diagnostic-outcome-reporting`** (ADR-0016, skip semantics per ADR-0019). Part 4 of the 9-change architecture-review series from #347; **based on `feat/unified-job-model`** (change 3).

## What's here

- `DiagnosticOutcome` (`Complete | Partial | Failed | Skipped`) derived from the report's recorded events — never set imperatively. `Skipped` distinguishes by-design from not-implemented.
- The report records **all** error/warning/success events (source + reason): `ProcessorSummary::merge(Err)`/`add_child(Err)` record failure events instead of warn-and-drop; collection failures persist via the manifest's per-request record.
- Two-level export status: the per-doc `status_counts` histogram is authoritative; mixed HTTP request codes keep the most severe code instead of collapsing to `0`; `0` is reserved for non-HTTP exporters, with a `599` sentinel for HTTP requests that never completed.
- `IncludedDiagnosticOutcome` unifies on `DiagnosticOutcome`: a child can be `Partial`, its verdict derives from its own report, skips carry their kind. Job feed, synchronous API entries, and CLI summaries render the unified outcome; the CLI `process` exit code reads it.

## Intended behavior change

Failures that were previously invisible now surface: fixture-based child diagnostics honestly derive `Partial` (missing selected sources become recorded events), and a `Failed` report fails the `process` command. This is the design's called-out "silent-behavior change".

🤖 Generated with [Claude Code](https://claude.com/claude-code)