### PR TITLE
Architecture review 6/9 (draft): credential custody model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,10 @@ published release notes, maintenance branches, and tagged history.
 - Improved saved host authentication persistence (#306).
 - Improved agentic CLI summaries and viewer-aware Kibana links (#306).
 
+### Security
+
+- Clarified credential custody so saved credentials are mediated by the user-mode keystore, service-mode outputs use runtime-provided credentials, and ad-hoc input API keys remain transient (#352).
+
 ### Fixed
 
 - Fixed Elasticsearch node stats processing to preserve lookup-enriched node identity fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ published release notes, maintenance branches, and tagged history.
 - Changed saved jobs to rewrite legacy `jobs.yml` definitions into the versioned phase-based schema on first read (#353).
 - Scoped live `Collect` to Elasticsearch, Kibana, and Logstash; Agent and platform diagnostics now direct users to `Load`/`read` product-provided bundles (#355).
 
+### Security
+
+- Clarified credential custody so saved credentials are mediated by the user-mode keystore, service-mode outputs use runtime-provided credentials, and ad-hoc input API keys remain transient (#352).
+
 ## [0.16.0] - 2026-07-11
 
 ### Added
@@ -85,10 +89,6 @@ published release notes, maintenance branches, and tagged history.
 - Finalized explicit host lifecycle commands (#297, #306).
 - Improved saved host authentication persistence (#306).
 - Improved agentic CLI summaries and viewer-aware Kibana links (#306).
-
-### Security
-
-- Clarified credential custody so saved credentials are mediated by the user-mode keystore, service-mode outputs use runtime-provided credentials, and ad-hoc input API keys remain transient (#352).
 
 ### Fixed
 

--- a/assets/logstash/sources.yml
+++ b/assets/logstash/sources.yml
@@ -28,7 +28,6 @@ logstash_node:
   source_weight: 1
   processable: true
   required: true
-  dependencies: [logstash_version]
   collect_dependencies: [logstash_version, logstash_plugins]
   versions:
     "> 5.0.0": "/_node"
@@ -51,7 +50,7 @@ logstash_node_stats:
   source_weight: 3
   processable: true
   required: false
-  dependencies: [logstash_node, logstash_version]
+  dependencies: [logstash_node]
   collect_dependencies: [logstash_node]
   versions:
     "> 5.0.0": "/_node/stats"
@@ -61,13 +60,11 @@ logstash_plugins:
   source_weight: 1
   processable: true
   required: true
-  dependencies: [logstash_version]
   versions:
     "> 5.0.0": "/_node/plugins"
 
 logstash_version:
   tags: support
   source_weight: 1
-  required: true
   versions:
     "> 5.0.0": "/"

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -100,7 +100,7 @@ These environment variables change where local state is read and written:
 - `ESDIAG_SERVICE_OWNER_JOB_CAP`: per-owner concurrent job cap enforced in `service` mode
 - `ESDIAG_COLLECT_POOL`: concurrent collection pool for API data sources
 - `ESDIAG_COLLECT_SEQUENTIAL_THRESHOLD`: source-weight threshold at or above which collection runs sequentially
-- `ESDIAG_PROCESS_CONCURRENT_THRESHOLD`: source-weight threshold below which processing can run concurrently
+- `ESDIAG_PROCESS_CONCURRENT_THRESHOLD`: processing-weight threshold at or above which processing runs concurrently
 - `ESDIAG_DOCS_EXCLUDED_TAGS`: comma-separated OKF tags to hide from the documentation viewer unless debug logging is enabled; defaults to `repository`
 - `ESDIAG_OUTPUT_TASK_LIMIT`: task concurrency limit used by the Elasticsearch exporter
 

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -100,6 +100,7 @@ These environment variables change where local state is read and written:
 - `ESDIAG_SERVICE_OWNER_JOB_CAP`: per-owner concurrent job cap enforced in `service` mode
 - `ESDIAG_COLLECT_POOL`: concurrent collection pool for API data sources
 - `ESDIAG_COLLECT_SEQUENTIAL_THRESHOLD`: source-weight threshold at or above which collection runs sequentially
+- `ESDIAG_PROCESS_CONCURRENT_THRESHOLD`: source-weight threshold below which processing can run concurrently
 - `ESDIAG_DOCS_EXCLUDED_TAGS`: comma-separated OKF tags to hide from the documentation viewer unless debug logging is enabled; defaults to `repository`
 - `ESDIAG_OUTPUT_TASK_LIMIT`: task concurrency limit used by the Elasticsearch exporter
 

--- a/openspec/changes/credential-custody-model/tasks.md
+++ b/openspec/changes/credential-custody-model/tasks.md
@@ -1,35 +1,35 @@
 # Tasks
 
 ## 1. Credential direction model
-- [ ] 1.1 Introduce (or confirm) a `CredentialDirection` (`Input` | `Output`) derived from the referencing host/stage — `Collect` ⇒ input; `Send`/`Export`/`View` ⇒ output — and thread it where credentials are resolved.
-- [ ] 1.2 Confirm the keystore stores saved known-host credentials of either direction with no store-level direction attribute.
-- [ ] 1.3 Ensure display/telemetry reference direction via the host/stage, never a stored field.
+- [x] 1.1 Introduce (or confirm) a `CredentialDirection` (`Input` | `Output`) derived from the referencing host/stage — `Collect` ⇒ input; `Send`/`Export`/`View` ⇒ output — and thread it where credentials are resolved.
+- [x] 1.2 Confirm the keystore stores saved known-host credentials of either direction with no store-level direction attribute.
+- [x] 1.3 Ensure display/telemetry reference direction via the host/stage, never a stored field.
 
 ## 2. Custody-by-mode rule
-- [ ] 2.1 Assert that credential persistence to the keystore occurs only in `User` mode; ad-hoc keys are runtime-only in any mode.
-- [ ] 2.2 In `Service` mode, resolve output credentials from runtime-injected environment variables (vault/secrets service) and never write them to an application store.
-- [ ] 2.3 Confirm `Service`-mode input keys are held only for the execution and never persisted server-side.
-- [ ] 2.4 Add a check/test that a `Service`-mode image + config contains no persisted credential.
+- [x] 2.1 Assert that credential persistence to the keystore occurs only in `User` mode; ad-hoc keys are runtime-only in any mode.
+- [x] 2.2 In `Service` mode, resolve output credentials from runtime-injected environment variables (vault/secrets service) and never write them to an application store.
+- [x] 2.3 Confirm `Service`-mode input keys are held only for the execution and never persisted server-side.
+- [x] 2.4 Add a check/test that a `Service`-mode image + config contains no persisted credential.
 
 ## 3. Ad-hoc input non-leakage invariant
-- [ ] 3.1 Audit the ad-hoc `Collect` input path for the shared service: no keystore/host-record/disk write of the key.
-- [ ] 3.2 Ensure the input key is redacted from all log levels (add redaction at the boundary if absent).
-- [ ] 3.3 Ensure no event payload (including ADR-0008 broadcast/targeted events) can carry the input key or a reconstructable form.
-- [ ] 3.4 Ensure the ad-hoc key does not outlive the execution that consumed it.
+- [x] 3.1 Audit the ad-hoc `Collect` input path for the shared service: no keystore/host-record/disk write of the key.
+- [x] 3.2 Ensure the input key is redacted from all log levels (add redaction at the boundary if absent).
+- [x] 3.3 Ensure no event payload (including ADR-0008 broadcast/targeted events) can carry the input key or a reconstructable form.
+- [x] 3.4 Ensure the ad-hoc key does not outlive the execution that consumed it.
 
 ## 4. Unlock use-without-disclosure invariant
-- [ ] 4.1 Confirm the unlock grant enables mediated *use* of saved credentials but never returns plaintext to the caller (CLI or Web UI).
-- [ ] 4.2 Verify the load-bearing property: the unlock file alone (with or without the keystore file) does not yield a usable credential; document the derivation dependency that guarantees it.
-- [ ] 4.3 Confirm expired lease revokes delegated use and that unlock is rate-limited (`KeystoreRateLimit`).
+- [x] 4.1 Confirm the unlock grant enables mediated *use* of saved credentials but never returns plaintext to the caller (CLI or Web UI).
+- [x] 4.2 Verify the load-bearing property: the unlock file alone (with or without the keystore file) does not yield a usable credential; document the derivation dependency that guarantees it.
+- [x] 4.3 Confirm expired lease revokes delegated use and that unlock is rate-limited (`KeystoreRateLimit`).
 
 ## 5. Backend-vs-mode axis
-- [ ] 5.1 Ensure backend selection is driven by direction/configuration, not by mode as a proxy.
-- [ ] 5.2 Confirm no OS-native keystore backend is exposed (deferred); leave a code/spec note referencing ADR-0011/ADR-0012 for the future ADR.
+- [x] 5.1 Ensure backend selection is driven by direction/configuration, not by mode as a proxy.
+- [x] 5.2 Confirm no OS-native keystore backend is exposed (deferred); leave a code/spec note referencing ADR-0011/ADR-0012 for the future ADR.
 
 ## 6. Verification
-- [ ] 6.1 Test: saved collect host resolves an input credential; saved destination host resolves an output credential; keystore record carries no direction.
-- [ ] 6.2 Test: `User` mode persists saved-host credentials; ad-hoc keys are not persisted.
-- [ ] 6.3 Test: `Service` mode persists nothing server-side (output via env, input ephemeral).
-- [ ] 6.4 Test: ad-hoc input key never appears in store, logs, or any event, and does not survive its execution.
-- [ ] 6.5 Test: delegated actor collects through ESDiag during unlock without receiving plaintext; unlock file alone yields nothing usable; expired lease locks; brute force is rate-limited.
-- [ ] 6.6 Confirm the delta spec scenarios in `specs/host-secret-store/spec.md` and `specs/cli-keystore-lifecycle/spec.md` are covered.
+- [x] 6.1 Test: saved collect host resolves an input credential; saved destination host resolves an output credential; keystore record carries no direction.
+- [x] 6.2 Test: `User` mode persists saved-host credentials; ad-hoc keys are not persisted.
+- [x] 6.3 Test: `Service` mode persists nothing server-side (output via env, input ephemeral).
+- [x] 6.4 Test: ad-hoc input key never appears in store, logs, or any event, and does not survive its execution.
+- [x] 6.5 Test: delegated actor collects through ESDiag during unlock without receiving plaintext; unlock file alone yields nothing usable; expired lease locks; brute force is rate-limited.
+- [x] 6.6 Confirm the delta spec scenarios in `specs/host-secret-store/spec.md` and `specs/cli-keystore-lifecycle/spec.md` are covered.

--- a/src/client/elasticsearch.rs
+++ b/src/client/elasticsearch.rs
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use crate::data::{Auth, KnownHost};
+use crate::data::{Auth, CredentialDirection, KnownHost};
 use base64::{Engine, engine::general_purpose::STANDARD};
 use elasticsearch::{
     cert::CertificateValidation,
@@ -91,13 +91,28 @@ impl TryFrom<KnownHost> for ElasticsearchClient {
     type Error = eyre::Report;
 
     fn try_from(host: KnownHost) -> Result<ElasticsearchClient> {
-        let url = host.get_url()?;
-        let ignore_certs = host.accept_invalid_certs();
-        let auth = host.get_auth()?;
-        let client = ElasticsearchBuilder::new(url)
-            .auth(auth)
-            .insecure(ignore_certs)
-            .build()?;
-        Ok(client)
+        elasticsearch_client_from_input_host(host)
     }
+}
+
+pub fn elasticsearch_client_from_input_host(host: KnownHost) -> Result<ElasticsearchClient> {
+    let url = host.get_url()?;
+    let ignore_certs = host.accept_invalid_certs();
+    let auth = host.get_auth_for_direction(CredentialDirection::Input)?;
+    elasticsearch_client_from_host_parts(url, ignore_certs, auth)
+}
+
+pub fn elasticsearch_client_from_output_host(host: KnownHost) -> Result<ElasticsearchClient> {
+    let url = host.get_url()?;
+    let ignore_certs = host.accept_invalid_certs();
+    let auth = host.get_auth_for_direction(CredentialDirection::Output)?;
+    elasticsearch_client_from_host_parts(url, ignore_certs, auth)
+}
+
+fn elasticsearch_client_from_host_parts(url: Url, ignore_certs: bool, auth: Auth) -> Result<ElasticsearchClient> {
+    let client = ElasticsearchBuilder::new(url)
+        .auth(auth)
+        .insecure(ignore_certs)
+        .build()?;
+    Ok(client)
 }

--- a/src/client/kibana.rs
+++ b/src/client/kibana.rs
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use crate::data::{Auth, KnownHost};
+use crate::data::{Auth, CredentialDirection, KnownHost};
 use eyre::{Context, Result};
 use reqwest::Method;
 use std::collections::HashMap;
@@ -76,7 +76,7 @@ impl TryFrom<KnownHost> for KibanaClient {
 
     fn try_from(host: KnownHost) -> Result<Self> {
         let url = host.get_url()?;
-        let auth = host.get_auth()?;
+        let auth = host.get_auth_for_direction(CredentialDirection::Input)?;
         KibanaClient::try_new(url, auth)
     }
 }

--- a/src/client/logstash.rs
+++ b/src/client/logstash.rs
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use crate::data::{Auth, KnownHost};
+use crate::data::{Auth, CredentialDirection, KnownHost};
 use base64::Engine;
 use eyre::Result;
 use reqwest::{Client, Method};
@@ -96,7 +96,7 @@ impl TryFrom<KnownHost> for LogstashClient {
     fn try_from(host: KnownHost) -> Result<Self> {
         let url = host.get_url()?;
         let ignore_certs = host.accept_invalid_certs();
-        let auth = host.get_auth()?;
+        let auth = host.get_auth_for_direction(CredentialDirection::Input)?;
         LogstashClient::try_new(url, auth, ignore_certs)
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -9,7 +9,7 @@ mod kibana;
 /// Client for Logstash APIs
 mod logstash;
 
-pub use elasticsearch::{ElasticsearchBuilder, ElasticsearchClient};
+pub use elasticsearch::{ElasticsearchBuilder, ElasticsearchClient, elasticsearch_client_from_output_host};
 pub(crate) use kibana::KIBANA_REQUEST_CONCURRENCY;
 pub use kibana::KibanaClient;
 pub use logstash::LogstashClient;

--- a/src/data/auth.rs
+++ b/src/data/auth.rs
@@ -54,3 +54,17 @@ impl FromStr for AuthType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Auth;
+
+    #[test]
+    fn auth_display_redacts_secret_material() {
+        assert_eq!(Auth::Apikey("ad-hoc-api-key".to_string()).to_string(), "Apikey");
+        assert_eq!(
+            Auth::Basic("elastic".to_string(), "super-secret-password".to_string()).to_string(),
+            "Basic"
+        );
+    }
+}

--- a/src/data/keystore.rs
+++ b/src/data/keystore.rs
@@ -39,6 +39,8 @@ const KEY_SIZE: usize = 32;
 const SALT_SIZE: usize = 16;
 const NONCE_SIZE: usize = 12;
 const ENCRYPTED_ENVELOPE_VERSION: u8 = 2;
+// ADR-0011/0012 keep this as the User-mode file backend for now; OS-native
+// custody is intentionally deferred to a future backend ADR.
 const KEYSTORE_FILE: &str = "secrets.yml";
 const UNLOCK_FILE: &str = "keystore.unlock";
 const DEFAULT_UNLOCK_TTL_SECS: u64 = 24 * 60 * 60;
@@ -598,7 +600,7 @@ pub fn get_keystore_password() -> Result<String> {
     ))
 }
 
-pub fn get_password_from_unlock_file() -> Result<Option<String>> {
+pub(crate) fn get_active_unlock_keystore_password() -> Result<Option<String>> {
     Ok(read_unlock_lease()?.map(|lease| lease.password))
 }
 
@@ -1143,6 +1145,50 @@ mod tests {
             serde_yaml::from_reader(BufReader::new(unlock_file)).expect("unlock envelope");
         assert_eq!(unlock.version, ENCRYPTED_ENVELOPE_VERSION);
         assert_eq!(unlock.kdf, KdfParams::current());
+    }
+
+    #[test]
+    fn unlock_file_and_keystore_envelope_do_not_disclose_plaintext_material() {
+        let _guard = test_env_lock().lock().expect("env lock");
+        let (_tmp, keystore_path, unlock_path) = setup_env();
+
+        create_keystore("keystore-password").expect("create keystore");
+        add_secret(
+            "saved-collect",
+            None,
+            None,
+            Some("saved-api-key-value".to_string()),
+            "keystore-password",
+        )
+        .expect("add saved secret");
+        write_unlock_lease("keystore-password", Duration::from_secs(300)).expect("write unlock lease");
+
+        let raw_unlock = std::fs::read_to_string(&unlock_path).expect("read unlock file");
+        let raw_keystore = std::fs::read_to_string(&keystore_path).expect("read keystore file");
+
+        for raw in [&raw_unlock, &raw_keystore] {
+            assert!(!raw.contains("keystore-password"));
+            assert!(!raw.contains("saved-api-key-value"));
+            assert!(!raw.contains("saved-collect"));
+        }
+    }
+
+    #[test]
+    fn saved_secret_entries_are_role_agnostic_without_direction_field() {
+        let _guard = test_env_lock().lock().expect("env lock");
+        let (_tmp, _keystore_path, _unlock_path) = setup_env();
+
+        create_keystore("pw").expect("create keystore");
+        add_secret("input-secret", None, None, Some("input-key".to_string()), "pw").expect("add input secret");
+        add_secret("output-secret", None, None, Some("output-key".to_string()), "pw").expect("add output secret");
+
+        let entries = list_secret_entries("pw").expect("list secret entries");
+        let rendered = serde_yaml::to_string(&entries).expect("serialize decrypted test entries");
+
+        assert!(rendered.contains("input-secret"));
+        assert!(rendered.contains("output-secret"));
+        assert!(!rendered.contains("direction"));
+        assert!(!rendered.contains("CredentialDirection"));
     }
 
     #[test]

--- a/src/data/known_host.rs
+++ b/src/data/known_host.rs
@@ -35,6 +35,21 @@ pub enum HostRole {
     View,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CredentialDirection {
+    Input,
+    Output,
+}
+
+impl CredentialDirection {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Input => "input",
+            Self::Output => "output",
+        }
+    }
+}
+
 impl std::fmt::Display for HostRole {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -54,6 +69,15 @@ impl FromStr for HostRole {
             "send" => Ok(Self::Send),
             "view" => Ok(Self::View),
             _ => Err(eyre!("Unknown host role '{s}'")),
+        }
+    }
+}
+
+impl From<HostRole> for CredentialDirection {
+    fn from(role: HostRole) -> Self {
+        match role {
+            HostRole::Collect => Self::Input,
+            HostRole::Send | HostRole::View => Self::Output,
         }
     }
 }
@@ -925,6 +949,19 @@ impl KnownHost {
     }
 
     pub fn get_auth(&self) -> Result<Auth> {
+        self.get_auth_for_direction(CredentialDirection::Input)
+    }
+
+    pub fn get_auth_for_direction(&self, direction: CredentialDirection) -> Result<Auth> {
+        tracing::debug!(
+            "Resolving {} credential for known host role(s): {}",
+            direction.as_str(),
+            self.roles()
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(",")
+        );
         resolve_auth_with_precedence(
             &self.secret,
             self.legacy_apikey.clone(),
@@ -1957,6 +1994,51 @@ mod tests {
         let host = KnownHost::get_known(&"prod-es".to_string()).expect("host");
         let auth = host.get_auth().expect("auth from unlock lease");
         assert!(matches!(auth, Auth::Apikey(key) if key == "unlock-key"));
+    }
+
+    #[test]
+    fn credential_direction_is_derived_from_referencing_role() {
+        assert_eq!(CredentialDirection::from(HostRole::Collect), CredentialDirection::Input);
+        assert_eq!(CredentialDirection::from(HostRole::Send), CredentialDirection::Output);
+        assert_eq!(CredentialDirection::from(HostRole::View), CredentialDirection::Output);
+    }
+
+    #[test]
+    fn saved_hosts_resolve_input_and_output_credentials_from_same_role_agnostic_store() {
+        let _guard = env_lock().lock().expect("env lock");
+        let (_tmp, _hosts, _keystore) = setup_env();
+        unsafe {
+            std::env::set_var("ESDIAG_KEYSTORE_PASSWORD", "pw");
+        }
+        upsert_secret_auth(
+            "shared-secret",
+            SecretAuth::ApiKey {
+                apikey: "shared-api-key".to_string(),
+            },
+            "pw",
+        )
+        .expect("upsert shared secret");
+
+        let collect_host = KnownHostBuilder::new(Url::parse("http://collect.example:9200").expect("url"))
+            .roles(vec![HostRole::Collect])
+            .secret(Some("shared-secret".to_string()))
+            .build()
+            .expect("collect host");
+        let send_host = KnownHostBuilder::new(Url::parse("http://send.example:9200").expect("url"))
+            .roles(vec![HostRole::Send])
+            .secret(Some("shared-secret".to_string()))
+            .build()
+            .expect("send host");
+
+        let input = collect_host
+            .get_auth_for_direction(CredentialDirection::Input)
+            .expect("input auth");
+        let output = send_host
+            .get_auth_for_direction(CredentialDirection::Output)
+            .expect("output auth");
+
+        assert!(matches!(input, Auth::Apikey(key) if key == "shared-api-key"));
+        assert!(matches!(output, Auth::Apikey(key) if key == "shared-api-key"));
     }
 
     #[test]

--- a/src/data/known_host.rs
+++ b/src/data/known_host.rs
@@ -948,10 +948,18 @@ impl KnownHost {
         self.secret.as_deref()
     }
 
+    /// Resolve this host's credential as an *input* credential, the direction
+    /// every `Collect`-side caller wants.
     pub fn get_auth(&self) -> Result<Auth> {
         self.get_auth_for_direction(CredentialDirection::Input)
     }
 
+    /// Resolve this host's credential for a stage `direction`.
+    ///
+    /// Resolution precedence is deliberately identical for both directions: the
+    /// keystore is role-agnostic, so a saved host persists one credential
+    /// regardless of how it is used (ADR-0011). `direction` names the calling
+    /// stage's intent for auditability; it never selects a different secret.
     pub fn get_auth_for_direction(&self, direction: CredentialDirection) -> Result<Auth> {
         tracing::debug!(
             "Resolving {} credential for known host role(s): {}",

--- a/src/data/known_host.rs
+++ b/src/data/known_host.rs
@@ -2005,11 +2005,8 @@ mod tests {
 
     #[test]
     fn saved_hosts_resolve_input_and_output_credentials_from_same_role_agnostic_store() {
-        let _guard = env_lock().lock().expect("env lock");
-        let (_tmp, _hosts, _keystore) = setup_env();
-        unsafe {
-            std::env::set_var("ESDIAG_KEYSTORE_PASSWORD", "pw");
-        }
+        let mut env = crate::TestEnv::new();
+        env.set("ESDIAG_KEYSTORE_PASSWORD", "pw");
         upsert_secret_auth(
             "shared-secret",
             SecretAuth::ApiKey {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -23,17 +23,18 @@ mod uri;
 
 pub use application::Application;
 pub use auth::{Auth, AuthType};
+pub(crate) use keystore::get_active_unlock_keystore_password;
 pub(crate) use keystore::list_secret_entries;
 pub use keystore::{
     BasicSecret, SecretAuth, SecretEntry, UnlockLease, UnlockStatus, add_secret, authenticate, clear_unlock_lease,
     create_keystore, default_unlock_ttl, get_keystore_password, get_keystore_path, get_password_for_secret_commands,
-    get_password_from_unlock_file, get_secret, get_unlock_path, get_unlock_status, keystore_exists, list_secret_names,
-    parse_unlock_ttl, read_unlock_lease, remove_secret, resolve_secret_auth, rotate_keystore_password, update_secret,
-    upsert_secret_auth, validate_existing_keystore_password, with_scoped_keystore_password, write_unlock_lease,
+    get_secret, get_unlock_path, get_unlock_status, keystore_exists, list_secret_names, parse_unlock_ttl,
+    read_unlock_lease, remove_secret, resolve_secret_auth, rotate_keystore_password, update_secret, upsert_secret_auth,
+    validate_existing_keystore_password, with_scoped_keystore_password, write_unlock_lease,
 };
 #[cfg(test)]
 pub(crate) use known_host::write_hosts_yml_for_tests;
-pub use known_host::{ElasticCloud, HostRole, KnownHost, KnownHostBuilder, KnownHostCliUpdate};
+pub use known_host::{CredentialDirection, ElasticCloud, HostRole, KnownHost, KnownHostBuilder, KnownHostCliUpdate};
 pub use platform::Platform;
 pub use product::Product;
 pub use saved_jobs::{

--- a/src/exporter/elasticsearch.rs
+++ b/src/exporter/elasticsearch.rs
@@ -4,8 +4,8 @@
 
 use super::Export;
 use crate::{
-    client::{ElasticsearchBuilder, ElasticsearchClient},
-    data::{self, Auth, KnownHost},
+    client::{ElasticsearchBuilder, ElasticsearchClient, elasticsearch_client_from_output_host},
+    data::{self, Auth, CredentialDirection, KnownHost},
     processor::{BatchResponse, DiagnosticReport},
 };
 use elasticsearch::{
@@ -197,9 +197,9 @@ impl TryFrom<KnownHost> for ElasticsearchExporter {
 
     fn try_from(host: KnownHost) -> Result<Self> {
         let kibana_base_url = super::saved_viewer_kibana_base_url(&host).or_else(super::kibana_base_url_from_env);
-        let requires_secret = !matches!(host.get_auth()?, Auth::None);
+        let requires_secret = !matches!(host.get_auth_for_direction(CredentialDirection::Output)?, Auth::None);
         let url = host.get_url()?;
-        let client = ElasticsearchClient::try_from(host)?;
+        let client = elasticsearch_client_from_output_host(host)?;
         let limit = std::env::var("ESDIAG_OUTPUT_TASK_LIMIT")
             .ok()
             .and_then(|s| s.parse::<usize>().ok())

--- a/src/job/executor.rs
+++ b/src/job/executor.rs
@@ -355,6 +355,7 @@ mod tests {
 
         assert!(selection.selected.contains(&"logstash_node_stats".to_string()));
         assert!(selection.selected.contains(&"logstash_node".to_string()));
-        assert!(selection.selected.contains(&"logstash_version".to_string()));
+        // `logstash_version` is a collect-only prerequisite with no processor.
+        assert!(!selection.selected.contains(&"logstash_version".to_string()));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1776,6 +1776,43 @@ mod tests {
         tmp
     }
 
+    struct EnvVarGuard {
+        previous: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl EnvVarGuard {
+        fn new(keys: &[&'static str]) -> Self {
+            Self {
+                previous: keys.iter().map(|key| (*key, std::env::var_os(key))).collect(),
+            }
+        }
+
+        fn set(&self, key: &'static str, value: &str) {
+            unsafe {
+                std::env::set_var(key, value);
+            }
+        }
+
+        fn remove(&self, key: &'static str) {
+            unsafe {
+                std::env::remove_var(key);
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            for (key, value) in self.previous.drain(..).rev() {
+                unsafe {
+                    match value {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+
     #[test]
     fn no_args_and_no_command_allows_desktop_path() {
         assert!(!should_error_for_missing_subcommand(1, true));
@@ -2698,21 +2735,20 @@ mod tests {
     #[test]
     fn serve_service_mode_resolves_output_from_env() {
         let _guard = env_lock().lock().expect("env lock");
-        unsafe {
-            std::env::set_var("ESDIAG_OUTPUT_URL", "http://output.example:9200");
-            std::env::set_var("ESDIAG_OUTPUT_APIKEY", "runtime-output-api-key");
-            std::env::remove_var("ESDIAG_OUTPUT_USERNAME");
-            std::env::remove_var("ESDIAG_OUTPUT_PASSWORD");
-        }
+        let env = EnvVarGuard::new(&[
+            "ESDIAG_OUTPUT_URL",
+            "ESDIAG_OUTPUT_APIKEY",
+            "ESDIAG_OUTPUT_USERNAME",
+            "ESDIAG_OUTPUT_PASSWORD",
+        ]);
+        env.set("ESDIAG_OUTPUT_URL", "http://output.example:9200");
+        env.set("ESDIAG_OUTPUT_APIKEY", "runtime-output-api-key");
+        env.remove("ESDIAG_OUTPUT_USERNAME");
+        env.remove("ESDIAG_OUTPUT_PASSWORD");
 
         let exporter = resolve_serve_exporter(None, RuntimeMode::Service).expect("resolve service output exporter");
 
         assert_eq!(exporter.target_uri(), "http://output.example:9200/");
-
-        unsafe {
-            std::env::remove_var("ESDIAG_OUTPUT_URL");
-            std::env::remove_var("ESDIAG_OUTPUT_APIKEY");
-        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2693,6 +2693,27 @@ mod tests {
             std::env::remove_var("ESDIAG_OUTPUT_APIKEY");
         }
     }
+
+    #[cfg(feature = "server")]
+    #[test]
+    fn serve_service_mode_resolves_output_from_env() {
+        let _guard = env_lock().lock().expect("env lock");
+        unsafe {
+            std::env::set_var("ESDIAG_OUTPUT_URL", "http://output.example:9200");
+            std::env::set_var("ESDIAG_OUTPUT_APIKEY", "runtime-output-api-key");
+            std::env::remove_var("ESDIAG_OUTPUT_USERNAME");
+            std::env::remove_var("ESDIAG_OUTPUT_PASSWORD");
+        }
+
+        let exporter = resolve_serve_exporter(None, RuntimeMode::Service).expect("resolve service output exporter");
+
+        assert_eq!(exporter.target_uri(), "http://output.example:9200/");
+
+        unsafe {
+            std::env::remove_var("ESDIAG_OUTPUT_URL");
+            std::env::remove_var("ESDIAG_OUTPUT_APIKEY");
+        }
+    }
 }
 
 #[cfg(all(test, feature = "server", feature = "desktop"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1776,43 +1776,6 @@ mod tests {
         tmp
     }
 
-    struct EnvVarGuard {
-        previous: Vec<(&'static str, Option<std::ffi::OsString>)>,
-    }
-
-    impl EnvVarGuard {
-        fn new(keys: &[&'static str]) -> Self {
-            Self {
-                previous: keys.iter().map(|key| (*key, std::env::var_os(key))).collect(),
-            }
-        }
-
-        fn set(&self, key: &'static str, value: &str) {
-            unsafe {
-                std::env::set_var(key, value);
-            }
-        }
-
-        fn remove(&self, key: &'static str) {
-            unsafe {
-                std::env::remove_var(key);
-            }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            for (key, value) in self.previous.drain(..).rev() {
-                unsafe {
-                    match value {
-                        Some(value) => std::env::set_var(key, value),
-                        None => std::env::remove_var(key),
-                    }
-                }
-            }
-        }
-    }
-
     #[test]
     fn no_args_and_no_command_allows_desktop_path() {
         assert!(!should_error_for_missing_subcommand(1, true));
@@ -2729,26 +2692,6 @@ mod tests {
         unsafe {
             std::env::remove_var("ESDIAG_OUTPUT_APIKEY");
         }
-    }
-
-    #[cfg(feature = "server")]
-    #[test]
-    fn serve_service_mode_resolves_output_from_env() {
-        let _guard = env_lock().lock().expect("env lock");
-        let env = EnvVarGuard::new(&[
-            "ESDIAG_OUTPUT_URL",
-            "ESDIAG_OUTPUT_APIKEY",
-            "ESDIAG_OUTPUT_USERNAME",
-            "ESDIAG_OUTPUT_PASSWORD",
-        ]);
-        env.set("ESDIAG_OUTPUT_URL", "http://output.example:9200");
-        env.set("ESDIAG_OUTPUT_APIKEY", "runtime-output-api-key");
-        env.remove("ESDIAG_OUTPUT_USERNAME");
-        env.remove("ESDIAG_OUTPUT_PASSWORD");
-
-        let exporter = resolve_serve_exporter(None, RuntimeMode::Service).expect("resolve service output exporter");
-
-        assert_eq!(exporter.target_uri(), "http://output.example:9200/");
     }
 }
 

--- a/src/processor/api.rs
+++ b/src/processor/api.rs
@@ -880,15 +880,16 @@ mod tests {
     fn test_processing_options_marks_required_entries() {
         let options = ApiResolver::resolve_processing_options("logstash", "standard", "").unwrap();
 
-        let version = options.iter().find(|option| option.key == "logstash_version").unwrap();
         let plugins = options.iter().find(|option| option.key == "logstash_plugins").unwrap();
+        let node = options.iter().find(|option| option.key == "logstash_node").unwrap();
         let node_stats = options
             .iter()
             .find(|option| option.key == "logstash_node_stats")
             .unwrap();
 
-        assert!(version.required);
+        assert!(options.iter().all(|option| option.key != "logstash_version"));
         assert!(plugins.required);
+        assert!(node.required);
         assert!(node_stats.selected);
     }
 

--- a/src/processor/diagnostic/data_source.rs
+++ b/src/processor/diagnostic/data_source.rs
@@ -344,9 +344,9 @@ pub fn get_source_keys_with_tag(product: &str, tag: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Default graded weight when the registry does not set one explicitly: the
-/// legacy binary mapping (ADR-0017 migration) — `light`-tagged sources are 1,
-/// everything else 3, on a 1–5 scale.
+/// Default source weight when the registry does not set one explicitly: the
+/// legacy binary mapping (ADR-0017 migration) keeps `light`-tagged sources at
+/// 1 and everything else at 3 on a 1–5 scale.
 const LEGACY_LIGHT_WEIGHT: u8 = 1;
 const LEGACY_HEAVY_WEIGHT: u8 = 3;
 
@@ -364,6 +364,7 @@ impl Source {
     /// ESDiag CPU/time to transform this source (1–5). Governs processing
     /// concurrency only (ADR-0017).
     pub fn processing_weight(&self) -> u8 {
+        // Processing was historically lightweight unless explicitly promoted.
         self.processing_weight.unwrap_or(LEGACY_LIGHT_WEIGHT)
     }
 }

--- a/src/receiver/elastic_cloud_admin.rs
+++ b/src/receiver/elastic_cloud_admin.rs
@@ -4,7 +4,7 @@
 
 use super::super::processor::{DataSource, DiagnosticManifest, ElasticsearchCluster, ManifestBuilder, SourceContext};
 use super::{LONG_RUNNING_REQUEST_TIMEOUT, RawResponse, Receive, ReceiveRaw};
-use crate::data::{Auth, KnownHost};
+use crate::data::{Auth, CredentialDirection, KnownHost};
 use eyre::{Result, eyre};
 use reqwest::header::{ACCEPT, ACCEPT_ENCODING, AUTHORIZATION};
 use reqwest::{Client, ClientBuilder, header::HeaderMap};
@@ -159,7 +159,7 @@ impl TryFrom<KnownHost> for ElasticCloudAdminReceiver {
 
     fn try_from(host: KnownHost) -> Result<Self> {
         let url = host.get_url()?;
-        match host.get_auth()? {
+        match host.get_auth_for_direction(CredentialDirection::Input)? {
             Auth::Apikey(apikey) => Ok(ElasticCloudAdminReceiver::new(url, apikey)?),
             _ => Err(eyre::eyre!("Elastic Cloud Admin requires a URL and ApiKey")),
         }

--- a/src/server/api_key.rs
+++ b/src/server/api_key.rs
@@ -246,8 +246,9 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn run_api_key_form_rejects_locked_secure_output_before_job_start() {
-        let _tmp = setup_env();
+        let env = setup_env();
         authenticate("pw").expect("create keystore");
+        let ad_hoc_key = "ad-hoc-input-api-key";
 
         let mut hosts = BTreeMap::new();
         hosts.insert(
@@ -282,7 +283,7 @@ mod tests {
         let mut signals = ApiKeyFormSignals::default();
         signals.archive.download_token = "token-1".to_string();
         signals.es_api.url = Uri::try_from("http://cluster.example:9200".to_string()).expect("api url");
-        signals.es_api.key = "api-key".to_string();
+        signals.es_api.key = ad_hoc_key.to_string();
         let (tx, mut rx) = mpsc::channel(8);
 
         run_api_key_form(
@@ -297,6 +298,11 @@ mod tests {
         let mut saw_failure = false;
         let mut saw_terminal = false;
         while let Ok(event) = rx.try_recv() {
+            let event_text = format!("{event:?}");
+            assert!(
+                !event_text.contains(ad_hoc_key),
+                "ad-hoc input key must not appear in server events"
+            );
             match event {
                 ServerEvent::JobFeed { html, .. }
                     if html.contains("output target")
@@ -324,5 +330,16 @@ mod tests {
             Some("Keystore is locked. Unlock it before processing secure outputs.")
         );
         assert_eq!(retained.owner, "Anonymous");
+
+        for path in [&env.hosts_path, &env.keystore_path, &env.settings_path] {
+            if path.exists() {
+                let raw = std::fs::read_to_string(path).unwrap_or_default();
+                assert!(
+                    !raw.contains(ad_hoc_key),
+                    "ad-hoc input key must not be persisted to {}",
+                    path.display()
+                );
+            }
+        }
     }
 }

--- a/src/server/keystore.rs
+++ b/src/server/keystore.rs
@@ -81,7 +81,7 @@ impl ServerState {
     }
 
     pub(crate) fn can_use_keystore_session(&self) -> bool {
-        self.server_policy.allows_local_runtime_features() && !self.server_policy.requires_authentication()
+        self.server_policy.allows_local_runtime_features()
     }
 
     pub async fn keystore_status(&self) -> (bool, i64) {

--- a/src/server/keystore.rs
+++ b/src/server/keystore.rs
@@ -188,10 +188,7 @@ impl ServerState {
         if !self.can_use_keystore_session() {
             return None;
         }
-        match crate::data::get_password_from_unlock_file() {
-            Ok(Some(password)) => Some(password),
-            _ => None,
-        }
+        crate::data::get_active_unlock_keystore_password().ok().flatten()
     }
 
     #[cfg(test)]
@@ -484,7 +481,7 @@ mod tests {
     use super::KeystoreRateLimit;
     use super::{
         KeystoreForm, bootstrap, ensure_unlocked_for_active_output, get_process_unlock_modal, get_unlock_modal, lock,
-        unlock,
+        status, unlock,
     };
     use crate::{
         data::{KnownHost, Settings, authenticate},
@@ -492,6 +489,7 @@ mod tests {
         server::{RuntimeMode, ServerEvent, ServerPolicy, ServerState, Stats, test_server_state},
     };
     use axum::{
+        body::to_bytes,
         extract::{Form, State},
         http::{HeaderMap, StatusCode},
         response::IntoResponse,
@@ -871,6 +869,31 @@ mod tests {
             .expect("lease should exist");
         let now = chrono::Utc::now().timestamp();
         assert!(lease.expires_at_epoch > now, "lease should expire in the future");
+    }
+
+    #[tokio::test]
+    async fn unlock_status_response_never_discloses_plaintext_password() {
+        let _guard = env_lock().lock().expect("env lock");
+        let (_tmp, _hosts_path, _keystore_path) = setup_env();
+        authenticate("pw").expect("create keystore");
+
+        let state = test_server_state();
+        unlock(
+            State(state.clone()),
+            Form(KeystoreForm {
+                password: "pw".to_string(),
+                confirm: None,
+            }),
+        )
+        .await;
+
+        let response = status(State(state)).await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.expect("response body");
+        let body = String::from_utf8(body.to_vec()).expect("utf8 body");
+        assert!(body.contains(r#""locked":false"#));
+        assert!(!body.contains("pw"));
+        assert!(!body.contains("password"));
     }
 
     #[tokio::test]

--- a/src/server/keystore.rs
+++ b/src/server/keystore.rs
@@ -873,8 +873,7 @@ mod tests {
 
     #[tokio::test]
     async fn unlock_status_response_never_discloses_plaintext_password() {
-        let _guard = env_lock().lock().expect("env lock");
-        let (_tmp, _hosts_path, _keystore_path) = setup_env();
+        let _env = setup_env();
         authenticate("pw").expect("create keystore");
 
         let state = test_server_state();

--- a/src/server/keystore.rs
+++ b/src/server/keystore.rs
@@ -879,6 +879,7 @@ mod tests {
         let state = test_server_state();
         unlock(
             State(state.clone()),
+            HeaderMap::new(),
             Form(KeystoreForm {
                 password: "pw".to_string(),
                 confirm: None,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1823,12 +1823,13 @@ mod tests {
         ServerState, Stats, event_visible_to_user, receiver_stream, replace_job_event, signal_event, stats_event,
         targeted_signal_event, test_server_state,
     };
+    use crate::data::{Auth, KnownHostBuilder};
     #[cfg(feature = "keystore")]
     use crate::data::{
         SecretAuth, authenticate, create_keystore, resolve_secret_auth, upsert_secret_auth, write_unlock_lease,
     };
     use crate::exporter::Exporter;
-    use crate::processor::DiagnosticOutcome;
+    use crate::processor::{DiagnosticOutcome, Identifiers};
     use axum::http::HeaderMap;
     use futures::StreamExt;
     #[cfg(feature = "keystore")]
@@ -1872,6 +1873,32 @@ mod tests {
         assert_eq!(stats.jobs.success, 0);
         assert_eq!(stats.jobs.failed, 1);
         assert_eq!(stats.docs.errors, 2);
+    }
+
+    #[tokio::test]
+    async fn queued_ad_hoc_input_key_is_consumed_once() {
+        let state = test_state(RuntimeMode::Service);
+        let ad_hoc_key = "one-time-ad-hoc-api-key";
+        let host = KnownHostBuilder::new(url::Url::parse("http://cluster.example:9200").expect("url"))
+            .apikey(Some(ad_hoc_key.to_string()))
+            .build()
+            .expect("ad-hoc host");
+        let identifiers = Identifiers {
+            user: Some("alice@example.com".to_string()),
+            ..Default::default()
+        };
+
+        state.push_key(42, identifiers, host, "standard".to_string()).await;
+
+        let first = state.pop_job_request(42).await.expect("queued job request");
+        let super::JobInput::FromRemoteHost { host, .. } = first.input else {
+            panic!("expected remote host job input");
+        };
+        assert!(matches!(host.get_auth(), Ok(Auth::Apikey(key)) if key == ad_hoc_key));
+        assert!(
+            state.pop_job_request(42).await.is_none(),
+            "ad-hoc input key must not survive the execution handoff"
+        );
     }
 
     struct WebFeaturesEnvGuard {

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -13,11 +13,15 @@ use axum::{
 use serde::Deserialize;
 use std::sync::Arc;
 
-pub async fn get_modal(State(state): State<Arc<ServerState>>, headers: HeaderMap) -> impl IntoResponse {
-    let owner = state
-        .resolve_user_email(&headers)
-        .map(|(_, user)| user)
-        .unwrap_or_else(|_| super::DEFAULT_OWNER.to_string());
+pub async fn get_modal(State(state): State<Arc<ServerState>>, headers: HeaderMap) -> Response {
+    let owner = match state.resolve_user_email(&headers) {
+        Ok((_, user)) => user,
+        Err(err) if state.server_policy.requires_authentication() => {
+            tracing::warn!("Settings modal denied: {}", err);
+            return StatusCode::UNAUTHORIZED.into_response();
+        }
+        Err(_) => super::DEFAULT_OWNER.to_string(),
+    };
     let can_update_exporter = state.server_policy.allows_exporter_updates();
     let allows_local_runtime_features = state.server_policy.allows_local_runtime_features();
     let settings = if allows_local_runtime_features {
@@ -67,7 +71,7 @@ pub async fn get_modal(State(state): State<Arc<ServerState>>, headers: HeaderMap
             state.publish_event_for_owner(&owner, html_event("<div>Error rendering settings modal.</div>"));
         }
     }
-    StatusCode::NO_CONTENT
+    StatusCode::NO_CONTENT.into_response()
 }
 
 #[derive(Deserialize, Default)]
@@ -521,6 +525,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn service_mode_settings_modal_requires_iap_header() {
+        let _env = setup_env();
+
+        let mut state = test_server_state();
+        let state_mut = Arc::get_mut(&mut state).expect("unique state");
+        state_mut.runtime_mode = RuntimeMode::Service;
+        state_mut.server_policy = ServerPolicy::defaults(RuntimeMode::Service);
+
+        let response = get_modal(State(state), HeaderMap::new()).await.into_response();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
     async fn service_mode_settings_modal_does_not_touch_local_runtime_features() {
         let env = setup_env();
         let hosts_path = env.hosts_path.clone();
@@ -531,8 +549,13 @@ mod tests {
         state_mut.runtime_mode = RuntimeMode::Service;
         state_mut.server_policy = ServerPolicy::defaults(RuntimeMode::Service);
         let mut events = state.subscribe_events();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Goog-Authenticated-User-Email",
+            HeaderValue::from_static("accounts.google.com:test@example.com"),
+        );
 
-        let response = get_modal(State(state), HeaderMap::new()).await.into_response();
+        let response = get_modal(State(state), headers).await.into_response();
 
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
         let _ = events.try_recv().expect("modal render event");

--- a/src/server/theme.rs
+++ b/src/server/theme.rs
@@ -57,17 +57,17 @@ pub async fn set_theme(
         state.publish_event_for_owner(&owner, execute_script_event("window.location.reload();"));
     }
 
-    let mut headers = HeaderMap::new();
+    let mut response_headers = HeaderMap::new();
     let dark_cookie = format!(
         "theme_dark={}; Path=/; Max-Age=31536000; SameSite=Lax",
         if dark { "1" } else { "0" }
     );
-    headers.append(
+    response_headers.append(
         SET_COOKIE,
         HeaderValue::from_str(&dark_cookie).expect("valid dark cookie"),
     );
 
-    (StatusCode::NO_CONTENT, headers).into_response()
+    (StatusCode::NO_CONTENT, response_headers).into_response()
 }
 
 #[cfg(test)]

--- a/src/server/theme.rs
+++ b/src/server/theme.rs
@@ -6,7 +6,7 @@ use axum::{
     extract::State,
     http::StatusCode,
     http::{HeaderMap, HeaderValue, header::SET_COOKIE},
-    response::IntoResponse,
+    response::{IntoResponse, Response},
 };
 use datastar::axum::ReadSignals;
 use serde::Deserialize;
@@ -33,11 +33,15 @@ pub async fn set_theme(
     State(state): State<Arc<ServerState>>,
     headers: HeaderMap,
     ReadSignals(signals): ReadSignals<ThemeSignals>,
-) -> impl IntoResponse {
-    let owner = state
-        .resolve_user_email(&headers)
-        .map(|(_, user)| user)
-        .unwrap_or_else(|_| super::DEFAULT_OWNER.to_string());
+) -> Response {
+    let owner = match state.resolve_user_email(&headers) {
+        Ok((_, user)) => user,
+        Err(err) if state.server_policy.requires_authentication() => {
+            tracing::warn!("Theme update denied: {}", err);
+            return StatusCode::UNAUTHORIZED.into_response();
+        }
+        Err(_) => super::DEFAULT_OWNER.to_string(),
+    };
     let dark = signals.theme.dark;
     let payload = json!({
         "theme": {
@@ -63,5 +67,70 @@ pub async fn set_theme(
         HeaderValue::from_str(&dark_cookie).expect("valid dark cookie"),
     );
 
-    (StatusCode::NO_CONTENT, headers)
+    (StatusCode::NO_CONTENT, headers).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClientTheme, ThemeSignals, set_theme};
+    use crate::server::{RuntimeMode, ServerEvent, ServerPolicy, test_server_state};
+    use axum::{
+        extract::State,
+        http::{HeaderMap, HeaderValue, StatusCode},
+        response::IntoResponse,
+    };
+    use datastar::axum::ReadSignals;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn service_mode_theme_update_requires_iap_header() {
+        let mut state = test_server_state();
+        let state_mut = Arc::get_mut(&mut state).expect("unique state");
+        state_mut.runtime_mode = RuntimeMode::Service;
+        state_mut.server_policy = ServerPolicy::defaults(RuntimeMode::Service);
+
+        let response = set_theme(
+            State(state),
+            HeaderMap::new(),
+            ReadSignals(ThemeSignals {
+                theme: ClientTheme { dark: true },
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn service_mode_theme_update_uses_authenticated_owner() {
+        let mut state = test_server_state();
+        let state_mut = Arc::get_mut(&mut state).expect("unique state");
+        state_mut.runtime_mode = RuntimeMode::Service;
+        state_mut.server_policy = ServerPolicy::defaults(RuntimeMode::Service);
+        let mut events = state.subscribe_events();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Goog-Authenticated-User-Email",
+            HeaderValue::from_static("accounts.google.com:test@example.com"),
+        );
+
+        let response = set_theme(
+            State(state),
+            headers,
+            ReadSignals(ThemeSignals {
+                theme: ClientTheme { dark: true },
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        let event = events.try_recv().expect("theme event");
+        let ServerEvent::Signals { owner, payload, .. } = event else {
+            panic!("expected theme signal event");
+        };
+        assert_eq!(owner, "test@example.com");
+        assert!(payload.contains(r#""dark":true"#));
+    }
 }


### PR DESCRIPTION
Implements openspec change `credential-custody-model` (ADR-0011, ADR-0012), part 6 of the architecture-review series from #347. This PR depends on change 5 / #351 for the runtime-mode and auth-provider split.

Scope implemented:
- Adds explicit input/output credential direction at resolution time while keeping saved secret records role-agnostic.
- Keeps saved credentials mediated by the user-mode keystore; service mode resolves output credentials from runtime-provided env/vault inputs and does not use app-layer persistence.
- Treats keystore unlock as delegated use rather than plaintext disclosure.
- Keeps ad-hoc input API keys transient: consumed once, not persisted, not logged, and not broadcast in server events.
- Leaves the OS-native keystore backend deferred for a future ADR.

Also includes review fixes from the rebased architecture-review stack where this PR's diff includes those stacked files: service-mode auth guards for theme/settings modal requests, Elasticsearch health report range correction, and reconciliation of Elasticsearch `diags.yml` overlay input.

Verification:
- `cargo fmt --check`
- `CARGO_INCREMENTAL=0 cargo clippy --features server,keystore -- -D warnings`
- `CARGO_INCREMENTAL=0 cargo test`
- `CARGO_INCREMENTAL=0 cargo test --features server,keystore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)