### PR TITLE
Architecture review 7/9 (draft): saved-job migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ published release notes, maintenance branches, and tagged history.
 - Changed `process` to return a non-zero exit when the derived diagnostic outcome is failed (#350).
 - Changed synchronous API results to include a derived `outcome` field and align failed statuses with failed report outcomes (#350).
 - Changed service-mode web authentication, event delivery, and job admission to use a pluggable auth provider, owner-scoped UI events, and service job caps (#351).
+- Changed saved jobs to rewrite legacy `jobs.yml` definitions into the versioned phase-based schema on first read (#353).
 
 ## [0.16.0] - 2026-07-11
 

--- a/openspec/changes/saved-job-migration/tasks.md
+++ b/openspec/changes/saved-job-migration/tasks.md
@@ -1,32 +1,32 @@
 # Tasks
 
 ## 1. Versioned schema
-- [ ] 1.1 Add a `schema_version` field to the persisted `jobs.yml` document (map wrapper), with the current schema version constant.
-- [ ] 1.2 Serialize `schema_version` on every write in `save_saved_jobs` / the rewrite path.
-- [ ] 1.3 Define the load-time dispatch: absent `schema_version` ⇒ v1 legacy; current version ⇒ direct deserialize. No shape-sniffing.
+- [x] 1.1 Add a `schema_version` field to the persisted `jobs.yml` document (map wrapper), with the current schema version constant.
+- [x] 1.2 Serialize `schema_version` on every write in `save_saved_jobs` / the rewrite path.
+- [x] 1.3 Define the load-time dispatch: absent `schema_version` ⇒ v1 legacy; current version ⇒ direct deserialize. No shape-sniffing.
 
 ## 2. Legacy shape + closed mapping
-- [ ] 2.1 Retain the legacy `Job { collect, action }` types as `LegacyJob` (deserialize-only) so v1 files parse.
-- [ ] 2.2 Implement a closed, total `From<LegacyJob>` for the phase-based `Job` (ADR-0004): `input` always `Collect`.
-- [ ] 2.3 Map `action: Collect { output_dir }` → `save: Some(output_dir)`.
-- [ ] 2.4 Map `action: Upload { upload_id }` → `save: Some(dir)`, `send: Some(upload_id)`.
-- [ ] 2.5 Map `action: Process { output, selection }` → `save: save_dir?`, `process: Some { selection, export: output }`; no `save_dir` ⇒ streaming (no `Save`).
-- [ ] 2.6 Carry `JobProcessSelection` through unchanged; leave the `Product` → `Application` mapping to the platform/application split (out of scope here).
+- [x] 2.1 Retain the legacy `Job { collect, action }` types as `LegacyJob` (deserialize-only) so v1 files parse.
+- [x] 2.2 Implement a closed, total `From<LegacyJob>` for the phase-based `Job` (ADR-0004): `input` always `Collect`.
+- [x] 2.3 Map `action: Collect { output_dir }` → `save: Some(output_dir)`.
+- [x] 2.4 Map `action: Upload { upload_id }` → `save: Some(dir)`, `send: Some(upload_id)`.
+- [x] 2.5 Map `action: Process { output, selection }` → `save: save_dir?`, `process: Some { selection, export: output }`; no `save_dir` ⇒ streaming (no `Save`).
+- [x] 2.6 Carry `JobProcessSelection` through unchanged; leave the `Product` → `Application` mapping to the platform/application split (out of scope here).
 
 ## 3. Rewrite-on-first-read
-- [ ] 3.1 In `load_saved_jobs` (and `load_saved_jobs_async`), when the file is v1, migrate all entries and set the flag to rewrite.
-- [ ] 3.2 If any entry was legacy, rewrite the whole file in the new shape reusing `write_yaml_atomic` / `replace_file_atomic` / `secure_output_file`.
-- [ ] 3.3 Ensure the rewrite is idempotent: a second load of the rewritten file deserializes directly with no migration or rewrite.
-- [ ] 3.4 Preserve the existing `saved_jobs_io_lock` guarantees so the read-then-rewrite is serialized.
+- [x] 3.1 In `load_saved_jobs` (and `load_saved_jobs_async`), when the file is v1, migrate all entries and set the flag to rewrite.
+- [x] 3.2 If any entry was legacy, rewrite the whole file in the new shape reusing `write_yaml_atomic` / `replace_file_atomic` / `secure_output_file`.
+- [x] 3.3 Ensure the rewrite is idempotent: a second load of the rewritten file deserializes directly with no migration or rewrite.
+- [x] 3.4 Preserve the existing `saved_jobs_io_lock` guarantees so the read-then-rewrite is serialized.
 
 ## 4. Scope guards
-- [ ] 4.1 Confirm the migration is invoked only for `jobs.yml`; do NOT apply it to bundles/manifests (received artifacts use read tolerance, ADR-0010).
-- [ ] 4.2 Do NOT introduce `owner` into the saved schema (ADR-0008 — execution-level only).
+- [x] 4.1 Confirm the migration is invoked only for `jobs.yml`; do NOT apply it to bundles/manifests (received artifacts use read tolerance, ADR-0010).
+- [x] 4.2 Do NOT introduce `owner` into the saved schema (ADR-0008 — execution-level only).
 
 ## 5. Verification
-- [ ] 5.1 Unit test: v1 file with each legacy `action` migrates to the expected phase-based `Job` (Collect / Upload / Process staged).
-- [ ] 5.2 Unit test: legacy `Process` without `save_dir` migrates to a streaming job (no `Save`).
-- [ ] 5.3 Unit test: loading a v1 file rewrites it once with `schema_version` set; a second load performs no rewrite (idempotent).
-- [ ] 5.4 Unit test: a current-version file loads directly with no migration.
-- [ ] 5.5 Test that a crash-safe atomic rewrite leaves the original intact on write failure (or assert reuse of the atomic helpers).
-- [ ] 5.6 Confirm the delta spec scenarios in `specs/saved-jobs/spec.md` are covered.
+- [x] 5.1 Unit test: v1 file with each legacy `action` migrates to the expected phase-based `Job` (Collect / Upload / Process staged).
+- [x] 5.2 Unit test: legacy `Process` without `save_dir` migrates to a streaming job (no `Save`).
+- [x] 5.3 Unit test: loading a v1 file rewrites it once with `schema_version` set; a second load performs no rewrite (idempotent).
+- [x] 5.4 Unit test: a current-version file loads directly with no migration.
+- [x] 5.5 Test that a crash-safe atomic rewrite leaves the original intact on write failure (or assert reuse of the atomic helpers).
+- [x] 5.6 Confirm the delta spec scenarios in `specs/saved-jobs/spec.md` are covered.

--- a/src/data/keystore.rs
+++ b/src/data/keystore.rs
@@ -291,7 +291,7 @@ fn replace_file_atomic(path: &Path, temp_path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn write_yaml_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+pub(crate) fn write_yaml_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
     let temp_path = temp_output_path(path)?;
     let write_result = (|| -> Result<()> {
         let file = secure_output_file(&temp_path)?;
@@ -919,9 +919,8 @@ fn derive_key(password: &str, salt: &[u8], params: &KdfParams) -> Result<[u8; KE
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::data::{
-        HostRole, Job, JobAction, JobCollect, JobOutput, KnownHostBuilder, Product, SavedJobs, save_saved_jobs,
-    };
+    use crate::data::{HostRole, Job, JobOutput, KnownHostBuilder, Product, SavedJobs, save_saved_jobs};
+    use crate::job::model::{Input, Process, SaveTarget, SendTarget};
     use crate::test_env_lock;
     use tempfile::TempDir;
     use url::Url;
@@ -1230,6 +1229,15 @@ ciphertext: ""
         host.save(host_name).expect("save host");
     }
 
+    fn collect_input(host: &str) -> Input {
+        Input::Collect {
+            host: host.to_string(),
+            diagnostic_type: "standard".to_string(),
+            include: None,
+            exclude: None,
+        }
+    }
+
     #[test]
     fn remove_secret_blocks_direct_host_reference() {
         let _guard = test_env_lock().lock().expect("env lock");
@@ -1271,20 +1279,19 @@ ciphertext: ""
         let mut jobs = SavedJobs::default();
         jobs.insert(
             "nightly-prod".to_string(),
-            Job {
-                identifiers: Default::default(),
-                collect: JobCollect {
-                    host: "prod".to_string(),
-                    diagnostic_type: "standard".to_string(),
-                    save_dir: None,
-                },
-                action: JobAction::Process {
-                    output: JobOutput::KnownHost {
+            Job::try_new(
+                Default::default(),
+                collect_input("prod"),
+                None,
+                Some(Process {
+                    selection: None,
+                    export: JobOutput::KnownHost {
                         name: "prod".to_string(),
                     },
-                    selection: None,
-                },
-            },
+                }),
+                None,
+            )
+            .expect("valid job"),
         );
         save_saved_jobs(&jobs).expect("save jobs");
 
@@ -1316,37 +1323,35 @@ ciphertext: ""
 
     #[test]
     fn referenced_job_hosts_only_uses_active_send_mode_targets() {
-        let job = Job {
-            identifiers: Default::default(),
-            collect: JobCollect {
-                host: "collector".to_string(),
-                diagnostic_type: "standard".to_string(),
-                save_dir: None,
-            },
-            action: JobAction::Process {
-                output: JobOutput::KnownHost {
+        let job = Job::try_new(
+            Default::default(),
+            collect_input("collector"),
+            None,
+            Some(Process {
+                selection: None,
+                export: JobOutput::KnownHost {
                     name: "sender".to_string(),
                 },
-                selection: None,
-            },
-        };
+            }),
+            None,
+        )
+        .expect("valid job");
 
         assert_eq!(referenced_job_hosts(&job), vec!["collector", "sender"]);
     }
 
     #[test]
     fn referenced_job_hosts_ignores_remote_urls() {
-        let job = Job {
-            identifiers: Default::default(),
-            collect: JobCollect {
-                host: "collector".to_string(),
-                diagnostic_type: "standard".to_string(),
-                save_dir: None,
-            },
-            action: JobAction::Upload {
+        let job = Job::try_new(
+            Default::default(),
+            collect_input("collector"),
+            Some(SaveTarget::temporary()),
+            None,
+            Some(SendTarget {
                 upload_id: "https://upload.elastic.co/g/abc123".to_string(),
-            },
-        };
+            }),
+        )
+        .expect("valid job");
 
         assert_eq!(referenced_job_hosts(&job), vec!["collector"]);
     }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -37,9 +37,9 @@ pub use known_host::{ElasticCloud, HostRole, KnownHost, KnownHostBuilder, KnownH
 pub use platform::Platform;
 pub use product::Product;
 pub use saved_jobs::{
-    CollectMode, CollectSource, Job, JobAction, JobBuilder, JobCollect, JobOutput, JobProcessSelection, JobSignals,
-    JobSignalsCollect, JobSignalsProcess, JobSignalsSend, NeedsAction, NeedsCollect, ProcessMode, SavedJobs, SendMode,
-    load_saved_jobs, load_saved_jobs_async, save_saved_jobs, with_saved_jobs_async,
+    CollectMode, CollectSource, Job, JobBuilder, JobOutput, JobProcessSelection, JobSignals, JobSignalsCollect,
+    JobSignalsProcess, JobSignalsSend, NeedsAction, NeedsCollect, ProcessMode, SavedJobs, SendMode, load_saved_jobs,
+    load_saved_jobs_async, save_saved_jobs, with_saved_jobs_async,
 };
 pub use settings::Settings;
 pub use uri::Uri;

--- a/src/data/saved_jobs.rs
+++ b/src/data/saved_jobs.rs
@@ -2,39 +2,65 @@ use eyre::{Result, eyre};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::{
-    fs::{self, File},
-    io::{BufWriter, Write},
+    fs,
     marker::PhantomData,
     path::{Path, PathBuf},
-    sync::OnceLock,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    sync::{Mutex, OnceLock},
 };
-use tokio::{sync::Mutex, task};
+use tokio::task;
 
 use super::{HostRole, KnownHost, Uri};
-use crate::processor::Identifiers;
+use crate::{
+    job::model::{Input, Process, SaveTarget, SendTarget},
+    processor::{
+        Identifiers,
+        api::{ApiResolver, ProcessSelection},
+    },
+};
 
-#[derive(Clone, Serialize, Deserialize)]
-pub struct Job {
+pub use crate::job::model::ExportTarget as JobOutput;
+pub use crate::job::model::Job;
+pub use crate::processor::api::ProcessSelection as JobProcessSelection;
+pub type SavedJobs = IndexMap<String, Job>;
+
+const CURRENT_SCHEMA_VERSION: u32 = 2;
+
+#[derive(Deserialize, Serialize)]
+struct SavedJobsDocument {
+    schema_version: u32,
+    jobs: SavedJobs,
+}
+
+impl SavedJobsDocument {
+    fn current(jobs: SavedJobs) -> Self {
+        Self {
+            schema_version: CURRENT_SCHEMA_VERSION,
+            jobs,
+        }
+    }
+}
+
+#[derive(Clone, Deserialize)]
+struct LegacyJob {
     #[serde(default, skip_serializing_if = "Identifiers::is_empty")]
-    pub identifiers: Identifiers,
-    pub collect: JobCollect,
+    identifiers: Identifiers,
+    collect: LegacyJobCollect,
     #[serde(flatten)]
-    pub action: JobAction,
+    action: LegacyJobAction,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-pub struct JobCollect {
-    pub host: String,
+#[derive(Clone, Deserialize)]
+struct LegacyJobCollect {
+    host: String,
     #[serde(default = "default_diagnostic_type")]
-    pub diagnostic_type: String,
+    diagnostic_type: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub save_dir: Option<PathBuf>,
+    save_dir: Option<PathBuf>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Deserialize)]
 #[serde(tag = "action", rename_all = "kebab-case")]
-pub enum JobAction {
+enum LegacyJobAction {
     Collect {
         output_dir: PathBuf,
     },
@@ -44,27 +70,18 @@ pub enum JobAction {
     Process {
         output: JobOutput,
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        selection: Option<JobProcessSelection>,
+        selection: Option<LegacyJobProcessSelection>,
     },
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "kebab-case")]
-pub enum JobOutput {
-    KnownHost { name: String },
-    File { path: PathBuf },
-    Directory { output_dir: PathBuf },
-    Stdout,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-pub struct JobProcessSelection {
+#[derive(Clone, Deserialize)]
+struct LegacyJobProcessSelection {
     #[serde(default = "default_process_product")]
-    pub product: String,
+    product: String,
     #[serde(default = "default_diagnostic_type")]
-    pub diagnostic_type: String,
+    diagnostic_type: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub selected: Vec<String>,
+    selected: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -74,11 +91,9 @@ pub struct NeedsAction;
 
 pub struct JobBuilder<State> {
     identifiers: Identifiers,
-    collect: Option<JobCollect>,
+    collect: Option<LegacyJobCollect>,
     _state: PhantomData<State>,
 }
-
-pub type SavedJobs = IndexMap<String, Job>;
 
 #[derive(Clone, Default, Deserialize, Serialize)]
 #[serde(default)]
@@ -207,39 +222,104 @@ pub enum SendMode {
     Local,
 }
 
+impl TryFrom<LegacyJob> for Job {
+    type Error = eyre::Report;
+
+    fn try_from(legacy: LegacyJob) -> Result<Self> {
+        let LegacyJob {
+            identifiers,
+            collect,
+            action,
+        } = legacy;
+        let input = Input::Collect {
+            host: collect.host,
+            diagnostic_type: collect.diagnostic_type,
+            include: None,
+            exclude: None,
+        };
+        let retained_save = collect.save_dir.map(SaveTarget::retained);
+
+        let (save, process, send) = match action {
+            LegacyJobAction::Collect { output_dir } => (Some(SaveTarget::retained(output_dir)), None, None),
+            LegacyJobAction::Upload { upload_id } => (
+                Some(retained_save.unwrap_or_else(SaveTarget::temporary)),
+                None,
+                Some(SendTarget { upload_id }),
+            ),
+            LegacyJobAction::Process { output, selection } => (
+                retained_save,
+                Some(Process {
+                    selection: canonicalize_legacy_selection(selection)?,
+                    export: output,
+                }),
+                None,
+            ),
+        };
+
+        Job::try_new(identifiers, input, save, process, send).map_err(Into::into)
+    }
+}
+
+fn canonicalize_legacy_selection(selection: Option<LegacyJobProcessSelection>) -> Result<Option<ProcessSelection>> {
+    let Some(selection) = selection else {
+        return Ok(None);
+    };
+    let selected =
+        ApiResolver::resolve_processing_selection(&selection.product, &selection.diagnostic_type, &selection.selected)?;
+    Ok(Some(JobProcessSelection {
+        product: selection.product,
+        diagnostic_type: selection.diagnostic_type,
+        selected,
+    }))
+}
+
 impl Job {
     pub fn builder() -> JobBuilder<NeedsCollect> {
         JobBuilder::new()
     }
 
     pub fn collect_host(&self) -> &str {
-        &self.collect.host
+        match self.input() {
+            Input::Collect { host, .. } => host,
+            Input::Load { .. } => "",
+        }
     }
 
     pub fn processing_label(&self) -> &str {
-        match &self.action {
-            JobAction::Process { selection, .. } => selection
-                .as_ref()
-                .map(|selection| selection.diagnostic_type.as_str())
-                .unwrap_or("standard"),
-            JobAction::Collect { .. } | JobAction::Upload { .. } => "skipped",
-        }
+        self.process()
+            .and_then(|process| process.selection.as_ref())
+            .map(|selection| selection.diagnostic_type.as_str())
+            .unwrap_or_else(|| {
+                if self.process().is_some() {
+                    "standard"
+                } else {
+                    "skipped"
+                }
+            })
     }
 
     pub fn send_target_label(&self) -> String {
-        match &self.action {
-            JobAction::Collect { output_dir } => format!("dir:{}", output_dir.display()),
-            JobAction::Upload { upload_id } => upload_id.clone(),
-            JobAction::Process { output, .. } => output.label(),
+        if let Some(send) = self.send() {
+            return send.upload_id.clone();
         }
+        if let Some(process) = self.process() {
+            return process.export.label();
+        }
+        self.save()
+            .and_then(|save| save.dir.as_ref())
+            .map(|dir| format!("dir:{}", dir.display()))
+            .unwrap_or_default()
     }
 
     pub fn referenced_hosts(&self) -> Vec<&str> {
-        let mut hosts = vec![self.collect.host.as_str()];
-        if let JobAction::Process {
-            output: JobOutput::KnownHost { name },
+        let mut hosts = Vec::new();
+        if let Input::Collect { host, .. } = self.input() {
+            hosts.push(host.as_str());
+        }
+        if let Some(Process {
+            export: JobOutput::KnownHost { name },
             ..
-        } = &self.action
+        }) = self.process()
         {
             hosts.push(name.as_str());
         }
@@ -248,45 +328,47 @@ impl Job {
 
     pub fn to_signals(&self) -> JobSignals {
         let mut signals = JobSignals::default();
-        signals.collect.mode = CollectMode::Collect;
-        signals.collect.source = CollectSource::KnownHost;
-        signals.collect.known_host = self.collect.host.clone();
-        signals.collect.diagnostic_type = self.collect.diagnostic_type.clone();
-        signals.collect.save = self.collect.save_dir.is_some();
-        signals.collect.download_dir = self
-            .collect
-            .save_dir
-            .as_ref()
-            .map(|path| path.display().to_string())
-            .unwrap_or_default();
+        if let Input::Collect {
+            host, diagnostic_type, ..
+        } = self.input()
+        {
+            signals.collect.mode = CollectMode::Collect;
+            signals.collect.source = CollectSource::KnownHost;
+            signals.collect.known_host = host.clone();
+            signals.collect.diagnostic_type = diagnostic_type.clone();
+        }
+        if let Some(save) = self.save() {
+            signals.collect.save = save.is_retained();
+            signals.collect.download_dir = save
+                .dir
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_default();
+        }
 
-        match &self.action {
-            JobAction::Collect { output_dir } => {
-                signals.collect.save = true;
-                signals.collect.download_dir = output_dir.display().to_string();
-                signals.process.enabled = false;
-                signals.process.mode = ProcessMode::Forward;
-                signals.send.mode = SendMode::Local;
-                signals.send.local_target = "directory".to_string();
-                signals.send.local_directory = output_dir.display().to_string();
+        if let Some(process) = self.process() {
+            signals.process.enabled = true;
+            signals.process.mode = ProcessMode::Process;
+            if let Some(selection) = &process.selection {
+                signals.process.product = selection.product.clone();
+                signals.process.diagnostic_type = selection.diagnostic_type.clone();
+                signals.process.advanced = !selection.selected.is_empty();
+                signals.process.selected = selection.selected.join(",");
             }
-            JobAction::Upload { upload_id } => {
-                signals.process.enabled = false;
-                signals.process.mode = ProcessMode::Forward;
-                signals.send.mode = SendMode::Remote;
-                signals.send.remote_target = Some(upload_id.clone());
-            }
-            JobAction::Process { output, selection } => {
-                signals.process.enabled = true;
-                signals.process.mode = ProcessMode::Process;
-                if let Some(selection) = selection {
-                    signals.process.product = selection.product.clone();
-                    signals.process.diagnostic_type = selection.diagnostic_type.clone();
-                    signals.process.advanced = !selection.selected.is_empty();
-                    signals.process.selected = selection.selected.join(",");
-                }
-                output.apply_to_signals(&mut signals);
-            }
+            process.export.apply_to_signals(&mut signals);
+        } else if self.send().is_some() {
+            signals.process.enabled = false;
+            signals.process.mode = ProcessMode::Forward;
+        } else {
+            signals.process.enabled = false;
+            signals.process.mode = ProcessMode::Forward;
+            signals.send.mode = SendMode::Local;
+            signals.send.local_target = "directory".to_string();
+            signals.send.local_directory = signals.collect.download_dir.clone();
+        }
+        if let Some(send) = self.send() {
+            signals.send.mode = SendMode::Remote;
+            signals.send.remote_target = Some(send.upload_id.clone());
         }
 
         signals
@@ -410,30 +492,37 @@ impl JobOutput {
     }
 }
 
-impl JobProcessSelection {
-    fn from_signals(signals: &JobSignals) -> Option<Self> {
-        let selected: Vec<String> = signals
-            .process
-            .selected
-            .split(',')
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(ToString::to_string)
-            .collect();
-        let has_explicit_choice = !selected.is_empty()
-            || signals.process.product != "elasticsearch"
-            || signals.process.diagnostic_type != "standard";
-        has_explicit_choice.then(|| Self {
-            product: signals.process.product.clone(),
-            diagnostic_type: signals.process.diagnostic_type.clone(),
-            selected,
-        })
-    }
-}
-
 fn intermediate_download_dir(signals: &JobSignals) -> Option<String> {
     (signals.collect.save && !signals.collect.download_dir.trim().is_empty())
         .then(|| signals.collect.download_dir.clone())
+}
+
+fn explicit_process_selection(signals: &JobSignals) -> Result<Option<ProcessSelection>> {
+    let selected: Vec<String> = signals
+        .process
+        .selected
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .collect();
+    let has_explicit_choice = !selected.is_empty()
+        || signals.process.product != "elasticsearch"
+        || signals.process.diagnostic_type != "standard";
+    if !has_explicit_choice {
+        return Ok(None);
+    }
+
+    let selected = ApiResolver::resolve_processing_selection(
+        &signals.process.product,
+        &signals.process.diagnostic_type,
+        &selected,
+    )?;
+    Ok(Some(ProcessSelection {
+        product: signals.process.product.clone(),
+        diagnostic_type: signals.process.diagnostic_type.clone(),
+        selected,
+    }))
 }
 
 impl JobBuilder<NeedsCollect> {
@@ -467,7 +556,7 @@ impl JobBuilder<NeedsCollect> {
                 builder = builder.save_collected_bundle_to(download_dir);
             }
             let output = JobOutput::from_signals_send(&signals)?;
-            let selection = JobProcessSelection::from_signals(&signals);
+            let selection = explicit_process_selection(&signals)?;
             builder.process_to_with_selection(output, selection)
         } else if signals.process.mode == ProcessMode::Forward && signals.send.mode == SendMode::Remote {
             if let Some(download_dir) = intermediate_download_dir(&signals) {
@@ -503,7 +592,7 @@ impl JobBuilder<NeedsCollect> {
         }
         Ok(JobBuilder {
             identifiers: self.identifiers,
-            collect: Some(JobCollect {
+            collect: Some(LegacyJobCollect {
                 host: host_name.to_string(),
                 diagnostic_type: default_diagnostic_type(),
                 save_dir: None,
@@ -550,7 +639,7 @@ impl JobBuilder<NeedsAction> {
                 "Collect jobs use output_dir as their final diagnostic bundle destination"
             ));
         }
-        self.build_action(JobAction::Collect { output_dir })
+        self.build(Some(SaveTarget::retained(output_dir)), None, None)
     }
 
     pub fn upload_to(self, upload_id: impl Into<String>) -> Result<Job> {
@@ -558,27 +647,48 @@ impl JobBuilder<NeedsAction> {
         if upload_id.trim().is_empty() {
             return Err(eyre!("Upload jobs require an Elastic Upload Service upload id or URL"));
         }
-        self.build_action(JobAction::Upload { upload_id })
+        let save = self
+            .collect
+            .as_ref()
+            .and_then(|collect| collect.save_dir.clone())
+            .map(SaveTarget::retained)
+            .unwrap_or_else(SaveTarget::temporary);
+        self.build(Some(save), None, Some(SendTarget { upload_id }))
     }
 
     pub fn process_to(self, output: JobOutput) -> Result<Job> {
         self.process_to_with_selection(output, None)
     }
 
-    pub fn process_to_with_selection(self, output: JobOutput, selection: Option<JobProcessSelection>) -> Result<Job> {
-        self.build_action(JobAction::Process { output, selection })
+    pub fn process_to_with_selection(self, output: JobOutput, selection: Option<ProcessSelection>) -> Result<Job> {
+        let save = self
+            .collect
+            .as_ref()
+            .and_then(|collect| collect.save_dir.clone())
+            .map(SaveTarget::retained);
+        self.build(
+            save,
+            Some(Process {
+                selection,
+                export: output,
+            }),
+            None,
+        )
     }
 
-    fn collect_mut(&mut self) -> &mut JobCollect {
+    fn collect_mut(&mut self) -> &mut LegacyJobCollect {
         self.collect.as_mut().expect("typestate guarantees collect")
     }
 
-    fn build_action(self, action: JobAction) -> Result<Job> {
-        Ok(Job {
-            identifiers: self.identifiers,
-            collect: self.collect.expect("typestate guarantees collect"),
-            action,
-        })
+    fn build(self, save: Option<SaveTarget>, process: Option<Process>, send: Option<SendTarget>) -> Result<Job> {
+        let collect = self.collect.expect("typestate guarantees collect");
+        let input = Input::Collect {
+            host: collect.host,
+            diagnostic_type: collect.diagnostic_type,
+            include: None,
+            exclude: None,
+        };
+        Job::try_new(self.identifiers, input, save, process, send).map_err(Into::into)
     }
 }
 
@@ -588,27 +698,87 @@ fn saved_jobs_io_lock() -> &'static Mutex<()> {
 }
 
 pub fn load_saved_jobs() -> Result<SavedJobs> {
+    let _guard = saved_jobs_io_lock()
+        .lock()
+        .map_err(|err| eyre!("Saved jobs IO lock poisoned: {err}"))?;
+    load_saved_jobs_unlocked()
+}
+
+fn load_saved_jobs_unlocked() -> Result<SavedJobs> {
     let path = get_jobs_path()?;
-    if path.exists() {
-        let content = fs::read_to_string(&path)?;
-        if content.trim().is_empty() {
-            return Ok(SavedJobs::default());
+    load_saved_jobs_from_path(&path)
+}
+
+fn load_saved_jobs_from_path(path: &Path) -> Result<SavedJobs> {
+    if !path.exists() {
+        return Ok(SavedJobs::default());
+    }
+    let content = fs::read_to_string(path)?;
+    if content.trim().is_empty() {
+        return Ok(SavedJobs::default());
+    }
+
+    let version = schema_version(&content)?;
+    match version {
+        None => {
+            let legacy_jobs: IndexMap<String, LegacyJob> = serde_yaml::from_str(&content)?;
+            let should_rewrite = !legacy_jobs.is_empty();
+            let jobs = legacy_jobs
+                .into_iter()
+                .map(|(name, job)| Job::try_from(job).map(|job| (name, job)))
+                .collect::<Result<SavedJobs>>()?;
+            if should_rewrite {
+                write_saved_jobs_document(path, &jobs)?;
+            }
+            Ok(jobs)
         }
-        let jobs: SavedJobs = serde_yaml::from_str(&content)?;
-        Ok(jobs)
-    } else {
-        Ok(SavedJobs::default())
+        Some(CURRENT_SCHEMA_VERSION) => {
+            let document: SavedJobsDocument = serde_yaml::from_str(&content)?;
+            Ok(document.jobs)
+        }
+        Some(version) => Err(eyre!("Unsupported saved jobs schema_version {version}")),
+    }
+}
+
+fn schema_version(content: &str) -> Result<Option<u32>> {
+    let value: serde_yaml::Value = serde_yaml::from_str(content)?;
+    let Some(mapping) = value.as_mapping() else {
+        return Err(eyre!("Saved jobs file must be a YAML mapping"));
+    };
+    let key = serde_yaml::Value::String("schema_version".to_string());
+    let Some(version) = mapping.get(&key) else {
+        return Ok(None);
+    };
+
+    match version {
+        serde_yaml::Value::Number(number) => number
+            .as_u64()
+            .and_then(|version| u32::try_from(version).ok())
+            .map(Some)
+            .ok_or_else(|| eyre!("Invalid saved jobs schema_version value")),
+        serde_yaml::Value::Mapping(_) => Ok(None),
+        _ => Err(eyre!("Invalid saved jobs schema_version value")),
     }
 }
 
 pub fn save_saved_jobs(jobs: &SavedJobs) -> Result<()> {
+    let _guard = saved_jobs_io_lock()
+        .lock()
+        .map_err(|err| eyre!("Saved jobs IO lock poisoned: {err}"))?;
+    save_saved_jobs_unlocked(jobs)
+}
+
+fn save_saved_jobs_unlocked(jobs: &SavedJobs) -> Result<()> {
     let path = get_jobs_path()?;
-    write_yaml_atomic(&path, jobs)?;
-    Ok(())
+    write_saved_jobs_document(&path, jobs)
+}
+
+fn write_saved_jobs_document(path: &Path, jobs: &SavedJobs) -> Result<()> {
+    let document = SavedJobsDocument::current(jobs.clone());
+    super::keystore::write_yaml_atomic(path, &document)
 }
 
 pub async fn load_saved_jobs_async() -> Result<SavedJobs> {
-    let _guard = saved_jobs_io_lock().lock().await;
     task::spawn_blocking(load_saved_jobs)
         .await
         .map_err(|err| eyre::eyre!("Saved jobs load task failed: {err}"))?
@@ -617,12 +787,18 @@ pub async fn load_saved_jobs_async() -> Result<SavedJobs> {
 pub async fn with_saved_jobs_async<T, F>(operation: F) -> Result<T>
 where
     T: Send + 'static,
-    F: FnOnce(&mut SavedJobs) -> Result<T> + Send + 'static,
+    F: FnOnce(&mut SavedJobs) -> Result<(T, bool)> + Send + 'static,
 {
-    let _guard = saved_jobs_io_lock().lock().await;
     task::spawn_blocking(move || {
-        let mut jobs = load_saved_jobs()?;
-        operation(&mut jobs)
+        let _guard = saved_jobs_io_lock()
+            .lock()
+            .map_err(|err| eyre!("Saved jobs IO lock poisoned: {err}"))?;
+        let mut jobs = load_saved_jobs_unlocked()?;
+        let (result, changed) = operation(&mut jobs)?;
+        if changed {
+            save_saved_jobs_unlocked(&jobs)?;
+        }
+        Ok(result)
     })
     .await
     .map_err(|err| eyre::eyre!("Saved jobs update task failed: {err}"))?
@@ -635,90 +811,6 @@ fn get_jobs_path() -> Result<PathBuf> {
         fs::create_dir_all(&esdiag_dir)?;
     }
     Ok(esdiag_dir.join("jobs.yml"))
-}
-
-fn secure_output_file(path: &Path) -> Result<File> {
-    let mut options = fs::OpenOptions::new();
-    options.create_new(true).write(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-
-        options.mode(0o600);
-        let file = options.open(path)?;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-        Ok(file)
-    }
-    #[cfg(not(unix))]
-    {
-        Ok(options.open(path)?)
-    }
-}
-
-fn temp_output_path(path: &Path) -> Result<PathBuf> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| eyre::eyre!("Path '{}' has no parent directory", path.display()))?;
-    let file_name = path
-        .file_name()
-        .ok_or_else(|| eyre::eyre!("Path '{}' has no file name", path.display()))?
-        .to_string_lossy();
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or(Duration::from_secs(0))
-        .as_nanos();
-    Ok(parent.join(format!(".{file_name}.tmp-{}-{unique}", std::process::id())))
-}
-
-fn replace_file_atomic(path: &Path, temp_path: &Path) -> Result<()> {
-    #[cfg(windows)]
-    {
-        let backup_path = path.with_extension("bak");
-        let mut backup_created = false;
-
-        if path.exists() {
-            if backup_path.exists() {
-                let _ = fs::remove_file(&backup_path);
-            }
-            fs::rename(path, &backup_path)?;
-            backup_created = true;
-        }
-
-        match fs::rename(temp_path, path) {
-            Ok(()) => {
-                if backup_created {
-                    let _ = fs::remove_file(&backup_path);
-                }
-                return Ok(());
-            }
-            Err(err) => {
-                if backup_created && !path.exists() {
-                    let _ = fs::rename(&backup_path, path);
-                }
-                return Err(err.into());
-            }
-        }
-    }
-
-    #[cfg(not(windows))]
-    fs::rename(temp_path, path)?;
-    Ok(())
-}
-
-fn write_yaml_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
-    let temp_path = temp_output_path(path)?;
-    let write_result = (|| -> Result<()> {
-        let file = secure_output_file(&temp_path)?;
-        let mut writer = BufWriter::new(file);
-        serde_yaml::to_writer(&mut writer, value)?;
-        writer.flush()?;
-        drop(writer);
-        replace_file_atomic(path, &temp_path)
-    })();
-    if write_result.is_err() {
-        let _ = fs::remove_file(&temp_path);
-    }
-    write_result
 }
 
 #[cfg(test)]
@@ -736,18 +828,48 @@ mod tests {
         tmp
     }
 
+    fn save_collect_host(name: &str) {
+        crate::data::KnownHostBuilder::new(url::Url::parse("http://localhost:9200/").expect("url"))
+            .product(crate::data::Product::Elasticsearch)
+            .roles(vec![HostRole::Collect, HostRole::Send])
+            .build()
+            .expect("host")
+            .save(name)
+            .expect("save host");
+    }
+
     fn test_job(host: &str) -> Job {
-        Job {
-            identifiers: Identifiers::default(),
-            collect: JobCollect {
+        Job::try_new(
+            Identifiers::default(),
+            Input::Collect {
                 host: host.to_string(),
                 diagnostic_type: "standard".to_string(),
-                save_dir: None,
+                include: None,
+                exclude: None,
             },
-            action: JobAction::Collect {
-                output_dir: PathBuf::from("/tmp/esdiag"),
-            },
-        }
+            Some(SaveTarget::retained(PathBuf::from("/tmp/esdiag"))),
+            None,
+            None,
+        )
+        .expect("valid job")
+    }
+
+    fn write_jobs(path: &Path, yaml: &str) {
+        std::fs::write(path, yaml.trim_start()).expect("write jobs");
+    }
+
+    #[test]
+    fn save_saved_jobs_writes_schema_version() {
+        let _guard = test_env_lock().lock().expect("env lock");
+        let tmp = setup_env();
+
+        let mut jobs = SavedJobs::default();
+        jobs.insert("first".to_string(), test_job("first"));
+        save_saved_jobs(&jobs).expect("save jobs");
+
+        let content = std::fs::read_to_string(tmp.path().join("jobs.yml")).expect("read jobs");
+        assert!(content.contains("schema_version: 2"));
+        assert!(content.contains("jobs:"));
     }
 
     #[test]
@@ -769,15 +891,276 @@ mod tests {
     }
 
     #[test]
-    fn job_serializes_typed_action_shape() {
+    fn job_serializes_phase_shape() {
         let yaml = serde_yaml::to_string(&test_job("prod")).expect("serialize job");
 
+        assert!(yaml.contains("input:"));
+        assert!(yaml.contains("type: collect"));
         assert!(yaml.contains("host: prod"));
-        assert!(yaml.contains("action: collect"));
-        assert!(yaml.contains("output_dir: /tmp/esdiag"));
-        assert!(!yaml.contains("save_dir"));
-        assert!(!yaml.contains("job:"));
+        assert!(yaml.contains("save:"));
+        assert!(!yaml.contains("action:"));
+        assert!(!yaml.contains("collect:"));
         assert!(!yaml.contains("local_target"));
+    }
+
+    #[test]
+    fn absent_schema_version_is_treated_as_v1_and_migrates_each_action() {
+        let _guard = test_env_lock().lock().expect("env lock");
+        let tmp = setup_env();
+        let path = tmp.path().join("jobs.yml");
+        write_jobs(
+            &path,
+            r#"
+collect-job:
+  collect:
+    host: prod
+    diagnostic_type: support
+  action: collect
+  output_dir: /tmp/collect
+upload-job:
+  collect:
+    host: prod
+    save_dir: /tmp/upload-bundle
+  action: upload
+  upload_id: upload-123
+process-job:
+  collect:
+    host: prod
+    save_dir: /tmp/process-bundle
+  action: process
+  output:
+    type: directory
+    output_dir: /tmp/process-output
+  selection:
+    product: elasticsearch
+    diagnostic_type: minimal
+    selected:
+      - nodes_stats
+"#,
+        );
+
+        let jobs = load_saved_jobs().expect("load and migrate jobs");
+
+        let collect = jobs.get("collect-job").expect("collect job");
+        assert!(
+            matches!(collect.input(), Input::Collect { host, diagnostic_type, .. } if host == "prod" && diagnostic_type == "support")
+        );
+        assert_eq!(
+            collect.save().and_then(|save| save.dir.as_ref()),
+            Some(&PathBuf::from("/tmp/collect"))
+        );
+        assert!(collect.process().is_none());
+        assert!(collect.send().is_none());
+
+        let upload = jobs.get("upload-job").expect("upload job");
+        assert_eq!(
+            upload.save().and_then(|save| save.dir.as_ref()),
+            Some(&PathBuf::from("/tmp/upload-bundle"))
+        );
+        assert_eq!(upload.send().expect("send").upload_id, "upload-123");
+
+        let process = jobs.get("process-job").expect("process job");
+        assert_eq!(
+            process.save().and_then(|save| save.dir.as_ref()),
+            Some(&PathBuf::from("/tmp/process-bundle"))
+        );
+        let process_stage = process.process().expect("process stage");
+        assert_eq!(
+            process_stage.export,
+            JobOutput::Directory {
+                output_dir: PathBuf::from("/tmp/process-output")
+            }
+        );
+        assert_eq!(
+            process_stage.selection.as_ref().expect("selection").diagnostic_type,
+            "minimal"
+        );
+    }
+
+    #[test]
+    fn legacy_process_without_save_dir_migrates_to_streaming() {
+        let _guard = test_env_lock().lock().expect("env lock");
+        let tmp = setup_env();
+        let path = tmp.path().join("jobs.yml");
+        write_jobs(
+            &path,
+            r#"
+streaming-job:
+  collect:
+    host: prod
+  action: process
+  output:
+    type: stdout
+"#,
+        );
+
+        let jobs = load_saved_jobs().expect("load jobs");
+        let job = jobs.get("streaming-job").expect("job");
+
+        assert!(job.save().is_none());
+        assert!(job.process().is_some());
+        assert_eq!(job.execution_mode(), crate::job::model::ExecutionMode::Streaming);
+    }
+
+    #[test]
+    fn legacy_job_named_schema_version_is_not_treated_as_version_marker() {
+        let _guard = test_env_lock().lock().expect("env lock");
+        let tmp = setup_env();
+        let path = tmp.path().join("jobs.yml");
+        write_jobs(
+            &path,
+            r#"
+schema_version:
+  collect:
+    host: prod
+  action: collect
+  output_dir: /tmp/collect
+"#,
+        );
+
+        let jobs = load_saved_jobs().expect("legacy schema_version job migrates");
+
+        assert!(jobs.contains_key("schema_version"));
+        let migrated = std::fs::read_to_string(&path).expect("read migrated file");
+        assert!(migrated.contains("schema_version: 2"));
+        assert!(migrated.contains("jobs:"));
+    }
+
+    #[test]
+    fn legacy_process_selection_is_canonicalized_during_migration() {
+        let _guard = test_env_lock().lock().expect("env lock");
+        let tmp = setup_env();
+        let path = tmp.path().join("jobs.yml");
+        write_jobs(
+            &path,
+            r#"
+process-job:
+  collect:
+    host: prod
+  action: process
+  output:
+    type: stdout
+  selection:
+    product: logstash
+    diagnostic_type: standard
+    selected:
+      - node
+"#,
+        );
+
+        let jobs = load_saved_jobs().expect("load and migrate jobs");
+        let selection = jobs
+            .get("process-job")
+            .and_then(|job| job.process())
+            .and_then(|process| process.selection.as_ref())
+            .expect("selection");
+
+        assert!(selection.selected.iter().any(|selected| selected == "logstash_node"));
+    }
+
+    #[test]
+    fn legacy_process_selection_defaults_product_and_diagnostic_type() {
+        let _guard = test_env_lock().lock().expect("env lock");
+        let tmp = setup_env();
+        let path = tmp.path().join("jobs.yml");
+        write_jobs(
+            &path,
+            r#"
+process-job:
+  collect:
+    host: prod
+  action: process
+  output:
+    type: stdout
+  selection:
+    selected:
+      - nodes_stats
+"#,
+        );
+
+        let jobs = load_saved_jobs().expect("load and migrate jobs");
+        let selection = jobs
+            .get("process-job")
+            .and_then(|job| job.process())
+            .and_then(|process| process.selection.as_ref())
+            .expect("selection");
+
+        assert_eq!(selection.product, "elasticsearch");
+        assert_eq!(selection.diagnostic_type, "standard");
+        assert!(selection.selected.iter().any(|selected| selected == "nodes_stats"));
+    }
+
+    #[test]
+    fn v1_load_rewrites_once_and_second_load_is_direct() {
+        let _guard = test_env_lock().lock().expect("env lock");
+        let tmp = setup_env();
+        let path = tmp.path().join("jobs.yml");
+        write_jobs(
+            &path,
+            r#"
+collect-job:
+  collect:
+    host: prod
+  action: collect
+  output_dir: /tmp/collect
+"#,
+        );
+
+        let jobs = load_saved_jobs().expect("first load migrates");
+        let migrated = std::fs::read_to_string(&path).expect("read migrated file");
+        assert!(migrated.contains("schema_version: 2"));
+        assert!(migrated.contains("jobs:"));
+        assert!(!migrated.contains("action: collect"));
+
+        let loaded_again = load_saved_jobs().expect("second load is direct");
+        let after_second_load = std::fs::read_to_string(&path).expect("read again");
+
+        assert_eq!(loaded_again.keys().collect::<Vec<_>>(), jobs.keys().collect::<Vec<_>>());
+        assert_eq!(after_second_load, migrated);
+    }
+
+    #[test]
+    fn current_version_loads_directly_without_rewrite() {
+        let _guard = test_env_lock().lock().expect("env lock");
+        let tmp = setup_env();
+        let path = tmp.path().join("jobs.yml");
+        let mut jobs = SavedJobs::default();
+        jobs.insert("current".to_string(), test_job("prod"));
+        write_saved_jobs_document(&path, &jobs).expect("write current jobs");
+        let before = std::fs::read_to_string(&path).expect("read current jobs");
+
+        let loaded = load_saved_jobs_from_path(&path).expect("load current jobs");
+        let after = std::fs::read_to_string(&path).expect("read after load");
+
+        assert!(loaded.contains_key("current"));
+        assert_eq!(after, before);
+    }
+
+    #[test]
+    fn atomic_write_failure_leaves_original_file_intact() {
+        struct FailingSerialize;
+
+        impl Serialize for FailingSerialize {
+            fn serialize<S>(&self, _serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                Err(serde::ser::Error::custom("intentional failure"))
+            }
+        }
+
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join("jobs.yml");
+        std::fs::write(&path, "original: true\n").expect("seed original");
+
+        let err = super::super::keystore::write_yaml_atomic(&path, &FailingSerialize)
+            .expect_err("write should fail before replace");
+
+        assert!(err.to_string().contains("intentional failure"));
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read original"),
+            "original: true\n"
+        );
     }
 
     #[test]
@@ -814,13 +1197,7 @@ mod tests {
     fn collect_only_job_uses_download_dir_as_output_dir() {
         let _guard = test_env_lock().lock().expect("env lock");
         let _tmp = setup_env();
-        crate::data::KnownHostBuilder::new(url::Url::parse("http://localhost:9200/").expect("url"))
-            .product(crate::data::Product::Elasticsearch)
-            .roles(vec![HostRole::Collect])
-            .build()
-            .expect("host")
-            .save("prod")
-            .expect("save collect host");
+        save_collect_host("prod");
 
         let mut signals = JobSignals::default();
         signals.collect.known_host = "prod".to_string();
@@ -832,33 +1209,37 @@ mod tests {
 
         let job = Job::from_signals(signals, Identifiers::default()).expect("job from signals");
 
-        match job.action {
-            JobAction::Collect { output_dir } => assert_eq!(output_dir, PathBuf::from("/tmp/browser-download")),
-            _ => panic!("expected collect action"),
-        }
-        assert!(job.collect.save_dir.is_none());
+        assert_eq!(
+            job.save().and_then(|save| save.dir.as_ref()),
+            Some(&PathBuf::from("/tmp/browser-download"))
+        );
+        assert!(job.process().is_none());
     }
 
     #[test]
     fn process_directory_output_serializes_as_output_dir() {
-        let job = Job {
-            identifiers: Identifiers::default(),
-            collect: JobCollect {
+        let job = Job::try_new(
+            Identifiers::default(),
+            Input::Collect {
                 host: "prod".to_string(),
                 diagnostic_type: "standard".to_string(),
-                save_dir: Some(PathBuf::from("/tmp/retain-bundle")),
+                include: None,
+                exclude: None,
             },
-            action: JobAction::Process {
-                output: JobOutput::Directory {
+            Some(SaveTarget::retained(PathBuf::from("/tmp/retain-bundle"))),
+            Some(Process {
+                selection: None,
+                export: JobOutput::Directory {
                     output_dir: PathBuf::from("/tmp/final-output"),
                 },
-                selection: None,
-            },
-        };
+            }),
+            None,
+        )
+        .expect("valid job");
 
         let yaml = serde_yaml::to_string(&job).expect("serialize job");
 
-        assert!(yaml.contains("save_dir: /tmp/retain-bundle"));
+        assert!(yaml.contains("dir: /tmp/retain-bundle"));
         assert!(yaml.contains("type: directory"));
         assert!(yaml.contains("output_dir: /tmp/final-output"));
         assert!(!yaml.contains("path: /tmp/final-output"));
@@ -868,20 +1249,8 @@ mod tests {
     fn job_signals_preserve_local_known_host_output() {
         let _guard = test_env_lock().lock().expect("env lock");
         let _tmp = setup_env();
-        crate::data::KnownHostBuilder::new(url::Url::parse("http://localhost:9200/").expect("url"))
-            .product(crate::data::Product::Elasticsearch)
-            .roles(vec![HostRole::Collect])
-            .build()
-            .expect("host")
-            .save("prod")
-            .expect("save collect host");
-        crate::data::KnownHostBuilder::new(url::Url::parse("http://localhost:9201/").expect("url"))
-            .product(crate::data::Product::Elasticsearch)
-            .roles(vec![HostRole::Send])
-            .build()
-            .expect("host")
-            .save("monitoring")
-            .expect("save send host");
+        save_collect_host("prod");
+        save_collect_host("monitoring");
 
         let mut signals = JobSignals::default();
         signals.collect.known_host = "prod".to_string();
@@ -892,11 +1261,8 @@ mod tests {
 
         let job = Job::from_signals(signals, Identifiers::default()).expect("job from signals");
 
-        match job.action {
-            JobAction::Process {
-                output: JobOutput::KnownHost { name },
-                ..
-            } => assert_eq!(name, "monitoring"),
+        match &job.process().expect("process").export {
+            JobOutput::KnownHost { name } => assert_eq!(name, "monitoring"),
             _ => panic!("expected process to known host"),
         }
     }
@@ -905,15 +1271,9 @@ mod tests {
     fn job_signals_preserve_local_directory_output() {
         let _guard = test_env_lock().lock().expect("env lock");
         let tmp = setup_env();
+        save_collect_host("prod");
         let output_dir = tmp.path().join("output");
         std::fs::create_dir(&output_dir).expect("create output dir");
-        crate::data::KnownHostBuilder::new(url::Url::parse("http://localhost:9200/").expect("url"))
-            .product(crate::data::Product::Elasticsearch)
-            .roles(vec![HostRole::Collect])
-            .build()
-            .expect("host")
-            .save("prod")
-            .expect("save collect host");
 
         let mut signals = JobSignals::default();
         signals.collect.known_host = "prod".to_string();
@@ -924,11 +1284,8 @@ mod tests {
 
         let job = Job::from_signals(signals, Identifiers::default()).expect("job from signals");
 
-        match job.action {
-            JobAction::Process {
-                output: JobOutput::Directory { output_dir: actual },
-                ..
-            } => assert_eq!(actual, output_dir),
+        match &job.process().expect("process").export {
+            JobOutput::Directory { output_dir: actual } => assert_eq!(actual, &output_dir),
             _ => panic!("expected process to directory"),
         }
     }
@@ -937,12 +1294,7 @@ mod tests {
     fn collect_job_requires_output_dir() {
         let _guard = test_env_lock().lock().expect("env lock");
         let _tmp = setup_env();
-        crate::data::KnownHostBuilder::new(url::Url::parse("http://localhost:9200/").expect("url"))
-            .product(crate::data::Product::Elasticsearch)
-            .build()
-            .expect("host")
-            .save("prod")
-            .expect("save host");
+        save_collect_host("prod");
 
         let err = match Job::builder().collect_from("prod").expect("known host").collect_to("") {
             Ok(_) => panic!("empty output directories should be rejected"),
@@ -956,12 +1308,7 @@ mod tests {
     fn collect_job_rejects_separate_save_dir() {
         let _guard = test_env_lock().lock().expect("env lock");
         let _tmp = setup_env();
-        crate::data::KnownHostBuilder::new(url::Url::parse("http://localhost:9200/").expect("url"))
-            .product(crate::data::Product::Elasticsearch)
-            .build()
-            .expect("host")
-            .save("prod")
-            .expect("save host");
+        save_collect_host("prod");
 
         let err = match Job::builder()
             .collect_from("prod")

--- a/src/data/saved_jobs.rs
+++ b/src/data/saved_jobs.rs
@@ -749,6 +749,7 @@ fn schema_version(content: &str) -> Result<Option<u32>> {
     let Some(version) = mapping.get(&key) else {
         return Ok(None);
     };
+    let has_jobs_key = mapping.get(&serde_yaml::Value::String("jobs".to_string())).is_some();
 
     match version {
         serde_yaml::Value::Number(number) => number
@@ -756,7 +757,10 @@ fn schema_version(content: &str) -> Result<Option<u32>> {
             .and_then(|version| u32::try_from(version).ok())
             .map(Some)
             .ok_or_else(|| eyre!("Invalid saved jobs schema_version value")),
-        serde_yaml::Value::Mapping(_) => Ok(None),
+        // A v1 file may hold a job literally named `schema_version`, whose value is
+        // the job mapping. A versioned document instead pairs `schema_version` with
+        // `jobs`, so that pairing means the version itself is malformed.
+        serde_yaml::Value::Mapping(_) if !has_jobs_key => Ok(None),
         _ => Err(eyre!("Invalid saved jobs schema_version value")),
     }
 }
@@ -1024,6 +1028,32 @@ schema_version:
         let migrated = std::fs::read_to_string(&path).expect("read migrated file");
         assert!(migrated.contains("schema_version: 2"));
         assert!(migrated.contains("jobs:"));
+    }
+
+    #[test]
+    fn versioned_document_with_malformed_schema_version_is_rejected() {
+        let _guard = test_env_lock().lock().expect("env lock");
+        let tmp = setup_env();
+        let path = tmp.path().join("jobs.yml");
+        write_jobs(
+            &path,
+            r#"
+schema_version:
+  unexpected: mapping
+jobs:
+  prod:
+    input:
+      type: collect
+      host: prod
+      diagnostic_type: standard
+    save:
+      dir: /tmp/collect
+"#,
+        );
+
+        let err = load_saved_jobs().expect_err("malformed schema_version must be rejected");
+
+        assert!(err.to_string().contains("Invalid saved jobs schema_version value"));
     }
 
     #[test]

--- a/src/data/uri.rs
+++ b/src/data/uri.rs
@@ -6,7 +6,7 @@ use crate::data::Product;
 
 use super::{ElasticCloud, KnownHost, KnownHostBuilder};
 use eyre::{OptionExt, Report, Result, eyre};
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     path::{Path, PathBuf},
     str::FromStr,
@@ -95,6 +95,35 @@ impl<'de> Deserialize<'de> for Uri {
         let s = String::deserialize(deserializer)?;
         Uri::try_from(&s).map_err(serde::de::Error::custom)
     }
+}
+
+impl Serialize for Uri {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Uri::ServiceLink(url) | Uri::ServiceLinkNoAuth(url) | Uri::Url(url) => {
+                serializer.serialize_str(redacted_url_string(url).as_str())
+            }
+            Uri::Directory(path) | Uri::File(path) => serializer.serialize_str(&path.display().to_string()),
+            Uri::ElasticCloud(host)
+            | Uri::ElasticCloudAdmin(host)
+            | Uri::ElasticGovCloudAdmin(host)
+            | Uri::KnownHost(host) => Err(serde::ser::Error::custom(format!(
+                "resolved host URI '{}' cannot be serialized without losing saved-host semantics",
+                host.transport_display()
+            ))),
+            Uri::Stream => serializer.serialize_str("-"),
+        }
+    }
+}
+
+fn redacted_url_string(url: &Url) -> String {
+    let mut url = url.clone();
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.to_string()
 }
 
 impl From<Uri> for Url {

--- a/src/job/executor.rs
+++ b/src/job/executor.rs
@@ -13,7 +13,7 @@
 
 use super::model::{ExecutionMode, ExportTarget, Input, Job, Process, SendTarget};
 use crate::{
-    data::{Product, Uri},
+    data::{HostRole, KnownHost, Product, Uri},
     exporter::Exporter,
     processor::{
         Collector, Identifiers, Processor,
@@ -50,11 +50,20 @@ pub async fn execute(job: Job) -> Result<JobOutcome> {
 
     match job.input() {
         Input::Collect {
-            host,
+            host: host_name,
             diagnostic_type,
             include,
             exclude,
         } => {
+            let hosts = KnownHost::parse_hosts_yml()?;
+            let host_key = host_name.trim();
+            let host = hosts
+                .get(host_key)
+                .cloned()
+                .ok_or_else(|| eyre!("Host '{host_key}' referenced by job not found in hosts.yml"))?;
+            if !host.has_role(HostRole::Collect) {
+                return Err(eyre!("Collect host '{host_key}' is missing the collect role"));
+            }
             match job.execution_mode() {
                 ExecutionMode::Staged => {
                     // `Save` is the serialization barrier: collection
@@ -69,7 +78,7 @@ pub async fn execute(job: Job) -> Result<JobOutcome> {
                     };
                     outcome.bundle_retained = save.is_retained();
 
-                    let receiver = Receiver::try_from((**host).clone())?;
+                    let receiver = Receiver::try_from(host.clone())?;
                     let product = host.app().clone();
                     let collect_exporter = Exporter::for_collect_archive(output_dir)?;
                     let collector = Collector::try_new(
@@ -126,13 +135,7 @@ pub async fn execute(job: Job) -> Result<JobOutcome> {
                         exclude.as_ref(),
                         process,
                     )?;
-                    run_process(
-                        Receiver::try_from((**host).clone())?,
-                        process,
-                        job.identifiers.clone(),
-                        selection,
-                    )
-                    .await?;
+                    run_process(Receiver::try_from(host)?, process, job.identifiers.clone(), selection).await?;
                     outcome.processed = true;
                 }
             }
@@ -239,9 +242,23 @@ async fn run_send(bundle_path: &std::path::Path, send: &SendTarget) -> Result<St
 /// Resolve the `Export` sink for processed documents.
 fn export_target_exporter(target: &ExportTarget) -> Result<Exporter> {
     match target {
-        ExportTarget::KnownHost { name } => Exporter::try_from(Uri::try_from(name.clone())?),
+        ExportTarget::KnownHost { name } => {
+            let hosts = KnownHost::parse_hosts_yml()?;
+            let host_key = name.trim();
+            let host = hosts
+                .get(host_key)
+                .cloned()
+                .ok_or_else(|| eyre!("Export host '{host_key}' not found in hosts.yml"))?;
+            if !host.has_role(HostRole::Send) {
+                return Err(eyre!("Export host '{host_key}' is missing the send role"));
+            }
+            if host.app() != &Product::Elasticsearch {
+                return Err(eyre!("Export host '{host_key}' must be an Elasticsearch host"));
+            }
+            Exporter::try_from(Uri::try_from(host)?)
+        }
         ExportTarget::File { path } => Exporter::try_from(Uri::File(path.clone())),
-        ExportTarget::Directory { dir } => Exporter::try_from(Uri::Directory(dir.clone())),
+        ExportTarget::Directory { output_dir } => Exporter::try_from(Uri::Directory(output_dir.clone())),
         ExportTarget::Stdout => Exporter::try_from(Uri::Stream),
     }
 }
@@ -293,7 +310,7 @@ mod tests {
             Some(Process {
                 selection: None,
                 export: ExportTarget::Directory {
-                    dir: output.path().to_path_buf(),
+                    output_dir: output.path().to_path_buf(),
                 },
             }),
             None,

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -12,12 +12,9 @@ pub mod executor;
 /// The phase-structured `Job` model with validated construction.
 pub mod model;
 
-use crate::{
-    data::{Job as SavedJob, JobAction, JobOutput, JobProcessSelection, KnownHost, load_saved_jobs, save_saved_jobs},
-    processor::api::{ApiResolver, ProcessSelection},
-};
+use crate::data::{Job as SavedJob, KnownHost, load_saved_jobs, save_saved_jobs};
+use crate::job::model::Input;
 use eyre::{Result, eyre};
-use model::{ExportTarget, Input, Job, Process, SaveTarget, SendTarget};
 use std::io::IsTerminal;
 
 pub fn handle_job_list() -> Result<()> {
@@ -63,22 +60,15 @@ pub async fn handle_job_run(name: &str) -> Result<()> {
     let jobs = load_saved_jobs()?;
     let job = jobs.get(name).ok_or_else(|| eyre!("Saved job '{}' not found", name))?;
 
-    let host_name = job.collect_host();
-    if host_name.is_empty() {
-        return Err(eyre!("Saved job '{}' has no collection host configured", name));
+    if let Input::Collect { host, .. } = job.input() {
+        let host_key = host.trim();
+        if host_key.is_empty() {
+            return Err(eyre!("Saved job '{}' has no collection host configured", name));
+        }
     }
 
-    let hosts = KnownHost::parse_hosts_yml()?;
-    let host = hosts.get(host_name).cloned().ok_or_else(|| {
-        eyre!(
-            "Host '{}' referenced by job '{}' not found in hosts.yml",
-            host_name,
-            name
-        )
-    })?;
-
     tracing::info!("Running saved job '{name}'");
-    run_job(job.clone(), host).await?;
+    run_job(job.clone()).await?;
     tracing::info!("Saved job '{name}' completed successfully");
     Ok(())
 }
@@ -116,174 +106,73 @@ pub fn validate_saved_job_name(name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Run a saved job definition: build the unified phase-structured [`Job`]
-/// from the legacy `{collect, action}` shape and hand it to the one executor.
-///
-/// (The on-disk migration of `jobs.yml` to the phase shape is owned by
-/// `saved-job-migration`; this converts at the execution boundary.)
-pub async fn run_job(job: SavedJob, host: KnownHost) -> Result<()> {
-    let host_url = host.get_url()?.to_string();
-    tracing::info!("Running saved job against {host_url}");
+/// Run a saved phase-structured job definition with the one executor.
+pub async fn run_job(job: SavedJob) -> Result<()> {
+    match job.input() {
+        Input::Collect { host, .. } => tracing::info!("Running saved collect job against {host}"),
+        Input::Load { uri } => tracing::info!("Running saved load job from {uri}"),
+    }
 
-    let unified = unify_saved_job(&job, host)?;
-    let outcome = executor::execute(unified).await?;
+    let outcome = executor::execute(job).await?;
     if let (Some(bundle_path), true) = (&outcome.bundle_path, outcome.bundle_retained) {
         tracing::info!("Retained collected bundle: {}", bundle_path.display());
     }
     Ok(())
 }
 
-/// Map the legacy `{collect, action}` saved-job shape onto the unified
-/// phase-structured model. Every legacy action collects and materialises a
-/// bundle first (always staged) — that behavior is preserved here; streaming
-/// shapes become expressible for newly authored jobs.
-fn unify_saved_job(job: &SavedJob, host: KnownHost) -> Result<Job> {
-    let input = Input::Collect {
-        host: Box::new(host),
-        diagnostic_type: job.collect.diagnostic_type.clone(),
-        include: None,
-        exclude: None,
-    };
-
-    let retained_save = job.collect.save_dir.clone().map(SaveTarget::retained);
-
-    let (save, process, send) = match &job.action {
-        JobAction::Collect { output_dir } => (Some(SaveTarget::retained(output_dir.clone())), None, None),
-        JobAction::Upload { upload_id } => (
-            Some(retained_save.unwrap_or_else(SaveTarget::temporary)),
-            None,
-            Some(SendTarget {
-                upload_id: upload_id.clone(),
-            }),
-        ),
-        JobAction::Process { output, selection } => (
-            Some(retained_save.unwrap_or_else(SaveTarget::temporary)),
-            Some(Process {
-                selection: explicit_process_selection(selection.as_ref())?,
-                export: export_target(output),
-            }),
-            None,
-        ),
-    };
-
-    Job::try_new(job.identifiers.clone(), input, save, process, send).map_err(Into::into)
-}
-
-fn export_target(output: &JobOutput) -> ExportTarget {
-    match output {
-        JobOutput::KnownHost { name } => ExportTarget::KnownHost { name: name.clone() },
-        JobOutput::File { path } => ExportTarget::File { path: path.clone() },
-        JobOutput::Directory { output_dir } => ExportTarget::Directory {
-            dir: output_dir.clone(),
-        },
-        JobOutput::Stdout => ExportTarget::Stdout,
-    }
-}
-
-fn explicit_process_selection(selection: Option<&JobProcessSelection>) -> Result<Option<ProcessSelection>> {
-    let Some(selection) = selection else {
-        return Ok(None);
-    };
-    let selected =
-        ApiResolver::resolve_processing_selection(&selection.product, &selection.diagnostic_type, &selection.selected)?;
-
-    Ok(Some(ProcessSelection {
-        product: selection.product.clone(),
-        diagnostic_type: selection.diagnostic_type.clone(),
-        selected,
-    }))
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{explicit_process_selection, unify_saved_job, validate_saved_job_name};
-    use crate::data::{Job as SavedJob, JobProcessSelection, KnownHostBuilder};
-    use crate::job::model::{ExecutionMode, Input};
+    use super::validate_saved_job_name;
+    use crate::data::Job as SavedJob;
+    use crate::job::model::{ExecutionMode, ExportTarget, Input, Process, SaveTarget};
     use std::path::PathBuf;
-    use url::Url;
 
-    fn host() -> crate::data::KnownHost {
-        KnownHostBuilder::new(Url::parse("http://localhost:9200").expect("url"))
-            .build()
-            .expect("host")
+    fn saved_collect_job() -> SavedJob {
+        SavedJob::try_new(
+            Default::default(),
+            Input::Collect {
+                host: "prod".to_string(),
+                diagnostic_type: "standard".to_string(),
+                include: None,
+                exclude: None,
+            },
+            Some(SaveTarget::retained(PathBuf::from("/tmp/esdiag-saved-jobs"))),
+            None,
+            None,
+        )
+        .expect("valid saved job")
     }
 
     #[test]
     fn job_builder_creates_collect_job() {
-        let job = SavedJob {
-            identifiers: Default::default(),
-            collect: crate::data::JobCollect {
-                host: "prod".to_string(),
-                diagnostic_type: "standard".to_string(),
-                save_dir: None,
-            },
-            action: crate::data::JobAction::Collect {
-                output_dir: PathBuf::from("/tmp/esdiag-saved-jobs"),
-            },
-        };
+        let job = saved_collect_job();
 
         assert_eq!(job.send_target_label(), "dir:/tmp/esdiag-saved-jobs");
     }
 
     #[test]
-    fn explicit_process_selection_uses_job_values() {
-        let selection = JobProcessSelection {
-            product: "logstash".to_string(),
-            diagnostic_type: "standard".to_string(),
-            selected: vec!["node".to_string()],
-        };
-
-        let selection = explicit_process_selection(Some(&selection))
-            .expect("selection")
-            .expect("saved selection");
-
-        assert_eq!(selection.product, "logstash");
-        // Legacy short keys canonicalize to registry keys (ADR-0005)
-        assert!(selection.selected.iter().any(|item| item == "logstash_node"));
-    }
-
-    #[test]
-    fn legacy_process_action_unifies_to_staged_collect_save_process() {
-        let job = SavedJob {
-            identifiers: Default::default(),
-            collect: crate::data::JobCollect {
+    fn process_job_without_save_is_streaming() {
+        let job = SavedJob::try_new(
+            Default::default(),
+            Input::Collect {
                 host: "prod".to_string(),
                 diagnostic_type: "standard".to_string(),
-                save_dir: None,
+                include: None,
+                exclude: None,
             },
-            action: crate::data::JobAction::Process {
-                output: crate::data::JobOutput::Stdout,
+            None,
+            Some(Process {
                 selection: None,
-            },
-        };
+                export: ExportTarget::Stdout,
+            }),
+            None,
+        )
+        .expect("streaming process job");
 
-        let unified = unify_saved_job(&job, host()).expect("unified job");
-        assert!(matches!(unified.input(), Input::Collect { .. }));
-        // Legacy actions always stage through a bundle; without a save_dir
-        // the bundle is temporary (not retained)
-        assert!(!unified.save().expect("save stage").is_retained());
-        assert!(unified.process().is_some());
-        assert_eq!(unified.execution_mode(), ExecutionMode::Staged);
-    }
-
-    #[test]
-    fn legacy_upload_action_unifies_to_collect_save_send() {
-        let job = SavedJob {
-            identifiers: Default::default(),
-            collect: crate::data::JobCollect {
-                host: "prod".to_string(),
-                diagnostic_type: "standard".to_string(),
-                save_dir: Some(PathBuf::from("/tmp/keep")),
-            },
-            action: crate::data::JobAction::Upload {
-                upload_id: "abc123".to_string(),
-            },
-        };
-
-        let unified = unify_saved_job(&job, host()).expect("unified job");
-        assert!(unified.save().expect("save stage").is_retained());
-        assert!(unified.process().is_none());
-        assert_eq!(unified.send().expect("send stage").upload_id, "abc123");
+        assert!(matches!(job.input(), Input::Collect { .. }));
+        assert!(job.save().is_none());
+        assert!(job.process().is_some());
+        assert_eq!(job.execution_mode(), ExecutionMode::Streaming);
     }
 
     #[test]

--- a/src/job/model.rs
+++ b/src/job/model.rs
@@ -17,20 +17,24 @@
 //! barrier): see [`Job::execution_mode`].
 
 use crate::{
-    data::{KnownHost, Uri},
+    data::Uri,
     processor::{Identifiers, api::ProcessSelection},
 };
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 /// Phase 1: where the diagnostic comes from — exactly one of a *new*
 /// collection from live product APIs, or an *existing* bundle.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
 pub enum Input {
     /// Call live product APIs to acquire a new diagnostic.
     Collect {
-        host: Box<KnownHost>,
+        host: String,
         diagnostic_type: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         include: Option<Vec<String>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         exclude: Option<Vec<String>>,
     },
     /// Read an existing diagnostic from a directory, bundle, or download.
@@ -52,8 +56,9 @@ impl Input {
 /// `dir: None` materialises the bundle in a temporary directory that is not
 /// retained after the job — the bundle still exists during execution (it is
 /// the staged-mode serialization barrier and the `Send` source).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SaveTarget {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dir: Option<PathBuf>,
 }
 
@@ -73,27 +78,29 @@ impl SaveTarget {
 
 /// Phase 2b: transform the diagnostic into documents, exporting them to
 /// `export`. `Export` ⟺ `Process` is structural: the sink lives here.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Process {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub selection: Option<ProcessSelection>,
     pub export: ExportTarget,
 }
 
 /// The destination for *processed* documents (the `Export` stage).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "kebab-case")]
 pub enum ExportTarget {
     /// A saved known host (an Elasticsearch output cluster).
     KnownHost { name: String },
     /// A local newline-delimited JSON file.
     File { path: PathBuf },
     /// A local directory of per-stream files.
-    Directory { dir: PathBuf },
+    Directory { output_dir: PathBuf },
     /// Standard output.
     Stdout,
 }
 
 /// Phase 3: transmit an existing bundle to the Elastic Uploader service.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SendTarget {
     pub upload_id: String,
 }
@@ -123,6 +130,12 @@ pub enum JobValidationError {
     SendRequiresArchiveFile,
     /// A job must do something: at least one of `save`/`process`/`send`.
     NoWork,
+    /// A temporary save must feed another stage before the temp dir is removed.
+    TemporarySaveRequiresConsumer,
+    /// Collect jobs need a saved-host reference.
+    EmptyCollectHost,
+    /// Persisted load inputs must keep their wire semantics across a YAML round trip.
+    ResolvedLoadUriNotPersistable,
 }
 
 impl std::fmt::Display for JobValidationError {
@@ -141,6 +154,15 @@ impl std::fmt::Display for JobValidationError {
                 "`send` with `Load` requires a local bundle archive file; provide a .zip bundle or collect with `save` enabled"
             ),
             Self::NoWork => write!(f, "a job must select at least one of `save`, `process`, or `send`"),
+            Self::TemporarySaveRequiresConsumer => write!(
+                f,
+                "temporary `save` requires `process` or `send` so the staged bundle is consumed before cleanup"
+            ),
+            Self::EmptyCollectHost => write!(f, "`Collect` input requires a non-empty host"),
+            Self::ResolvedLoadUriNotPersistable => write!(
+                f,
+                "`Load` input cannot persist resolved host URIs; use a file, directory, URL, or stream reference"
+            ),
         }
     }
 }
@@ -152,13 +174,39 @@ impl std::error::Error for JobValidationError {}
 ///
 /// Constructed only through [`Job::try_new`], which enforces the phase
 /// invariants; the accessors expose the validated stages read-only.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(try_from = "JobWire")]
 pub struct Job {
+    #[serde(default, skip_serializing_if = "Identifiers::is_empty")]
     pub identifiers: Identifiers,
     input: Input,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     save: Option<SaveTarget>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     process: Option<Process>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     send: Option<SendTarget>,
+}
+
+#[derive(Deserialize)]
+struct JobWire {
+    #[serde(default, skip_serializing_if = "Identifiers::is_empty")]
+    identifiers: Identifiers,
+    input: Input,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    save: Option<SaveTarget>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    process: Option<Process>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    send: Option<SendTarget>,
+}
+
+impl TryFrom<JobWire> for Job {
+    type Error = JobValidationError;
+
+    fn try_from(wire: JobWire) -> Result<Self, Self::Error> {
+        Job::try_new(wire.identifiers, wire.input, wire.save, wire.process, wire.send)
+    }
 }
 
 impl Job {
@@ -172,6 +220,17 @@ impl Job {
         if save.is_some() && !input.is_collect() {
             return Err(JobValidationError::SaveRequiresCollect);
         }
+        if let Input::Collect { host, .. } = &input
+            && host.trim().is_empty()
+        {
+            return Err(JobValidationError::EmptyCollectHost);
+        }
+        if let Input::Load {
+            uri: Uri::KnownHost(_) | Uri::ElasticCloud(_) | Uri::ElasticCloudAdmin(_) | Uri::ElasticGovCloudAdmin(_),
+        } = &input
+        {
+            return Err(JobValidationError::ResolvedLoadUriNotPersistable);
+        }
         if send.is_some() && input.is_collect() && save.is_none() {
             return Err(JobValidationError::SendRequiresBundle);
         }
@@ -180,6 +239,9 @@ impl Job {
         }
         if save.is_none() && process.is_none() && send.is_none() {
             return Err(JobValidationError::NoWork);
+        }
+        if matches!(&save, Some(SaveTarget { dir: None })) && process.is_none() && send.is_none() {
+            return Err(JobValidationError::TemporarySaveRequiresConsumer);
         }
         Ok(Self {
             identifiers,
@@ -220,20 +282,10 @@ impl Job {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::data::KnownHostBuilder;
-    use url::Url;
-
-    fn host() -> Box<KnownHost> {
-        Box::new(
-            KnownHostBuilder::new(Url::parse("http://localhost:9200").expect("url"))
-                .build()
-                .expect("host"),
-        )
-    }
 
     fn collect_input() -> Input {
         Input::Collect {
-            host: host(),
+            host: "prod".to_string(),
             diagnostic_type: "standard".to_string(),
             include: None,
             exclude: None,
@@ -309,6 +361,73 @@ mod tests {
         let err = Job::try_new(Identifiers::default(), collect_input(), None, None, None)
             .expect_err("no-op job must be rejected");
         assert_eq!(err, JobValidationError::NoWork);
+    }
+
+    #[test]
+    fn collect_input_requires_non_empty_host() {
+        let err = Job::try_new(
+            Identifiers::default(),
+            Input::Collect {
+                host: "  ".to_string(),
+                diagnostic_type: "standard".to_string(),
+                include: None,
+                exclude: None,
+            },
+            Some(SaveTarget::retained("/tmp/esdiag".into())),
+            None,
+            None,
+        )
+        .expect_err("empty collect host must be rejected");
+        assert_eq!(err, JobValidationError::EmptyCollectHost);
+    }
+
+    #[test]
+    fn load_input_rejects_resolved_host_uri() {
+        let host = crate::data::KnownHostBuilder::new(url::Url::parse("https://prod.example.com:9200").expect("url"))
+            .build()
+            .expect("known host");
+        let err = Job::try_new(
+            Identifiers::default(),
+            Input::Load {
+                uri: Uri::KnownHost(host),
+            },
+            None,
+            Some(process()),
+            None,
+        )
+        .expect_err("resolved host Uri must not be persisted in jobs.yml");
+
+        assert_eq!(err, JobValidationError::ResolvedLoadUriNotPersistable);
+    }
+
+    #[test]
+    fn temporary_save_must_feed_another_stage() {
+        let err = Job::try_new(
+            Identifiers::default(),
+            collect_input(),
+            Some(SaveTarget { dir: None }),
+            None,
+            None,
+        )
+        .expect_err("temporary save without process or send must be rejected");
+        assert_eq!(err, JobValidationError::TemporarySaveRequiresConsumer);
+    }
+
+    #[test]
+    fn deserialization_rejects_invalid_job_shape() {
+        let err = serde_yaml::from_str::<Job>(
+            r#"
+input:
+  type: collect
+  host: prod
+  diagnostic_type: standard
+send:
+  upload_id: abc123
+"#,
+        )
+        .expect_err("collect+send without save must be rejected");
+
+        assert!(err.to_string().contains("`send` requires a bundle"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1741,7 +1741,7 @@ mod tests {
     #[cfg(feature = "server")]
     use super::{resolve_serve_exporter, resolve_serve_runtime_mode};
     use clap::Parser;
-    use esdiag::data::{HostRole, JobAction, KnownHost, Product, SecretAuth, UnlockStatus, Uri, upsert_secret_auth};
+    use esdiag::data::{HostRole, KnownHost, Product, SecretAuth, UnlockStatus, Uri, upsert_secret_auth};
     use esdiag::processor::diagnostic::DiagnosticReportBuilder;
     use esdiag::processor::{
         CollectionResult, Completed, DiagnosticManifest, DiagnosticOutcome, Identifiers, IncludedDiagnosticOutcome,
@@ -2069,13 +2069,12 @@ mod tests {
         let job = derive_collect_job("prod-es", "/tmp/esdiag-output", "support", None, Identifiers::default())
             .expect("derive collect job");
 
-        assert_eq!(job.collect.save_dir, None);
-        match job.action {
-            JobAction::Collect { output_dir } => {
-                assert_eq!(output_dir, std::path::PathBuf::from("/tmp/esdiag-output"));
-            }
-            _ => panic!("expected collect action"),
-        }
+        assert!(job.process().is_none());
+        assert!(job.send().is_none());
+        assert_eq!(
+            job.save().and_then(|save| save.dir.as_ref()),
+            Some(&std::path::PathBuf::from("/tmp/esdiag-output"))
+        );
     }
 
     #[cfg(feature = "keystore")]

--- a/src/processor/api.rs
+++ b/src/processor/api.rs
@@ -1,7 +1,7 @@
 use crate::processor::diagnostic::data_source::{get_product_sources, get_source, get_source_keys_with_tag};
 use eyre::{Result, eyre};
 use indexmap::IndexSet;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
 const MIN_WEIGHT: u8 = 1;
@@ -184,7 +184,7 @@ pub struct ProcessingOption {
     pub selected: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProcessSelection {
     pub product: String,
     pub diagnostic_type: String,

--- a/src/server/saved_jobs.rs
+++ b/src/server/saved_jobs.rs
@@ -1,7 +1,5 @@
 use super::ServerState;
-use crate::data::{
-    CollectSource, HostRole, Job, JobSignals, KnownHost, load_saved_jobs_async, save_saved_jobs, with_saved_jobs_async,
-};
+use crate::data::{CollectSource, HostRole, Job, JobSignals, KnownHost, load_saved_jobs_async, with_saved_jobs_async};
 use crate::processor::Identifiers;
 use askama::Template;
 use axum::{
@@ -123,8 +121,7 @@ pub async fn save_job(signals: ReadSignals<SaveJobSignals>) -> Response {
     let name_for_save = name.clone();
     let names = match with_saved_jobs_async(move |jobs| {
         jobs.insert(name_for_save, saved_job);
-        save_saved_jobs(jobs)?;
-        Ok::<Vec<String>, eyre::Report>(jobs.keys().cloned().collect())
+        Ok::<(Vec<String>, bool), eyre::Report>((jobs.keys().cloned().collect(), true))
     })
     .await
     {
@@ -187,10 +184,9 @@ pub async fn delete_saved_job(
     let name_for_delete = name.clone();
     let names = match with_saved_jobs_async(move |jobs| {
         if jobs.shift_remove(&name_for_delete).is_none() {
-            return Ok::<Option<Vec<String>>, eyre::Report>(None);
+            return Ok::<(Option<Vec<String>>, bool), eyre::Report>((None, false));
         }
-        save_saved_jobs(jobs)?;
-        Ok(Some(jobs.keys().cloned().collect()))
+        Ok((Some(jobs.keys().cloned().collect()), true))
     })
     .await
     {


### PR DESCRIPTION
Implements OpenSpec change `saved-job-migration` (ADR-0009). Part 7 of the series from #347; depends on change 3 (#349).

Scope implemented:
- Adds `schema_version` to `jobs.yml` (absent ⇒ v1 legacy).
- Rewrites legacy `{collect, action}` saved jobs into the phase-based `Job` shape on first read using the existing atomic-write helpers.
- Migrates no-`save_dir` process jobs to streaming mode as accepted in ADR-0009.
- Keeps received artifacts/bundle manifests out of migration scope.

Artifacts: `openspec/changes/saved-job-migration/` tasks are checked off, with regression coverage for v1 detection, action mappings, rewrite idempotence, atomic-write behavior, and legacy selection defaults/canonicalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)