### PR TITLE
Architecture review 9/9 (draft): product acquisition scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ published release notes, maintenance branches, and tagged history.
 - Changed synchronous API results to include a derived `outcome` field and align failed statuses with failed report outcomes (#350).
 - Changed service-mode web authentication, event delivery, and job admission to use a pluggable auth provider, owner-scoped UI events, and service job caps (#351).
 - Changed saved jobs to rewrite legacy `jobs.yml` definitions into the versioned phase-based schema on first read (#353).
+- Scoped live `Collect` to Elasticsearch, Kibana, and Logstash; Agent and platform diagnostics now direct users to `Load`/`read` product-provided bundles (#355).
 
 ## [0.16.0] - 2026-07-11
 

--- a/openspec/changes/platform-application-split/tasks.md
+++ b/openspec/changes/platform-application-split/tasks.md
@@ -19,7 +19,7 @@
 - [x] 4.1 In `spawn_sub_processors`, set each child's `Platform` from the parent explicitly (typed), preserving the application-layer invariant for children.
 
 ## 5. Migration of call sites
-- [ ] 5.1 Migrate `Product` call sites (~90) to `Platform`/`Application`; remove the legacy alias once clear.
+- [x] 5.1 Migrate `Product` call sites (~90) to `Platform`/`Application`; remove the legacy alias once clear.
   > **Staged (see QUESTIONS.md):** the processor/report/manifest/display axes are fully
   > migrated. The remaining `Product` sites are the known-host `app` axis (KnownHost,
   > client/receiver dispatch, CLI host flags, server host forms) plus the legacy wire

--- a/openspec/changes/product-acquisition-scope/tasks.md
+++ b/openspec/changes/product-acquisition-scope/tasks.md
@@ -1,26 +1,26 @@
 # Tasks
 
 ## 1. Collect scope (core + CLI)
-- [ ] 1.1 Constrain the Phase-1 input `Receiver` resolution: build a `Collect` receiver only for Elasticsearch/Kibana/Logstash; resolve Agent/platform inputs to a `Load` receiver.
-- [ ] 1.2 Make `esdiag collect` refuse an Agent/platform target as out-of-scope by design, with a message directing the caller to `read`/`Load` (distinct from an unimplemented-product error).
-- [ ] 1.3 Ensure the refusal path is separable from the not-yet-implemented path (the *reason* is preserved, not just the fact).
+- [x] 1.1 Constrain the Phase-1 input `Receiver` resolution: build a `Collect` receiver only for Elasticsearch/Kibana/Logstash; resolve Agent/platform inputs to a `Load` receiver.
+- [x] 1.2 Make `esdiag collect` refuse an Agent/platform target as out-of-scope by design, with a message directing the caller to `read`/`Load` (distinct from an unimplemented-product error).
+- [x] 1.3 Ensure the refusal path is separable from the not-yet-implemented path (the *reason* is preserved, not just the fact).
 
 ## 2. Collection definition
-- [ ] 2.1 Confirm `assets/<product>/sources.yml` exists only for Elasticsearch/Kibana/Logstash; ensure resolution never attempts an Agent/platform source set (ADR-0005).
+- [x] 2.1 Confirm `assets/<product>/sources.yml` exists only for Elasticsearch/Kibana/Logstash; ensure resolution never attempts an Agent/platform source set (ADR-0005).
 
 ## 3. Load-entry for product-provided diagnostics
-- [ ] 3.1 Ensure Agent and platform diagnostics take the `Load → [Process] → …` shape (no `Collect` stage) end to end.
-- [ ] 3.2 Confirm a platform bundle is Loaded then fanned out one level; assert ECE yields no included diagnostics (no application data).
+- [x] 3.1 Ensure Agent and platform diagnostics take the `Load → [Process] → …` shape (no `Collect` stage) end to end.
+- [x] 3.2 Confirm a platform bundle is Loaded then fanned out one level; assert ECE yields no included diagnostics (no application data).
 
 ## 4. Gap-kind distinction
-- [ ] 4.1 Classify a recognized-but-unprocessable child skip (Kibana/Agent processing) as *not-yet-implemented*, distinct from the by-design Collect refusal. Coordinate the carrier with the ADR-0016 `Skipped`-subtype change; do not redefine the outcome type here.
+- [x] 4.1 Classify a recognized-but-unprocessable child skip (Kibana/Agent processing) as *not-yet-implemented*, distinct from the by-design Collect refusal. Coordinate the carrier with the ADR-0016 `Skipped`-subtype change; do not redefine the outcome type here.
 
 ## 5. Web UI
-- [ ] 5.1 Ensure the `Collect` panel's remote-collect option applies only to API-collectable products; product-provided bundles arrive via `Upload` (`Load`).
+- [x] 5.1 Ensure the `Collect` panel's remote-collect option applies only to API-collectable products; product-provided bundles arrive via `Upload` (`Load`).
 
 ## 6. Verification
-- [ ] 6.1 Test that `Collect` against Elasticsearch/Kibana/Logstash proceeds and against Agent/platform is refused by design.
-- [ ] 6.2 Test that an Agent/platform job begins with `Load` and contains no `Collect` stage.
-- [ ] 6.3 Test that an ECE bundle yields no included diagnostics.
-- [ ] 6.4 Test that a by-design Collect refusal and a not-yet-implemented child skip are reported distinctly (never conflated).
-- [ ] 6.5 Confirm the delta spec scenarios in `specs/collection-execution/spec.md` and `specs/included-diagnostic-jobs/spec.md` are covered.
+- [x] 6.1 Test that `Collect` against Elasticsearch/Kibana/Logstash proceeds and against Agent/platform is refused by design.
+- [x] 6.2 Test that an Agent/platform job begins with `Load` and contains no `Collect` stage.
+- [x] 6.3 Test that an ECE bundle yields no included diagnostics.
+- [x] 6.4 Test that a by-design Collect refusal and a not-yet-implemented child skip are reported distinctly (never conflated).
+- [x] 6.5 Confirm the delta spec scenarios in `specs/collection-execution/spec.md` and `specs/included-diagnostic-jobs/spec.md` are covered.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -15,7 +15,7 @@ pub use kibana::KibanaClient;
 pub use logstash::LogstashClient;
 
 extern crate elasticsearch as es;
-use crate::data::{Application, Product, Uri};
+use crate::data::{Product, Uri, collect_product};
 use eyre::{Result, eyre};
 use reqwest::Method;
 use std::collections::HashMap;
@@ -226,16 +226,11 @@ impl TryFrom<Uri> for Client {
 
     fn try_from(uri: Uri) -> Result<Self, Self::Error> {
         match uri {
-            Uri::KnownHost(host) => match host.app() {
-                Some(Application::Kibana) => Ok(Client::Kibana(KibanaClient::try_from(host)?)),
-                Some(Application::Elasticsearch) => Ok(Client::Elasticsearch(ElasticsearchClient::try_from(host)?)),
-                Some(Application::Logstash) => Ok(Client::Logstash(LogstashClient::try_from(host)?)),
-                Some(Application::Agent) => Err(eyre!(
-                    "Collect is out of scope by design for Elastic Agent. Elastic Agent provides its own diagnostic bundle; use `read`/Load instead."
-                )),
-                None => Err(eyre!(
-                    "Collect is out of scope by design for platform diagnostics. Load the platform-generated bundle with `read`/Load instead."
-                )),
+            Uri::KnownHost(host) => match collect_product(host.app())? {
+                Product::Kibana => Ok(Client::Kibana(KibanaClient::try_from(host)?)),
+                Product::Elasticsearch => Ok(Client::Elasticsearch(ElasticsearchClient::try_from(host)?)),
+                Product::Logstash => Ok(Client::Logstash(LogstashClient::try_from(host)?)),
+                product => unreachable!("collect_product returned non-collectable product {product}"),
             },
             _ => Err(eyre!("Unsupported URI")),
         }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -15,7 +15,7 @@ pub use kibana::KibanaClient;
 pub use logstash::LogstashClient;
 
 extern crate elasticsearch as es;
-use crate::data::{Product, Uri};
+use crate::data::{Application, Product, Uri};
 use eyre::{Result, eyre};
 use reqwest::Method;
 use std::collections::HashMap;
@@ -227,10 +227,15 @@ impl TryFrom<Uri> for Client {
     fn try_from(uri: Uri) -> Result<Self, Self::Error> {
         match uri {
             Uri::KnownHost(host) => match host.app() {
-                Product::Kibana => Ok(Client::Kibana(KibanaClient::try_from(host)?)),
-                Product::Elasticsearch => Ok(Client::Elasticsearch(ElasticsearchClient::try_from(host)?)),
-                Product::Logstash => Ok(Client::Logstash(LogstashClient::try_from(host)?)),
-                _ => Err(eyre!("Unsupported product: {}", host.app())),
+                Some(Application::Kibana) => Ok(Client::Kibana(KibanaClient::try_from(host)?)),
+                Some(Application::Elasticsearch) => Ok(Client::Elasticsearch(ElasticsearchClient::try_from(host)?)),
+                Some(Application::Logstash) => Ok(Client::Logstash(LogstashClient::try_from(host)?)),
+                Some(Application::Agent) => Err(eyre!(
+                    "Collect is out of scope by design for Elastic Agent. Elastic Agent provides its own diagnostic bundle; use `read`/Load instead."
+                )),
+                None => Err(eyre!(
+                    "Collect is out of scope by design for platform diagnostics. Load the platform-generated bundle with `read`/Load instead."
+                )),
             },
             _ => Err(eyre!("Unsupported URI")),
         }

--- a/src/data/known_host.rs
+++ b/src/data/known_host.rs
@@ -230,6 +230,13 @@ impl KnownHostBuilder {
         Self { app: Some(app), ..self }
     }
 
+    pub fn app(self, app: impl IntoKnownHostApp) -> Self {
+        Self {
+            app: app.into_known_host_app(),
+            ..self
+        }
+    }
+
     pub fn product(self, product: Product) -> Self {
         Self {
             app: app_from_legacy_product(product),

--- a/src/data/known_host.rs
+++ b/src/data/known_host.rs
@@ -107,7 +107,7 @@ where
         return Ok(None);
     };
     let trimmed = value.trim();
-    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("unknown") {
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("unknown") || trimmed.eq_ignore_ascii_case("none") {
         return Ok(None);
     }
     if let Ok(app) = Application::from_str(trimmed) {
@@ -2467,16 +2467,21 @@ mod tests {
     }
 
     #[test]
-    fn legacy_platform_app_values_deserialize_as_no_application() {
-        let host: KnownHost = serde_yaml::from_str(
+    fn legacy_platform_and_none_app_values_deserialize_as_no_application() {
+        for yaml in [
             r#"
 app: eck
 url: https://platform.example
 "#,
-        )
-        .expect("legacy platform host should deserialize");
+            r#"
+app: none
+url: https://platform.example
+"#,
+        ] {
+            let host: KnownHost = serde_yaml::from_str(yaml).expect("host without application should deserialize");
 
-        assert_eq!(host.app(), None);
+            assert_eq!(host.app(), None);
+        }
     }
 
     #[test]

--- a/src/data/known_host.rs
+++ b/src/data/known_host.rs
@@ -3,7 +3,10 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use super::keystore::upsert_secret_auth_batch;
-use crate::data::{Auth, Product, SecretAuth, get_keystore_password, resolve_secret_auth as resolve_secret_by_id};
+use crate::data::{
+    Application, Auth, Platform, Product, SecretAuth, get_keystore_password,
+    resolve_secret_auth as resolve_secret_by_id,
+};
 use eyre::{Result, eyre};
 #[cfg(test)]
 use serde::ser::SerializeMap;
@@ -59,18 +62,61 @@ fn default_collect_roles() -> Vec<HostRole> {
     vec![HostRole::Collect]
 }
 
-fn product_cli_name(product: &Product) -> &'static str {
-    match product {
-        Product::Agent => "agent",
-        Product::ECE => "ece",
-        Product::ECK => "eck",
-        Product::ElasticCloudHosted => "elastic-cloud-hosted",
-        Product::Elasticsearch => "elasticsearch",
-        Product::Kibana => "kibana",
-        Product::KubernetesPlatform => "kubernetes-platform",
-        Product::Logstash => "logstash",
-        Product::Unknown => "unknown",
+fn app_cli_name(app: Option<Application>) -> &'static str {
+    match app {
+        Some(app) => app.key(),
+        None => "none",
     }
+}
+
+fn app_display(app: Option<Application>) -> String {
+    app.map(|app| app.to_string()).unwrap_or_else(|| "None".to_string())
+}
+
+fn app_from_legacy_product(product: Product) -> Option<Application> {
+    product.application()
+}
+
+pub trait IntoKnownHostApp {
+    fn into_known_host_app(self) -> Option<Application>;
+}
+
+impl IntoKnownHostApp for Application {
+    fn into_known_host_app(self) -> Option<Application> {
+        Some(self)
+    }
+}
+
+impl IntoKnownHostApp for Option<Application> {
+    fn into_known_host_app(self) -> Option<Application> {
+        self
+    }
+}
+
+impl IntoKnownHostApp for Product {
+    fn into_known_host_app(self) -> Option<Application> {
+        app_from_legacy_product(self)
+    }
+}
+
+fn deserialize_host_app<'de, D>(deserializer: D) -> Result<Option<Application>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let Some(value) = Option::<String>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("unknown") {
+        return Ok(None);
+    }
+    if let Ok(app) = Application::from_str(trimmed) {
+        return Ok(Some(app));
+    }
+    if Platform::from_str(trimmed).is_ok() {
+        return Ok(None);
+    }
+    Err(serde::de::Error::custom(format!("Unknown application: {value}")))
 }
 
 fn roles_is_default_collect(roles: &[HostRole]) -> bool {
@@ -121,7 +167,7 @@ impl Display for ElasticCloud {
 pub struct KnownHostBuilder {
     accept_invalid_certs: bool,
     apikey: Option<String>,
-    product: Product,
+    app: Option<Application>,
     cloud_id: Option<ElasticCloud>,
     password: Option<String>,
     roles: Vec<HostRole>,
@@ -137,7 +183,7 @@ impl KnownHostBuilder {
         KnownHostBuilder {
             accept_invalid_certs: false,
             apikey: None,
-            product: Product::Elasticsearch,
+            app: Some(Application::Elasticsearch),
             cloud_id: None,
             password: None,
             roles: default_collect_roles(),
@@ -153,7 +199,7 @@ impl KnownHostBuilder {
         KnownHostBuilder {
             accept_invalid_certs: false,
             apikey: None,
-            product: Product::Unknown,
+            app: None,
             cloud_id: None,
             password: None,
             roles: default_collect_roles(),
@@ -180,8 +226,15 @@ impl KnownHostBuilder {
         Self { password, ..self }
     }
 
+    pub fn application(self, app: Application) -> Self {
+        Self { app: Some(app), ..self }
+    }
+
     pub fn product(self, product: Product) -> Self {
-        Self { product, ..self }
+        Self {
+            app: app_from_legacy_product(product),
+            ..self
+        }
     }
 
     pub fn secret(self, secret: Option<String>) -> Self {
@@ -232,7 +285,7 @@ impl KnownHostBuilder {
         };
         self.cloud_id = Some(cloud);
 
-        let Some(rendered) = elastic_cloud_proxy_url(url, &self.product) else {
+        let Some(rendered) = elastic_cloud_proxy_url(url, self.app) else {
             return;
         };
 
@@ -244,7 +297,7 @@ impl KnownHostBuilder {
         self.update_cloud_api_path();
         KnownHost::from_parts(KnownHostParts {
             accept_invalid_certs: self.accept_invalid_certs,
-            app: self.product,
+            app: self.app,
             cloud_id: self.cloud_id,
             roles: self.roles,
             secret: self.secret,
@@ -273,7 +326,7 @@ impl KnownHostBuilder {
 
         KnownHost::from_parts(KnownHostParts {
             accept_invalid_certs: self.accept_invalid_certs,
-            app: self.product,
+            app: self.app,
             cloud_id: self.cloud_id,
             roles: self.roles,
             secret: Some(secret),
@@ -287,8 +340,8 @@ impl KnownHostBuilder {
     }
 }
 
-fn elastic_cloud_proxy_url(url: &Url, product: &Product) -> Option<Url> {
-    if product != &Product::Elasticsearch {
+fn elastic_cloud_proxy_url(url: &Url, app: Option<Application>) -> Option<Url> {
+    if app != Some(Application::Elasticsearch) {
         return None;
     }
 
@@ -355,7 +408,7 @@ pub struct KnownHostSummary {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct KnownHost {
     pub accept_invalid_certs: bool,
-    pub app: Product,
+    pub app: Option<Application>,
     pub cloud_id: Option<ElasticCloud>,
     pub roles: Vec<HostRole>,
     pub secret: Option<String>,
@@ -371,7 +424,8 @@ pub struct KnownHost {
 struct FlatKnownHostRef<'a> {
     #[serde(default = "default_false", skip_serializing_if = "is_false")]
     accept_invalid_certs: bool,
-    app: &'a Product,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    app: &'a Option<Application>,
     #[serde(skip_serializing_if = "Option::is_none")]
     cloud_id: &'a Option<ElasticCloud>,
     #[serde(default = "default_collect_roles", skip_serializing_if = "roles_is_default_collect")]
@@ -395,7 +449,8 @@ enum LegacyKnownHostRef<'a> {
         accept_invalid_certs: bool,
         #[serde(skip_serializing_if = "Option::is_none")]
         apikey: &'a Option<String>,
-        app: &'a Product,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        app: &'a Option<Application>,
         #[serde(skip_serializing_if = "Option::is_none")]
         cloud_id: &'a Option<ElasticCloud>,
         #[serde(default = "default_collect_roles", skip_serializing_if = "roles_is_default_collect")]
@@ -409,7 +464,8 @@ enum LegacyKnownHostRef<'a> {
     Basic {
         #[serde(default = "default_false", skip_serializing_if = "is_false")]
         accept_invalid_certs: bool,
-        app: &'a Product,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        app: &'a Option<Application>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         password: &'a Option<String>,
         #[serde(default = "default_collect_roles", skip_serializing_if = "roles_is_default_collect")]
@@ -436,7 +492,8 @@ enum KnownHostWire {
 struct FlatKnownHostWire {
     #[serde(default = "default_false")]
     accept_invalid_certs: bool,
-    app: Product,
+    #[serde(default, deserialize_with = "deserialize_host_app")]
+    app: Option<Application>,
     #[serde(default)]
     cloud_id: Option<ElasticCloud>,
     #[serde(default = "default_collect_roles")]
@@ -465,7 +522,8 @@ enum LegacyKnownHostWire {
         accept_invalid_certs: bool,
         #[serde(default)]
         apikey: Option<String>,
-        app: Product,
+        #[serde(default, deserialize_with = "deserialize_host_app")]
+        app: Option<Application>,
         #[serde(default)]
         cloud_id: Option<ElasticCloud>,
         #[serde(default = "default_collect_roles")]
@@ -479,7 +537,8 @@ enum LegacyKnownHostWire {
     Basic {
         #[serde(default = "default_false")]
         accept_invalid_certs: bool,
-        app: Product,
+        #[serde(default, deserialize_with = "deserialize_host_app")]
+        app: Option<Application>,
         #[serde(default)]
         password: Option<String>,
         #[serde(default = "default_collect_roles")]
@@ -496,7 +555,8 @@ enum LegacyKnownHostWire {
     NoAuth {
         #[serde(default = "default_false")]
         accept_invalid_certs: bool,
-        app: Product,
+        #[serde(default, deserialize_with = "deserialize_host_app")]
+        app: Option<Application>,
         #[serde(default = "default_collect_roles")]
         roles: Vec<HostRole>,
         #[serde(default)]
@@ -507,7 +567,7 @@ enum LegacyKnownHostWire {
 
 struct KnownHostParts {
     accept_invalid_certs: bool,
-    app: Product,
+    app: Option<Application>,
     cloud_id: Option<ElasticCloud>,
     roles: Vec<HostRole>,
     secret: Option<String>,
@@ -724,7 +784,7 @@ impl KnownHost {
     }
 
     pub fn new_no_auth(
-        app: Product,
+        app: impl IntoKnownHostApp,
         url: Url,
         roles: Vec<HostRole>,
         viewer: Option<String>,
@@ -732,7 +792,7 @@ impl KnownHost {
     ) -> Self {
         Self::from_parts(KnownHostParts {
             accept_invalid_certs,
-            app,
+            app: app.into_known_host_app(),
             cloud_id: ElasticCloud::try_from(&url).ok(),
             roles,
             secret: None,
@@ -747,7 +807,7 @@ impl KnownHost {
     }
 
     pub fn new_legacy_apikey(
-        app: Product,
+        app: impl IntoKnownHostApp,
         url: Url,
         roles: Vec<HostRole>,
         viewer: Option<String>,
@@ -757,7 +817,7 @@ impl KnownHost {
     ) -> Self {
         Self::from_parts(KnownHostParts {
             accept_invalid_certs,
-            app,
+            app: app.into_known_host_app(),
             cloud_id: ElasticCloud::try_from(&url).ok(),
             roles,
             secret: secret.clone(),
@@ -772,7 +832,7 @@ impl KnownHost {
     }
 
     pub fn new_legacy_basic(
-        app: Product,
+        app: impl IntoKnownHostApp,
         url: Url,
         roles: Vec<HostRole>,
         viewer: Option<String>,
@@ -785,7 +845,7 @@ impl KnownHost {
             .unwrap_or((None, None));
         Self::from_parts(KnownHostParts {
             accept_invalid_certs,
-            app,
+            app: app.into_known_host_app(),
             cloud_id: ElasticCloud::try_from(&url).ok(),
             roles,
             secret: secret.clone(),
@@ -799,8 +859,8 @@ impl KnownHost {
         .expect("valid legacy basic host")
     }
 
-    pub fn app(&self) -> &Product {
-        &self.app
+    pub fn app(&self) -> Option<Application> {
+        self.app
     }
 
     pub fn get_url(&self) -> Result<Url> {
@@ -894,11 +954,11 @@ impl KnownHost {
         }
 
         let product = product.unwrap_or(DEFAULT_TEMPLATE_PRODUCT).trim().to_ascii_lowercase();
-        let app = Product::from_str(&product).map_err(|_| eyre!("Unsupported template product '{product}'"))?;
+        let app = Application::from_str(&product).map_err(|_| eyre!("Unsupported template application '{product}'"))?;
         let url = render_url_template_url(url_template, id, &product)?;
 
         let mut builder = KnownHostBuilder::new(url)
-            .product(app)
+            .application(app)
             .accept_invalid_certs(self.accept_invalid_certs)
             .roles(self.roles.clone())
             .viewer(self.viewer.clone())
@@ -942,7 +1002,7 @@ impl KnownHost {
     }
 
     pub fn merge_cli_update(&self, update: &KnownHostCliUpdate, secret_auth: Option<SecretAuth>) -> Result<Self> {
-        let app = self.app().clone();
+        let app = self.app();
         let url = self.concrete_url().cloned();
         let url_template = self.url_template.clone();
         let viewer = self.viewer().map(str::to_string);
@@ -1131,7 +1191,7 @@ impl KnownHost {
         Ok(hosts
             .into_iter()
             .map(|(name, host)| KnownHostSummary {
-                app: product_cli_name(host.app()).to_string(),
+                app: app_cli_name(host.app()).to_string(),
                 name,
                 secret: host.secret_reference().map(str::to_string),
             })
@@ -1141,7 +1201,7 @@ impl KnownHost {
     pub fn from_url(url: &Url) -> Self {
         KnownHost {
             accept_invalid_certs: false,
-            app: Product::Elasticsearch,
+            app: Some(Application::Elasticsearch),
             cloud_id: ElasticCloud::try_from(url).ok(),
             roles: default_collect_roles(),
             secret: None,
@@ -1260,7 +1320,7 @@ impl KnownHost {
     }
 
     fn normalize_and_validate_roles(&mut self, host_name: &str) -> Result<()> {
-        let app = self.app().clone();
+        let app = self.app();
         let roles = &mut self.roles;
 
         if roles.is_empty() {
@@ -1276,8 +1336,8 @@ impl KnownHost {
         for role in roles.iter() {
             match role {
                 HostRole::Collect => {}
-                HostRole::Send if app == Product::Elasticsearch => {}
-                HostRole::View if app == Product::Kibana => {}
+                HostRole::Send if app == Some(Application::Elasticsearch) => {}
+                HostRole::View if app == Some(Application::Kibana) => {}
                 HostRole::Send => {
                     return Err(eyre!(
                         "Host '{host_name}' role 'send' is only valid for Elasticsearch hosts"
@@ -1302,17 +1362,29 @@ impl Display for KnownHost {
                     .as_ref()
                     .map(std::string::ToString::to_string)
                     .unwrap_or_else(|| "None".to_string());
-                write!(fmt, "KnownHost ApiKey: {} {} {}", self.app, transport, cloud_id)
+                write!(
+                    fmt,
+                    "KnownHost ApiKey: {} {} {}",
+                    app_display(self.app),
+                    transport,
+                    cloud_id
+                )
             }
             "basic" => {
                 let username = self
                     .legacy_username
                     .clone()
                     .unwrap_or_else(|| "<secret-auth>".to_string());
-                write!(fmt, "KnownHost Basic: {} {}@ {}", self.app, username, transport)
+                write!(
+                    fmt,
+                    "KnownHost Basic: {} {}@ {}",
+                    app_display(self.app),
+                    username,
+                    transport
+                )
             }
-            "secret" => write!(fmt, "KnownHost Secret: {} {}", self.app, transport),
-            _ => write!(fmt, "KnownHost NoAuth: {} {}", self.app, transport),
+            "secret" => write!(fmt, "KnownHost Secret: {} {}", app_display(self.app), transport),
+            _ => write!(fmt, "KnownHost NoAuth: {} {}", app_display(self.app), transport),
         }
     }
 }
@@ -2369,7 +2441,7 @@ mod tests {
         let resolved = KnownHost::resolve_template_reference("elastic-cloud://cluster-1")
             .expect("resolve template reference")
             .expect("resolved host");
-        assert_eq!(resolved.app(), &Product::Elasticsearch);
+        assert_eq!(resolved.app(), Some(Application::Elasticsearch));
         assert_eq!(
             resolved.concrete_url().map(|url| url.as_str()),
             Some("https://cloud.elastic.co/api/v1/deployments/cluster-1/elasticsearch/_main/proxy/")
@@ -2392,6 +2464,19 @@ mod tests {
 
         let err = host.get_url().expect_err("template host has no concrete URL");
         assert!(err.to_string().contains("resolved into a concrete URL"));
+    }
+
+    #[test]
+    fn legacy_platform_app_values_deserialize_as_no_application() {
+        let host: KnownHost = serde_yaml::from_str(
+            r#"
+app: eck
+url: https://platform.example
+"#,
+        )
+        .expect("legacy platform host should deserialize");
+
+        assert_eq!(host.app(), None);
     }
 
     #[test]
@@ -2453,7 +2538,7 @@ mod tests {
     fn elastic_cloud_admin_proxy_urls_keep_trailing_slash() {
         let host = KnownHost::from_parts(KnownHostParts {
             accept_invalid_certs: false,
-            app: Product::Elasticsearch,
+            app: Some(Application::Elasticsearch),
             cloud_id: Some(ElasticCloud::ElasticCloudAdmin),
             roles: default_collect_roles(),
             secret: None,

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -59,9 +59,16 @@ pub fn collect_product(app: Option<Application>) -> Result<Product> {
             "Collect is out of scope by design for Elastic Agent. Elastic Agent provides its own diagnostic bundle; use `read`/`Load` instead."
         )),
         None => Err(eyre!(
-            "Collect is out of scope by design for platform diagnostics. Load the platform-generated bundle with `read`/`Load` instead."
+            "Collect is out of scope by design without an application. Select Elasticsearch, Kibana, or Logstash for API collection, or load a product-provided diagnostic bundle with `read`/`Load`."
         )),
     }
+}
+
+pub fn is_collectable_app(app: Option<Application>) -> bool {
+    matches!(
+        app,
+        Some(Application::Elasticsearch | Application::Kibana | Application::Logstash)
+    )
 }
 
 /// Save an arbitrary serializable object to a file

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -45,10 +45,24 @@ pub use settings::Settings;
 pub use uri::Uri;
 
 use crate::env;
-use eyre::Result;
+use eyre::{Result, eyre};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::{fs::OpenOptions, io::Write, path::PathBuf};
+
+pub fn collect_product(app: Option<Application>) -> Result<Product> {
+    match app {
+        Some(application @ (Application::Elasticsearch | Application::Kibana | Application::Logstash)) => {
+            Ok(Product::from(application))
+        }
+        Some(Application::Agent) => Err(eyre!(
+            "Collect is out of scope by design for Elastic Agent. Elastic Agent provides its own diagnostic bundle; use `read`/`Load` instead."
+        )),
+        None => Err(eyre!(
+            "Collect is out of scope by design for platform diagnostics. Load the platform-generated bundle with `read`/`Load` instead."
+        )),
+    }
+}
 
 /// Save an arbitrary serializable object to a file
 pub fn save_file<T: Serialize>(filename: &str, content: &T) -> Result<()> {

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -14,7 +14,7 @@ mod file;
 mod stream;
 
 use crate::{
-    data::{KnownHost, Product, Uri},
+    data::{Application, KnownHost, Uri},
     processor::{BatchResponse, DiagnosticReport, ProcessorSummary},
 };
 pub use archive::ArchiveExporter;
@@ -389,8 +389,8 @@ impl TryFrom<KnownHost> for Exporter {
     type Error = eyre::Report;
     fn try_from(host: KnownHost) -> std::result::Result<Self, Self::Error> {
         match host.app() {
-            Product::Elasticsearch => Ok(Exporter::Elasticsearch(ElasticsearchExporter::try_from(host)?)),
-            _ => Err(eyre!("Unsupported product")),
+            Some(Application::Elasticsearch) => Ok(Exporter::Elasticsearch(ElasticsearchExporter::try_from(host)?)),
+            _ => Err(eyre!("Export requires an Elasticsearch application host")),
         }
     }
 }
@@ -409,7 +409,7 @@ fn saved_viewer_kibana_base_url(host: &KnownHost) -> Option<String> {
         }
     };
 
-    if !viewer_host.has_role(crate::data::HostRole::View) || viewer_host.app() != &Product::Kibana {
+    if !viewer_host.has_role(crate::data::HostRole::View) || viewer_host.app() != Some(Application::Kibana) {
         tracing::warn!(
             "Output host viewer '{}' is not a valid Kibana view target; falling back to environment Kibana URL",
             viewer_name

--- a/src/job/executor.rs
+++ b/src/job/executor.rs
@@ -13,7 +13,7 @@
 
 use super::model::{ExecutionMode, ExportTarget, Input, Job, Process, SendTarget};
 use crate::{
-    data::{HostRole, KnownHost, Product, Uri},
+    data::{Application, HostRole, KnownHost, Product, Uri},
     exporter::Exporter,
     processor::{
         Collector, Identifiers, Processor,
@@ -79,7 +79,7 @@ pub async fn execute(job: Job) -> Result<JobOutcome> {
                     outcome.bundle_retained = save.is_retained();
 
                     let receiver = Receiver::try_from(host.clone())?;
-                    let product = host.app().clone();
+                    let product = collect_product(host.app())?;
                     let collect_exporter = Exporter::for_collect_archive(output_dir)?;
                     let collector = Collector::try_new(
                         receiver,
@@ -127,7 +127,7 @@ pub async fn execute(job: Job) -> Result<JobOutcome> {
                     let process = job
                         .process()
                         .ok_or_else(|| eyre!("streaming job without process (unreachable by construction)"))?;
-                    let product = host.app().clone();
+                    let product = collect_product(host.app())?;
                     let selection = collect_process_selection(
                         &product,
                         diagnostic_type,
@@ -164,6 +164,20 @@ pub async fn execute(job: Job) -> Result<JobOutcome> {
     }
 
     Ok(outcome)
+}
+
+fn collect_product(app: Option<Application>) -> Result<Product> {
+    match app {
+        Some(application @ (Application::Elasticsearch | Application::Kibana | Application::Logstash)) => {
+            Ok(Product::from(application))
+        }
+        Some(Application::Agent) => Err(eyre!(
+            "Collect is out of scope by design for Elastic Agent. Elastic Agent provides its own diagnostic bundle; use `read`/Load instead."
+        )),
+        None => Err(eyre!(
+            "Collect is out of scope by design for platform diagnostics. Load the platform-generated bundle with `read`/Load instead."
+        )),
+    }
 }
 
 /// Run the `Process` stage (with its `Export` sink) over the given input
@@ -252,7 +266,7 @@ fn export_target_exporter(target: &ExportTarget) -> Result<Exporter> {
             if !host.has_role(HostRole::Send) {
                 return Err(eyre!("Export host '{host_key}' is missing the send role"));
             }
-            if host.app() != &Product::Elasticsearch {
+            if host.app() != Some(Application::Elasticsearch) {
                 return Err(eyre!("Export host '{host_key}' must be an Elasticsearch host"));
             }
             Exporter::try_from(Uri::try_from(host)?)

--- a/src/job/executor.rs
+++ b/src/job/executor.rs
@@ -13,7 +13,7 @@
 
 use super::model::{ExecutionMode, ExportTarget, Input, Job, Process, SendTarget};
 use crate::{
-    data::{Application, HostRole, KnownHost, Product, Uri},
+    data::{Application, HostRole, KnownHost, Product, Uri, collect_product},
     exporter::Exporter,
     processor::{
         Collector, Identifiers, Processor,
@@ -164,20 +164,6 @@ pub async fn execute(job: Job) -> Result<JobOutcome> {
     }
 
     Ok(outcome)
-}
-
-fn collect_product(app: Option<Application>) -> Result<Product> {
-    match app {
-        Some(application @ (Application::Elasticsearch | Application::Kibana | Application::Logstash)) => {
-            Ok(Product::from(application))
-        }
-        Some(Application::Agent) => Err(eyre!(
-            "Collect is out of scope by design for Elastic Agent. Elastic Agent provides its own diagnostic bundle; use `read`/Load instead."
-        )),
-        None => Err(eyre!(
-            "Collect is out of scope by design for platform diagnostics. Load the platform-generated bundle with `read`/Load instead."
-        )),
-    }
 }
 
 /// Run the `Process` stage (with its `Export` sink) over the given input

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use esdiag::{
     client::Client,
     data::{
         Application, HostRole, KnownHost, KnownHostBuilder, KnownHostCliUpdate, Product, SecretAuth, Settings, Uri,
-        add_secret, clear_unlock_lease, create_keystore, default_unlock_ttl, get_keystore_path,
+        add_secret, clear_unlock_lease, collect_product, create_keystore, default_unlock_ttl, get_keystore_path,
         get_password_for_secret_commands, get_unlock_status, keystore_exists, parse_unlock_ttl, remove_secret,
         resolve_secret_auth, rotate_keystore_password, update_secret, validate_existing_keystore_password,
         write_unlock_lease,
@@ -1250,20 +1250,6 @@ fn sources_product_key(product: &Product) -> Result<&'static str> {
             product
         )
     })
-}
-
-fn collect_product(app: Option<Application>) -> Result<Product> {
-    match app {
-        Some(application @ (Application::Elasticsearch | Application::Kibana | Application::Logstash)) => {
-            Ok(Product::from(application))
-        }
-        Some(Application::Agent) => Err(eyre!(
-            "Collect is out of scope by design for Elastic Agent. Elastic Agent provides its own diagnostic bundle; use `read`/Load instead."
-        )),
-        None => Err(eyre!(
-            "Collect is out of scope by design for platform diagnostics. Load the platform-generated bundle with `read`/Load instead."
-        )),
-    }
 }
 
 async fn detect_sources_product_for_process(input_uri: &Uri, receiver: &Receiver) -> Result<Product> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,11 @@ use esdiag::setup;
 use esdiag::{
     client::Client,
     data::{
-        HostRole, KnownHost, KnownHostBuilder, KnownHostCliUpdate, Product, SecretAuth, Settings, Uri, add_secret,
-        clear_unlock_lease, create_keystore, default_unlock_ttl, get_keystore_path, get_password_for_secret_commands,
-        get_unlock_status, keystore_exists, parse_unlock_ttl, remove_secret, resolve_secret_auth,
-        rotate_keystore_password, update_secret, validate_existing_keystore_password, write_unlock_lease,
+        Application, HostRole, KnownHost, KnownHostBuilder, KnownHostCliUpdate, Product, SecretAuth, Settings, Uri,
+        add_secret, clear_unlock_lease, create_keystore, default_unlock_ttl, get_keystore_path,
+        get_password_for_secret_commands, get_unlock_status, keystore_exists, parse_unlock_ttl, remove_secret,
+        resolve_secret_auth, rotate_keystore_password, update_secret, validate_existing_keystore_password,
+        write_unlock_lease,
     },
     env::LOG_LEVEL,
     exporter::Exporter,
@@ -246,7 +247,7 @@ enum HostCommands {
         target: String,
         /// Application of this host when the target cannot infer it
         #[arg(help = "Application of this host when the target cannot infer it", long)]
-        app: Option<Product>,
+        app: Option<Application>,
         /// Treat <target> as a saved host URL template instead of a concrete URL
         #[arg(help = "Persist <target> as a saved host URL template", long, action = ArgAction::SetTrue)]
         url_template: bool,
@@ -710,7 +711,7 @@ async fn run(cli: Cli) -> Result<CommandResult> {
                 match known_host {
                     Uri::KnownHost(host) | Uri::ElasticCloudAdmin(host) | Uri::ElasticGovCloudAdmin(host) => {
                         ensure_host_role(&host, HostRole::Collect, "collect")?;
-                        let product = host.app().clone();
+                        let product = collect_product(host.app())?;
                         if let Some(sources) = sources {
                             esdiag::processor::init_sources(sources_product_key(&product)?, sources)?;
                         }
@@ -1245,15 +1246,32 @@ async fn upload_collected_archive(file_path: PathBuf, upload_id: String) -> Resu
 fn sources_product_key(product: &Product) -> Result<&'static str> {
     esdiag::processor::diagnostic::data_source::source_product_key(product).map_err(|_| {
         eyre!(
-            "--sources is only supported for Elasticsearch and Logstash inputs, got {}",
+            "--sources is only supported for Elasticsearch, Kibana, and Logstash inputs, got {}",
             product
         )
     })
 }
 
+fn collect_product(app: Option<Application>) -> Result<Product> {
+    match app {
+        Some(application @ (Application::Elasticsearch | Application::Kibana | Application::Logstash)) => {
+            Ok(Product::from(application))
+        }
+        Some(Application::Agent) => Err(eyre!(
+            "Collect is out of scope by design for Elastic Agent. Elastic Agent provides its own diagnostic bundle; use `read`/Load instead."
+        )),
+        None => Err(eyre!(
+            "Collect is out of scope by design for platform diagnostics. Load the platform-generated bundle with `read`/Load instead."
+        )),
+    }
+}
+
 async fn detect_sources_product_for_process(input_uri: &Uri, receiver: &Receiver) -> Result<Product> {
     match input_uri {
-        Uri::KnownHost(host) | Uri::ElasticCloudAdmin(host) | Uri::ElasticGovCloudAdmin(host) => Ok(host.app().clone()),
+        Uri::KnownHost(host) | Uri::ElasticCloudAdmin(host) | Uri::ElasticGovCloudAdmin(host) => host
+            .app()
+            .map(Product::from)
+            .ok_or_else(|| eyre!("--sources is only supported for application diagnostics")),
         _ => Ok(receiver.try_get_manifest_from_files().await?.product),
     }
 }
@@ -1306,11 +1324,11 @@ fn build_host_cli_update(args: HostMutationArgs) -> KnownHostCliUpdate {
     args.into()
 }
 
-fn infer_product_from_url(url: &Url) -> Option<Product> {
+fn infer_product_from_url(url: &Url) -> Option<Application> {
     match url.port_or_known_default() {
-        Some(9200) => Some(Product::Elasticsearch),
-        Some(5601) => Some(Product::Kibana),
-        Some(9600) => Some(Product::Logstash),
+        Some(9200) => Some(Application::Elasticsearch),
+        Some(5601) => Some(Application::Kibana),
+        Some(9600) => Some(Application::Logstash),
         _ => {
             let mut segments = url.path_segments()?.filter(|segment| !segment.is_empty());
             if matches!(segments.next(), Some("api"))
@@ -1318,7 +1336,7 @@ fn infer_product_from_url(url: &Url) -> Option<Product> {
                 && matches!(segments.next(), Some("deployments"))
             {
                 let _deployment_id = segments.next()?;
-                return Product::from_str(segments.next()?).ok();
+                return Application::from_str(segments.next()?).ok();
             }
             None
         }
@@ -1326,7 +1344,7 @@ fn infer_product_from_url(url: &Url) -> Option<Product> {
 }
 
 fn build_host_from_definition(
-    app: Option<Product>,
+    app: Option<Application>,
     target: &str,
     use_url_template: bool,
     update: &KnownHostCliUpdate,
@@ -1338,10 +1356,9 @@ fn build_host_from_definition(
         let url = Url::parse(target).map_err(|err| eyre!("Invalid host target URL: {err}"))?;
         let inferred_app = infer_product_from_url(&url);
         let app = app
-            .clone()
             .or(inferred_app)
             .ok_or_else(|| eyre!("Target '{target}' does not determine the app. Rerun with `--app <app>`."))?;
-        KnownHostBuilder::new(url).product(app)
+        KnownHostBuilder::new(url).application(app)
     }
     .accept_invalid_certs(update.accept_invalid_certs.unwrap_or(false))
     .apikey(update.apikey.clone())
@@ -1349,7 +1366,7 @@ fn build_host_from_definition(
     .password(update.password.clone())
     .secret(update.secret.clone());
     if let Some(app) = app {
-        builder = builder.product(app);
+        builder = builder.application(app);
     }
     if let Some(roles) = update.roles.clone() {
         builder = builder.roles(roles);

--- a/src/processor/diagnostic/diagnostic_manifest.rs
+++ b/src/processor/diagnostic/diagnostic_manifest.rs
@@ -392,6 +392,15 @@ mod tests {
     }
 
     #[test]
+    fn ece_manifest_carries_no_application_or_included_diagnostics() {
+        let manifest = manifest_with(Product::ECE, Some("diagnostic"), Some("ece"));
+
+        assert_eq!(manifest.platform(), Platform::ECE);
+        assert_eq!(manifest.application(), None);
+        assert!(manifest.included_diagnostics.is_none());
+    }
+
+    #[test]
     fn set_platform_overrides_detection_and_wins_for_children() {
         let mut manifest = manifest_with(Product::Elasticsearch, Some("api"), Some("unknown"));
         manifest.set_platform(Platform::ECK);

--- a/src/receiver/mod.rs
+++ b/src/receiver/mod.rs
@@ -529,8 +529,8 @@ mod tests {
 
         assert!(
             err.to_string()
-                .contains("out of scope by design for platform diagnostics")
+                .contains("out of scope by design without an application")
         );
-        assert!(err.to_string().contains("platform-generated bundle"));
+        assert!(err.to_string().contains("product-provided diagnostic bundle"));
     }
 }

--- a/src/receiver/mod.rs
+++ b/src/receiver/mod.rs
@@ -23,7 +23,7 @@ pub use kibana::{KibanaReceiver, KibanaRequestError};
 pub use logstash::{LogstashReceiver, LogstashRequestError};
 
 use super::{
-    data::{KnownHost, Product, Uri},
+    data::{Application, KnownHost, Product, Uri},
     processor::{DataSource, DiagnosticManifest, Manifest, SourceContext, StreamingDataSource},
 };
 use archive::{ArchiveBytesReceiver, ArchiveFileReceiver};
@@ -418,11 +418,18 @@ impl TryFrom<Uri> for Receiver {
             }
             Uri::File(file) => Receiver::ArchiveFile(ArchiveFileReceiver::try_from(file)?),
             Uri::KnownHost(host) => match host.app() {
-                Product::Elasticsearch => Receiver::Elasticsearch(ElasticsearchReceiver::try_from(host)?),
-                Product::Logstash => Receiver::Logstash(LogstashReceiver::try_from(host)?),
-                Product::Kibana => Receiver::Kibana(KibanaReceiver::try_from(host)?),
+                Some(Application::Elasticsearch) => Receiver::Elasticsearch(ElasticsearchReceiver::try_from(host)?),
+                Some(Application::Logstash) => Receiver::Logstash(LogstashReceiver::try_from(host)?),
+                Some(Application::Kibana) => Receiver::Kibana(KibanaReceiver::try_from(host)?),
+                Some(Application::Agent) => {
+                    return Err(eyre!(
+                        "Collect is out of scope by design for Elastic Agent. Elastic Agent provides its own diagnostic bundle; use `read`/Load instead."
+                    ));
+                }
                 _ => {
-                    return Err(eyre!("Unsupported known-host receiver product: {}", host.app()));
+                    return Err(eyre!(
+                        "Collect is out of scope by design for platform diagnostics. Load the platform-generated bundle with `read`/Load instead."
+                    ));
                 }
             },
             Uri::ServiceLink(url) => Receiver::ArchiveBytes(UploadServiceDownloader::try_from(url)?.download()?),
@@ -466,6 +473,8 @@ impl std::fmt::Display for Receiver {
 #[cfg(test)]
 mod tests {
     use super::{DirectoryReceiver, Receiver};
+    use crate::data::{Application, KnownHostBuilder, Product};
+    use url::Url;
 
     fn directory_receiver() -> Receiver {
         let root = tempfile::tempdir().expect("temp diagnostic root");
@@ -501,5 +510,36 @@ mod tests {
             .expect("absolute path should be rejected");
 
         assert!(err.to_string().contains("must be relative and stay within the bundle"));
+    }
+
+    #[test]
+    fn known_host_receiver_refuses_agent_collect_by_design() {
+        let host = KnownHostBuilder::new(Url::parse("http://localhost:8220").expect("url"))
+            .application(Application::Agent)
+            .build()
+            .expect("host");
+
+        let err = Receiver::try_from(host).err().expect("agent collect should be refused");
+
+        assert!(err.to_string().contains("out of scope by design for Elastic Agent"));
+        assert!(err.to_string().contains("read`/Load"));
+    }
+
+    #[test]
+    fn known_host_receiver_refuses_platform_collect_by_design() {
+        let host = KnownHostBuilder::new(Url::parse("https://platform.example").expect("url"))
+            .product(Product::ECK)
+            .build()
+            .expect("host");
+
+        let err = Receiver::try_from(host)
+            .err()
+            .expect("platform collect should be refused");
+
+        assert!(
+            err.to_string()
+                .contains("out of scope by design for platform diagnostics")
+        );
+        assert!(err.to_string().contains("platform-generated bundle"));
     }
 }

--- a/src/receiver/mod.rs
+++ b/src/receiver/mod.rs
@@ -23,7 +23,7 @@ pub use kibana::{KibanaReceiver, KibanaRequestError};
 pub use logstash::{LogstashReceiver, LogstashRequestError};
 
 use super::{
-    data::{Application, KnownHost, Product, Uri},
+    data::{KnownHost, Product, Uri, collect_product},
     processor::{DataSource, DiagnosticManifest, Manifest, SourceContext, StreamingDataSource},
 };
 use archive::{ArchiveBytesReceiver, ArchiveFileReceiver};
@@ -417,20 +417,11 @@ impl TryFrom<Uri> for Receiver {
                 Receiver::ElasticCloudAdmin(ElasticCloudAdminReceiver::try_from(host)?)
             }
             Uri::File(file) => Receiver::ArchiveFile(ArchiveFileReceiver::try_from(file)?),
-            Uri::KnownHost(host) => match host.app() {
-                Some(Application::Elasticsearch) => Receiver::Elasticsearch(ElasticsearchReceiver::try_from(host)?),
-                Some(Application::Logstash) => Receiver::Logstash(LogstashReceiver::try_from(host)?),
-                Some(Application::Kibana) => Receiver::Kibana(KibanaReceiver::try_from(host)?),
-                Some(Application::Agent) => {
-                    return Err(eyre!(
-                        "Collect is out of scope by design for Elastic Agent. Elastic Agent provides its own diagnostic bundle; use `read`/Load instead."
-                    ));
-                }
-                _ => {
-                    return Err(eyre!(
-                        "Collect is out of scope by design for platform diagnostics. Load the platform-generated bundle with `read`/Load instead."
-                    ));
-                }
+            Uri::KnownHost(host) => match collect_product(host.app())? {
+                Product::Elasticsearch => Receiver::Elasticsearch(ElasticsearchReceiver::try_from(host)?),
+                Product::Logstash => Receiver::Logstash(LogstashReceiver::try_from(host)?),
+                Product::Kibana => Receiver::Kibana(KibanaReceiver::try_from(host)?),
+                product => unreachable!("collect_product returned non-collectable product {product}"),
             },
             Uri::ServiceLink(url) => Receiver::ArchiveBytes(UploadServiceDownloader::try_from(url)?.download()?),
             _ => return Err(eyre!("Unsupported URI: {uri}")),
@@ -522,7 +513,7 @@ mod tests {
         let err = Receiver::try_from(host).err().expect("agent collect should be refused");
 
         assert!(err.to_string().contains("out of scope by design for Elastic Agent"));
-        assert!(err.to_string().contains("read`/Load"));
+        assert!(err.to_string().contains("`read`/`Load`"));
     }
 
     #[test]

--- a/src/server/hosts.rs
+++ b/src/server/hosts.rs
@@ -1849,7 +1849,6 @@ mod tests {
 
     #[tokio::test]
     async fn host_upsert_can_persist_no_application_for_concrete_hosts() {
-        let _guard = env_lock().lock().expect("env lock");
         let _tmp = setup_env();
         let state = test_server_state();
 

--- a/src/server/hosts.rs
+++ b/src/server/hosts.rs
@@ -1,7 +1,7 @@
 use super::{ServerState, get_theme_dark, template};
 use crate::data::{
-    HostRole, KnownHost, KnownHostBuilder, Product, SecretAuth, Settings, keystore_exists, list_secret_entries,
-    remove_secret, resolve_secret_auth, upsert_secret_auth,
+    Application, HostRole, KnownHost, KnownHostBuilder, Product, SecretAuth, Settings, keystore_exists,
+    list_secret_entries, remove_secret, resolve_secret_auth, upsert_secret_auth,
 };
 use askama::Template;
 use axum::{
@@ -738,7 +738,10 @@ fn host_row_from_known_host(name: String, host: KnownHost) -> template::HostsTab
     let mut row = template::HostsTableRow {
         name,
         auth: "none".to_string(),
-        app: host.app().to_string(),
+        app: host
+            .app()
+            .map(|app| app.to_string())
+            .unwrap_or_else(|| "None".to_string()),
         url: host.transport_display(),
         url_template: host.is_template(),
         roles: host
@@ -767,7 +770,7 @@ fn diagnostic_cluster_row(
     host: &KnownHost,
     hosts: &BTreeMap<String, KnownHost>,
 ) -> Option<template::DiagnosticClusterTableRow> {
-    if host.app() != &Product::Elasticsearch || !host.has_role(HostRole::Send) {
+    if host.app() != Some(Application::Elasticsearch) || !host.has_role(HostRole::Send) {
         return None;
     }
 
@@ -776,7 +779,7 @@ fn diagnostic_cluster_row(
         return None;
     }
     let kibana_host = hosts.get(&kibana_name)?;
-    if kibana_host.app() != &Product::Kibana || !kibana_host.has_role(HostRole::View) {
+    if kibana_host.app() != Some(Application::Kibana) || !kibana_host.has_role(HostRole::View) {
         return None;
     }
 
@@ -1145,7 +1148,7 @@ async fn apply_upsert_host(state: &Arc<ServerState>, form: HostUpsertForm) -> Re
         return Err("Host URL or URL template is required.".to_string());
     }
     let use_url_template = form.url_template.is_some();
-    let app = parse_product(form.app.trim())?;
+    let app = parse_application(form.app.trim())?;
     let roles = parse_roles(&form.roles)?;
     let viewer = to_opt(form.viewer);
     let secret = to_opt(form.secret);
@@ -1158,10 +1161,12 @@ async fn apply_upsert_host(state: &Arc<ServerState>, form: HostUpsertForm) -> Re
         let url = Url::parse(target).map_err(|err| format!("Invalid URL: {err}"))?;
         KnownHostBuilder::new(url)
     }
-    .product(app)
     .accept_invalid_certs(accept_invalid_certs)
     .roles(roles)
     .viewer(viewer);
+    if let Some(app) = app {
+        builder = builder.application(app);
+    }
     let host = match auth.as_str() {
         "none" => builder.build().map_err(to_message)?,
         "apikey" | "basic" | "secret" => {
@@ -1675,14 +1680,14 @@ fn parse_roles(value: &str) -> Result<Vec<HostRole>, String> {
     }
 }
 
-fn parse_product(value: &str) -> Result<Product, String> {
+fn parse_application(value: &str) -> Result<Option<Application>, String> {
     let normalized = value.trim().to_ascii_lowercase();
-    let mapped = match normalized.as_str() {
-        "elasticcloudhosted" => "elastic-cloud-hosted",
-        "kubernetesplatform" => "mki",
-        other => other,
-    };
-    Product::from_str(mapped).map_err(|err| format!("Invalid product: {err}"))
+    if normalized.is_empty() || normalized == "none" {
+        return Ok(None);
+    }
+    Application::from_str(&normalized)
+        .map(Some)
+        .map_err(|err| format!("Invalid application: {err}"))
 }
 
 async fn infer_auth_from_secret_selection(
@@ -1948,7 +1953,7 @@ mod tests {
         assert!(editing_html.contains("class=\"switch\""));
         assert!(editing_html.contains("Template URL"));
         assert!(editing_html.contains("Concrete URL"));
-        assert!(editing_html.contains(r#"<option value="Unknown""#));
+        assert!(editing_html.contains(r#"<option value="None""#));
 
         let template_readonly_html = render_host_row(1, &template_row, &[], false, false, true);
         let concrete_readonly_html = render_host_row(2, &concrete_row, &[], false, false, true);

--- a/src/server/hosts.rs
+++ b/src/server/hosts.rs
@@ -1163,10 +1163,8 @@ async fn apply_upsert_host(state: &Arc<ServerState>, form: HostUpsertForm) -> Re
     }
     .accept_invalid_certs(accept_invalid_certs)
     .roles(roles)
-    .viewer(viewer);
-    if let Some(app) = app {
-        builder = builder.application(app);
-    }
+    .viewer(viewer)
+    .app(app);
     let host = match auth.as_str() {
         "none" => builder.build().map_err(to_message)?,
         "apikey" | "basic" | "secret" => {
@@ -1847,6 +1845,35 @@ mod tests {
         let saved = saved_hosts.get("with-secret").expect("saved host");
         assert_eq!(saved.secret.as_deref(), Some("api-secret"));
         assert!(saved.legacy_apikey.is_none());
+    }
+
+    #[tokio::test]
+    async fn host_upsert_can_persist_no_application_for_concrete_hosts() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _tmp = setup_env();
+        let state = test_server_state();
+
+        apply_upsert_host(
+            &state,
+            HostUpsertForm {
+                original_name: None,
+                name: "platform-host".to_string(),
+                auth: "none".to_string(),
+                app: "none".to_string(),
+                url: "https://platform.example".to_string(),
+                url_template: None,
+                roles: "collect".to_string(),
+                viewer: None,
+                secret: None,
+                accept_invalid_certs: None,
+            },
+        )
+        .await
+        .expect("save platform host");
+
+        let saved_hosts = KnownHost::parse_hosts_yml().expect("reload hosts");
+        let saved = saved_hosts.get("platform-host").expect("saved host");
+        assert_eq!(saved.app(), None);
     }
 
     #[tokio::test]

--- a/src/server/index.rs
+++ b/src/server/index.rs
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use super::{ServerState, get_theme_dark, template};
-use crate::data::{HostRole, KnownHost, Product, Settings};
+use crate::data::{Application, HostRole, KnownHost, Settings};
 #[cfg(feature = "keystore")]
 use crate::data::{Job, load_saved_jobs_async};
 use crate::exporter::Exporter;
@@ -474,14 +474,19 @@ fn job_host_options(state: &Arc<ServerState>) -> JobHostOptions {
     let mut send_secure_hosts = Vec::new();
 
     for (name, host) in hosts_by_name {
-        if host.has_role(HostRole::Collect) {
+        if host.has_role(HostRole::Collect)
+            && matches!(
+                host.app(),
+                Some(Application::Elasticsearch | Application::Kibana | Application::Logstash)
+            )
+        {
             collect_hosts.push(name.clone());
             if host.requires_keystore_secret() {
                 collect_secure_hosts.push(name.clone());
             }
         }
 
-        if host.has_role(HostRole::Send) && host.app() == &Product::Elasticsearch {
+        if host.has_role(HostRole::Send) && host.app() == Some(Application::Elasticsearch) {
             send_remote_hosts.push(name.clone());
             if host.requires_keystore_secret() {
                 send_secure_hosts.push(name.clone());
@@ -528,7 +533,7 @@ fn default_downloads_dir() -> PathBuf {
 mod tests {
     use super::job_host_options;
     use crate::{
-        data::{HostRole, KnownHost, KnownHostBuilder, Product},
+        data::{Application, HostRole, KnownHost, KnownHostBuilder, Product},
         server::test_server_state,
     };
     use std::collections::BTreeMap;
@@ -562,6 +567,21 @@ mod tests {
                 .build()
                 .expect("kb host"),
         );
+        hosts.insert(
+            "agent-collect".to_string(),
+            KnownHostBuilder::new(Url::parse("https://agent.example.com:8220").expect("agent url"))
+                .application(Application::Agent)
+                .roles(vec![HostRole::Collect])
+                .build()
+                .expect("agent host"),
+        );
+        hosts.insert(
+            "platform-template".to_string(),
+            KnownHostBuilder::new_template("https://platform.example/{id}".to_string())
+                .roles(vec![HostRole::Collect])
+                .build()
+                .expect("platform host"),
+        );
         KnownHost::write_hosts_yml(&hosts).expect("write hosts");
         env
     }
@@ -578,6 +598,8 @@ mod tests {
         assert!(options.send_remote_hosts.contains(&"es-local".to_string()));
         assert_eq!(options.send_local_hosts, vec!["es-local".to_string()]);
         assert!(options.collect_hosts.contains(&"kb-collect".to_string()));
+        assert!(!options.collect_hosts.contains(&"agent-collect".to_string()));
+        assert!(!options.collect_hosts.contains(&"platform-template".to_string()));
         assert!(!options.send_remote_hosts.contains(&"kb-collect".to_string()));
         assert!(!options.send_local_hosts.contains(&"kb-collect".to_string()));
         assert!(!options.send_secure_hosts.contains(&"kb-collect".to_string()));

--- a/src/server/index.rs
+++ b/src/server/index.rs
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the Elastic License 2.0.
 
 use super::{ServerState, get_theme_dark, template};
-use crate::data::{Application, HostRole, KnownHost, Settings};
+use crate::data::{Application, HostRole, KnownHost, Settings, is_collectable_app};
 #[cfg(feature = "keystore")]
 use crate::data::{Job, load_saved_jobs_async};
 use crate::exporter::Exporter;
@@ -474,12 +474,7 @@ fn job_host_options(state: &Arc<ServerState>) -> JobHostOptions {
     let mut send_secure_hosts = Vec::new();
 
     for (name, host) in hosts_by_name {
-        if host.has_role(HostRole::Collect)
-            && matches!(
-                host.app(),
-                Some(Application::Elasticsearch | Application::Kibana | Application::Logstash)
-            )
-        {
+        if host.has_role(HostRole::Collect) && is_collectable_app(host.app()) {
             collect_hosts.push(name.clone());
             if host.requires_keystore_secret() {
                 collect_secure_hosts.push(name.clone());

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -7,7 +7,7 @@ use super::{
     ServerState, job_feed_event, replace_job_event, signal_event, template, template_event,
 };
 use crate::{
-    data::{Application, HostRole, Product, Uri},
+    data::{Application, HostRole, Uri, collect_product},
     exporter::Exporter,
     processor::{
         Collector, DiagnosticOutcome, Identifiers, IncludedDiagnosticJobEvent, Processor, SkipKind,
@@ -1094,20 +1094,6 @@ async fn collect_remote_archive(
             cleanup_path,
         },
     })
-}
-
-fn collect_product(app: Option<Application>) -> Result<Product> {
-    match app {
-        Some(application @ (Application::Elasticsearch | Application::Kibana | Application::Logstash)) => {
-            Ok(Product::from(application))
-        }
-        Some(Application::Agent) => Err(eyre!(
-            "Collect is out of scope by design for Elastic Agent. Elastic Agent provides its own diagnostic bundle; use `read`/Load instead."
-        )),
-        None => Err(eyre!(
-            "Collect is out of scope by design for platform diagnostics. Load the platform-generated bundle with `read`/Load instead."
-        )),
-    }
 }
 
 async fn collect_service_link_archive(

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -7,7 +7,7 @@ use super::{
     ServerState, job_feed_event, replace_job_event, signal_event, template, template_event,
 };
 use crate::{
-    data::{HostRole, Product, Uri},
+    data::{Application, HostRole, Product, Uri},
     exporter::Exporter,
     processor::{
         Collector, DiagnosticOutcome, Identifiers, IncludedDiagnosticJobEvent, Processor, SkipKind,
@@ -1040,7 +1040,7 @@ fn validate_remote_send_uri(uri: &Uri) -> Result<()> {
         if !host.has_role(HostRole::Send) {
             return Err(eyre!("Remote known-host send targets must have the `send` role"));
         }
-        if host.app() != &Product::Elasticsearch {
+        if host.app() != Some(Application::Elasticsearch) {
             return Err(eyre!("Remote known-host send targets must be Elasticsearch hosts"));
         }
     }
@@ -1069,7 +1069,7 @@ async fn collect_remote_archive(
     let collector = Collector::try_new(
         receiver,
         exporter,
-        host.app().clone(),
+        collect_product(host.app())?,
         diagnostic_type.to_string(),
         None,
         None,
@@ -1094,6 +1094,20 @@ async fn collect_remote_archive(
             cleanup_path,
         },
     })
+}
+
+fn collect_product(app: Option<Application>) -> Result<Product> {
+    match app {
+        Some(application @ (Application::Elasticsearch | Application::Kibana | Application::Logstash)) => {
+            Ok(Product::from(application))
+        }
+        Some(Application::Agent) => Err(eyre!(
+            "Collect is out of scope by design for Elastic Agent. Elastic Agent provides its own diagnostic bundle; use `read`/Load instead."
+        )),
+        None => Err(eyre!(
+            "Collect is out of scope by design for platform diagnostics. Load the platform-generated bundle with `read`/Load instead."
+        )),
+    }
 }
 
 async fn collect_service_link_archive(

--- a/src/server/saved_jobs.rs
+++ b/src/server/saved_jobs.rs
@@ -1,5 +1,7 @@
 use super::ServerState;
-use crate::data::{CollectSource, HostRole, Job, JobSignals, KnownHost, load_saved_jobs_async, with_saved_jobs_async};
+use crate::data::{
+    Application, CollectSource, HostRole, Job, JobSignals, KnownHost, load_saved_jobs_async, with_saved_jobs_async,
+};
 use crate::processor::Identifiers;
 use askama::Template;
 use axum::{
@@ -155,6 +157,12 @@ fn validate_saved_job(signals: &SaveJobSignals) -> Result<(), &'static str> {
         .ok_or("Saved jobs require a known host that exists in hosts.yml.")?;
     if !host.has_role(HostRole::Collect) {
         return Err("Saved jobs require a known host with the collect role.");
+    }
+    if !matches!(
+        host.app(),
+        Some(Application::Elasticsearch | Application::Kibana | Application::Logstash)
+    ) {
+        return Err("Saved jobs require an Elasticsearch, Kibana, or Logstash collect host.");
     }
 
     Ok(())

--- a/src/server/saved_jobs.rs
+++ b/src/server/saved_jobs.rs
@@ -1,6 +1,7 @@
 use super::ServerState;
 use crate::data::{
-    Application, CollectSource, HostRole, Job, JobSignals, KnownHost, load_saved_jobs_async, with_saved_jobs_async,
+    CollectSource, HostRole, Job, JobSignals, KnownHost, is_collectable_app, load_saved_jobs_async,
+    with_saved_jobs_async,
 };
 use crate::processor::Identifiers;
 use askama::Template;
@@ -158,10 +159,7 @@ fn validate_saved_job(signals: &SaveJobSignals) -> Result<(), &'static str> {
     if !host.has_role(HostRole::Collect) {
         return Err("Saved jobs require a known host with the collect role.");
     }
-    if !matches!(
-        host.app(),
-        Some(Application::Elasticsearch | Application::Kibana | Application::Logstash)
-    ) {
+    if !is_collectable_app(host.app()) {
         return Err("Saved jobs require an Elasticsearch, Kibana, or Logstash collect host.");
     }
 

--- a/src/server/template.rs
+++ b/src/server/template.rs
@@ -619,7 +619,6 @@ mod tests {
 
         assert!(skipped.contains("status-info"));
         assert!(skipped.contains("Included diagnostic: child-kibana"));
-        assert!(skipped.contains("not implemented"));
-        assert!(skipped.contains("Kibana processing is not yet implemented"));
+        assert!(skipped.contains("Kibana processing is not yet implemented (not implemented)"));
     }
 }

--- a/src/server/template.rs
+++ b/src/server/template.rs
@@ -612,13 +612,14 @@ mod tests {
             job_id: 101,
             source: "Included diagnostic: child-kibana",
             product: "Kibana",
-            reason: "Kibana processing is not yet implemented",
+            reason: "Kibana processing is not yet implemented (not implemented)",
         }
         .render()
         .expect("skipped template renders");
 
         assert!(skipped.contains("status-info"));
         assert!(skipped.contains("Included diagnostic: child-kibana"));
+        assert!(skipped.contains("not implemented"));
         assert!(skipped.contains("Kibana processing is not yet implemented"));
     }
 }

--- a/templates/hosts/host_row.html
+++ b/templates/hosts/host_row.html
@@ -4,15 +4,11 @@
     <td class="host-product-column">
         <form-input>
             <select data-bind:hosts.rows.{{ row_id }}.draft.app>
+                <option value="None" {% if host.app == "None" %}selected{% endif %}>None</option>
                 <option value="Elasticsearch" {% if host.app == "Elasticsearch" %}selected{% endif %}>Elasticsearch</option>
                 <option value="Kibana" {% if host.app == "Kibana" %}selected{% endif %}>Kibana</option>
                 <option value="Logstash" {% if host.app == "Logstash" %}selected{% endif %}>Logstash</option>
                 <option value="Agent" {% if host.app == "Agent" %}selected{% endif %}>Agent</option>
-                <option value="ECE" {% if host.app == "ECE" %}selected{% endif %}>ECE</option>
-                <option value="ECK" {% if host.app == "ECK" %}selected{% endif %}>ECK</option>
-                <option value="ElasticCloudHosted" {% if host.app == "ElasticCloudHosted" %}selected{% endif %}>ElasticCloudHosted</option>
-                <option value="KubernetesPlatform" {% if host.app == "KubernetesPlatform" %}selected{% endif %}>KubernetesPlatform</option>
-                <option value="Unknown" {% if host.app == "Unknown" %}selected{% endif %}>Unknown</option>
             </select>
         </form-input>
     </td>

--- a/tests/host_cli_tests.rs
+++ b/tests/host_cli_tests.rs
@@ -916,8 +916,8 @@ async fn host_add_infers_app_from_concrete_url_and_requires_app_for_ambiguous_ta
 
     let hosts = read_hosts(&home);
     assert_eq!(
-        hosts.get("prod-es").expect("saved host exists").app.to_string(),
-        "Elasticsearch"
+        hosts.get("prod-es").expect("saved host exists").app,
+        Some(esdiag::data::Application::Elasticsearch)
     );
 
     let ambiguous = run_esdiag_async(


### PR DESCRIPTION
## Summary

- Scopes live `Collect` to Elasticsearch, Kibana, and Logstash; Agent and platform targets now fail as out-of-scope by design with `Load`/`read` guidance.
- Migrates saved-host `app` storage to `Option<Application>` while reading legacy platform/unknown host values tolerantly as `None`.
- Distinguishes by-design Collect refusal from not-yet-implemented included-diagnostic skips via `SkipKind`.

## Modeling Notes

- Cloud-admin/template/platform-only saved hosts are not applications, so they use `app: None`; template references resolve to a concrete application when the reference includes or defaults to an application segment.
- The legacy `Product` type remains for manifest wire compatibility and collect/manifest bridge code; it no longer owns the saved-host `app` axis.
- No trigger-then-Load flow is implemented in this change.

## Validation

- `cargo fmt`
- `cargo clippy --all-targets --all-features` (passes with existing warnings)
- `cargo test -- --test-threads=1` (495 passed, 23 ignored)

Note: default parallel `cargo test` currently trips an existing shared environment race in service-mode web tests; the first failing test passes in isolation.