### PR TITLE
chore: apply rustfmt formatting

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -89,8 +89,7 @@ fn main() {
 
     #[cfg(feature = "desktop")]
     {
-        let manifest_dir =
-            env::var("CARGO_MANIFEST_DIR").expect("missing CARGO_MANIFEST_DIR for desktop build");
+        let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("missing CARGO_MANIFEST_DIR for desktop build");
         let manifest_path = Path::new(&manifest_dir);
         let desktop_dir = manifest_path.join("desktop");
 

--- a/src/processor/kibana/collector.rs
+++ b/src/processor/kibana/collector.rs
@@ -683,10 +683,13 @@ mod tests {
             let (socket, _) = listener.accept().await.expect("accept connection");
             drop(socket);
         });
-        let error = reqwest::Client::new().get(url).send().await.expect_err("request should fail");
+        let error = reqwest::Client::new()
+            .get(url)
+            .send()
+            .await
+            .expect_err("request should fail");
         close_connection.await.expect("connection close task should finish");
-        let sync_error =
-            eyre::Report::from(kibana_sync::Error::Transport(error)).wrap_err("Failed to send request");
+        let sync_error = eyre::Report::from(kibana_sync::Error::Transport(error)).wrap_err("Failed to send request");
 
         assert!(should_retry_kibana_error(&sync_error));
     }

--- a/src/server/index.rs
+++ b/src/server/index.rs
@@ -502,7 +502,11 @@ fn job_host_options(state: &Arc<ServerState>) -> JobHostOptions {
             if host.requires_keystore_secret() {
                 send_secure_hosts.push(name.clone());
             }
-            if host.concrete_url().and_then(|url| url.host_str()).is_some_and(is_local_host) {
+            if host
+                .concrete_url()
+                .and_then(|url| url.host_str())
+                .is_some_and(is_local_host)
+            {
                 send_local_hosts.push(name.clone());
             }
         }

--- a/src/server/known_host.rs
+++ b/src/server/known_host.rs
@@ -126,7 +126,12 @@ pub(super) async fn run_known_host_form(
         Err(e) => {
             let error_message = format!("Failed to resolve host URL: {}", e);
             state
-                .reject_retained_bundle(&download_token, &request_user, error_message.clone(), DOWNLOAD_REJECTION_TTL)
+                .reject_retained_bundle(
+                    &download_token,
+                    &request_user,
+                    error_message.clone(),
+                    DOWNLOAD_REJECTION_TTL,
+                )
                 .await;
             state.record_failure().await;
             send_event(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -396,7 +396,10 @@ impl Server {
                     .route("/settings/cluster/{action}/{id}", post(hosts::cluster_action))
                     .route("/settings/host/upsert", post(hosts::upsert_host))
                     .route("/settings/host/delete", post(hosts::delete_host))
-                    .route("/settings/secret/by-id/{secret_id}/delete", post(hosts::delete_secret_by_id))
+                    .route(
+                        "/settings/secret/by-id/{secret_id}/delete",
+                        post(hosts::delete_secret_by_id),
+                    )
                     .route("/settings/secret/{action}/{id}", post(hosts::secret_action))
                     .route("/settings/secret/upsert", post(hosts::upsert_secret))
                     .route("/settings/secret/delete", post(hosts::delete_secret))

--- a/tests/archive_lookup_enriched_processors_tests.rs
+++ b/tests/archive_lookup_enriched_processors_tests.rs
@@ -101,7 +101,13 @@ fn read_required_lookup_docs(output_dir: &Path, file_name: &str, archive: &Path)
     }
 }
 
-fn find_required_doc<'a, P>(docs: &'a [Value], archive: &Path, stream: &str, description: &str, predicate: P) -> &'a Value
+fn find_required_doc<'a, P>(
+    docs: &'a [Value],
+    archive: &Path,
+    stream: &str,
+    description: &str,
+    predicate: P,
+) -> &'a Value
 where
     P: Fn(&Value) -> bool,
 {
@@ -328,7 +334,8 @@ fn test_archive_index_settings_lookup_enrichment_for_index_metrics() {
                     && doc["index"]["number_of_replicas"].is_number()
                     && doc["index"]["refresh_interval"].is_string()
             };
-            if metrics_index_docs.iter().any(has_index_settings_lookup) || archive_requires_lookup_enrichment(&archive) {
+            if metrics_index_docs.iter().any(has_index_settings_lookup) || archive_requires_lookup_enrichment(&archive)
+            {
                 let metrics_index_doc = find_required_doc(
                     &metrics_index_docs,
                     &archive,
@@ -349,7 +356,8 @@ fn test_archive_index_settings_lookup_enrichment_for_index_metrics() {
                     && doc["index"]["number_of_replicas"].is_number()
                     && doc["index"]["refresh_interval"].is_string()
             };
-            if metrics_shard_docs.iter().any(has_index_settings_lookup) || archive_requires_lookup_enrichment(&archive) {
+            if metrics_shard_docs.iter().any(has_index_settings_lookup) || archive_requires_lookup_enrichment(&archive)
+            {
                 let metrics_shard_doc = find_required_doc(
                     &metrics_shard_docs,
                     &archive,

--- a/tests/logstash_collection_tests.rs
+++ b/tests/logstash_collection_tests.rs
@@ -174,10 +174,7 @@ fn run_external_logstash_collect_test(
     ];
 
     if let Some(apikey) = &config.apikey {
-        let secret = run_esdiag(
-            &["keystore", "add", &secret_id, "--apikey", apikey],
-            &test_home,
-        );
+        let secret = run_esdiag(&["keystore", "add", &secret_id, "--apikey", apikey], &test_home);
         assert_success(&secret, &format!("{env_prefix} api key secret setup"));
         host_args.push("--secret".to_string());
         host_args.push(secret_id.clone());
@@ -240,9 +237,7 @@ fn run_external_logstash_collect_test(
     assert_eq!(manifest["product"].as_str(), Some("logstash"));
     assert_eq!(manifest["mode"].as_str(), Some("support"));
 
-    let requested_apis = manifest["requested_apis"]
-        .as_object()
-        .expect("requested_apis object");
+    let requested_apis = manifest["requested_apis"].as_object().expect("requested_apis object");
     let api_names: Vec<&str> = requested_apis.keys().map(String::as_str).collect();
     for required in [
         "logstash_node",
@@ -266,8 +261,14 @@ fn run_external_logstash_collect_test(
             .get(required)
             .and_then(|value| value["response_size_bytes"].as_u64());
         assert!(retries.is_some(), "{env_prefix} missing retries for {required}");
-        assert!(response_time_ms.is_some(), "{env_prefix} missing response time for {required}");
-        assert!(response_size_bytes.is_some(), "{env_prefix} missing response size for {required}");
+        assert!(
+            response_time_ms.is_some(),
+            "{env_prefix} missing response time for {required}"
+        );
+        assert!(
+            response_size_bytes.is_some(),
+            "{env_prefix} missing response size for {required}"
+        );
     }
     assert_eq!(
         api_names.contains(&"logstash_health_report"),

--- a/tests/runtime_mode_web_tests.rs
+++ b/tests/runtime_mode_web_tests.rs
@@ -25,8 +25,8 @@ async fn start_server_with_features(mode: RuntimeMode, web_features: Option<&str
         mode,
         web_features,
     )
-        .await
-        .expect("start local server");
+    .await
+    .expect("start local server");
 
     let client = Client::new();
     let base = format!("http://127.0.0.1:{}", bound_addr.port());
@@ -103,10 +103,18 @@ async fn user_mode_default_nav_exposes_advanced_not_job_builder() {
     assert!(!body.contains("href=\"/jobs\""));
     assert!(!body.contains(">Job Builder</a>"));
 
-    let advanced = client.get(format!("{base}/advanced")).send().await.expect("advanced route");
+    let advanced = client
+        .get(format!("{base}/advanced"))
+        .send()
+        .await
+        .expect("advanced route");
     assert_eq!(advanced.status(), reqwest::StatusCode::OK);
 
-    let workflow = client.get(format!("{base}/workflow")).send().await.expect("workflow route");
+    let workflow = client
+        .get(format!("{base}/workflow"))
+        .send()
+        .await
+        .expect("workflow route");
     assert_eq!(workflow.status(), reqwest::StatusCode::NOT_FOUND);
 
     let jobs = client.get(format!("{base}/jobs")).send().await.expect("jobs route");
@@ -130,7 +138,11 @@ async fn explicit_job_builder_feature_mounts_jobs_and_omits_advanced() {
     assert!(body.contains("href=\"/jobs\""));
     assert!(body.contains(">Job Builder</a>"));
 
-    let advanced = client.get(format!("{base}/advanced")).send().await.expect("advanced route");
+    let advanced = client
+        .get(format!("{base}/advanced"))
+        .send()
+        .await
+        .expect("advanced route");
     assert_eq!(advanced.status(), reqwest::StatusCode::NOT_FOUND);
 
     let jobs = client.get(format!("{base}/jobs")).send().await.expect("jobs route");
@@ -142,8 +154,7 @@ async fn explicit_job_builder_feature_mounts_jobs_and_omits_advanced() {
 #[cfg(feature = "keystore")]
 #[tokio::test]
 async fn explicit_advanced_and_job_builder_features_mount_both_pages() {
-    let (mut server, client, base) =
-        start_server_with_features(RuntimeMode::User, Some("advanced,job-builder")).await;
+    let (mut server, client, base) = start_server_with_features(RuntimeMode::User, Some("advanced,job-builder")).await;
 
     let response = client.get(format!("{base}/")).send().await.expect("user mode request");
     assert_eq!(response.status(), reqwest::StatusCode::OK);
@@ -154,7 +165,11 @@ async fn explicit_advanced_and_job_builder_features_mount_both_pages() {
     assert!(body.contains("href=\"/advanced\""));
     assert!(body.contains("href=\"/jobs\""));
 
-    let advanced = client.get(format!("{base}/advanced")).send().await.expect("advanced route");
+    let advanced = client
+        .get(format!("{base}/advanced"))
+        .send()
+        .await
+        .expect("advanced route");
     assert_eq!(advanced.status(), reqwest::StatusCode::OK);
 
     let jobs = client.get(format!("{base}/jobs")).send().await.expect("jobs route");
@@ -176,7 +191,11 @@ async fn empty_web_features_omit_optional_nav_and_routes() {
     assert!(!body.contains("href=\"/advanced\""));
     assert!(!body.contains("href=\"/jobs\""));
 
-    let advanced = client.get(format!("{base}/advanced")).send().await.expect("advanced route");
+    let advanced = client
+        .get(format!("{base}/advanced"))
+        .send()
+        .await
+        .expect("advanced route");
     assert_eq!(advanced.status(), reqwest::StatusCode::NOT_FOUND);
 
     let jobs = client.get(format!("{base}/jobs")).send().await.expect("jobs route");
@@ -314,9 +333,9 @@ async fn user_mode_workflow_shows_known_host_collect_and_local_save_defaults() {
     assert!(body.contains("id=\"collect-save-toggle\""));
     assert!(body.contains("Download Archive"));
     assert!(body.contains("id=\"upload-form\""));
-    assert!(body.contains(
-        "data-attr:disabled=\"$job.collect.mode === 'upload' && $job.collect.source === 'upload-file'\""
-    ));
+    assert!(
+        body.contains("data-attr:disabled=\"$job.collect.mode === 'upload' && $job.collect.source === 'upload-file'\"")
+    );
     assert!(body.contains("placeholder=\"/"));
 
     server.shutdown().await;
@@ -365,7 +384,9 @@ async fn advanced_page_embeds_send_target_disable_and_auto_save_rules() {
     assert!(body.contains("$job.send.mode = 'local'"));
     assert!(body.contains("Download the archive from&nbsp;<strong>Collect</strong>."));
     assert!(body.contains("$job.collect.source === 'known-host'"));
-    assert!(body.contains("$job.collect.mode === 'collect' && $job.collect.source === 'known-host' && $job.collect.known_host !== ''"));
+    assert!(body.contains(
+        "$job.collect.mode === 'collect' && $job.collect.source === 'known-host' && $job.collect.known_host !== ''"
+    ));
     assert!(body.contains("id=\"send-local-directory\""));
     assert!(body.contains("Local directory"));
     assert!(body.contains("id=\"job-go-button\""));


### PR DESCRIPTION
## Summary
- run cargo fmt across the workspace on top of current upstream/main
- normalize rustfmt wrapping in server, processor, build, and test files

## Tests
- cargo fmt --all -- --check
- cargo check