### PR TITLE
fix: make StoreSnapshot.repository_uuid optional

### DIFF
--- a/src/processor/elasticsearch/indices_settings/data.rs
+++ b/src/processor/elasticsearch/indices_settings/data.rs
@@ -64,11 +64,12 @@ pub struct StoreSettings {
     pub snapshot: Option<StoreSnapshot>,
 }
 
+#[skip_serializing_none]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct StoreSnapshot {
     pub snapshot_name: String,
     pub index_uuid: String,
-    pub repository_uuid: String,
+    pub repository_uuid: Option<String>,
     pub index_name: String,
     pub partial: Option<String>,
     pub repository_name: String,


### PR DESCRIPTION
## Summary

- `StoreSnapshot.repository_uuid` was a required `String`, causing a hard deserialization failure for any diagnostic bundle that contains non-searchable-snapshot indices (i.e. indices that have no `repository_uuid` in their store settings)
- Changed `repository_uuid: String` → `repository_uuid: Option<String>` and added `#[skip_serializing_none]` to `StoreSnapshot` so the field is omitted cleanly on serialization when absent
- Fixes ingestion of `settings/index` documents for clusters with mixed searchable-snapshot and standard indices

## Test plan

- [ ] Ingest a diagnostic bundle from a cluster with searchable snapshot indices — verify `repository_uuid` is populated as before
- [ ] Ingest a diagnostic bundle from a cluster without searchable snapshot indices — verify `settings/index` documents are ingested without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)