### PR TITLE
feat(onboarding): add interactive local setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ published release notes, maintenance branches, and tagged history.
 
 ### Added
 
+- Added interactive `esdiag init` onboarding for securely configuring a local diagnostic user, output deployment, collect hosts, and default saved job (#377).
 - Added a portable ESDiag Agent Skill for Claude Code, Codex, and OpenCode that owns its executable helpers and references. Analysis runs through the diagnostic skill installed on the Elastic deployment and remains available in Kibana Agent Builder conversation history for continued investigation.
 - Added a read-only binding workflow that validates Kibana Agent Builder access and direct Elasticsearch diagnostic-data access without creating a model call or throwaway conversation.
 - Added a cluster-review workflow that selects or collects a diagnostic, guides first-job setup when needed, streams the cluster agent's progress, and reports which diagnostic was analyzed.
@@ -25,6 +26,7 @@ published release notes, maintenance branches, and tagged history.
 - Changed saved hosts to distinguish target applications from Cloud routing and unresolved URL templates, with clearer validation for legacy host records (#366).
 - Changed finite CLI commands to emit typed YAML outcomes on stdout by default, with `--format json` available for interoperability; command failures now return safe structured results and document streams retain their NDJSON-only stdout contract.
 - Removed the Agent Skill's prose-output parser; first-run onboarding and the remaining native agent CLI helpers are delivered by their successor changes.
+- Changed omitted CLI output and diagnostic-user resolution to use saved non-secret application preferences after explicit command and environment configuration (#377).
 - Changed diagnostic platform fields to serialize stable hyphenated platform keys (#347).
 - Changed platform detection to identify Elastic Cloud Hosted bundles from a cluster license issued to `Elastic Cloud`, so API-only hosted bundles no longer report an unknown platform (#347).
 - Changed collection and processing source selection to use canonical registry keys and added a maintainer reconciliation utility for upstream support-diagnostics sources (#348).

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -130,7 +130,6 @@ order: an explicit command target, complete `ESDIAG_OUTPUT_*` plus
 combine endpoints or credentials from different sources. The existing
 desktop-only `settings.yml` remains unchanged; a later GUI onboarding flow will
 migrate it.
-- `ESDIAG_KIBANA_URL`: Kibana URL used by `serve`, processing metadata, and host-omitted setup flows
 - `ESDIAG_KIBANA_SPACE`: optional Kibana space appended to generated Kibana links
 - `ESDIAG_MODE`: runtime mode for `serve` when `--mode` is omitted; valid values are `user` and `service`
 - `ESDIAG_AUTH_PROVIDER`: authentication provider for `serve` when `--auth-provider` is omitted; valid values are `google-iap` and `none`

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -24,6 +24,7 @@ esdiag <command> --help
 - Configure and validate saved hosts with `esdiag host`
 - Manage encrypted credentials with `esdiag keystore`
 - Install Elasticsearch and Kibana assets with `esdiag setup`
+- Initialize a repeatable local diagnostic workflow with `esdiag init`
 - Collect fresh API diagnostics from a saved host with `esdiag collect`
 - Process diagnostic input into Elasticsearch documents with `esdiag process`
 - Run a local upload/UI service with `esdiag serve`
@@ -40,6 +41,7 @@ Commands:
   collect   Collect a diagnostic bundle from a known host's API endpoints, writes output to a directory
   serve     Start a web server to receive diagnostic bundle uploads
   host      Configure, test and save a remote host connection to `~/.esdiag/hosts.yml`
+  init      Interactively configure a repeatable local diagnostic workflow
   keystore  Manage encrypted secrets in the local keystore
   process   Receives a diagnostic from the input, processes it, and sends processed docs to the output
   upload    Upload a raw diagnostic archive to Elastic Upload Service
@@ -95,6 +97,7 @@ By default, `esdiag` stores local state under `~/.esdiag/`:
 
 - `hosts.yml`: saved host definitions
 - `secrets.yml`: encrypted keystore backing `--secret` references
+- `esdiag.yml`: non-secret CLI preferences, including the default user, output host, and saved job
 - `settings.yml`: saved UI/runtime settings such as active target selection
 - `last_run/`: debug artifacts from processing and related commands
 
@@ -113,6 +116,20 @@ These environment variables change where local state is read and written:
 - `ESDIAG_OUTPUT_APIKEY`: default output API key
 - `ESDIAG_OUTPUT_USERNAME`: default output username
 - `ESDIAG_OUTPUT_PASSWORD`: default output password
+- `ESDIAG_KIBANA_URL`: default Kibana viewer URL paired with an environment-defined output deployment
+
+`esdiag init` is terminal-only. It creates or unlocks the keystore, validates a
+linked Elasticsearch output and Kibana viewer, optionally installs output assets
+after confirmation, saves one or more collect hosts, and creates a default saved
+job. Credentials are entered without echo and are stored only in `secrets.yml`;
+`esdiag.yml` retains names and preferences, never credential material.
+
+When an output is omitted, ESDiag resolves one complete deployment in this
+order: an explicit command target, complete `ESDIAG_OUTPUT_*` plus
+`ESDIAG_KIBANA_URL` environment configuration, then `esdiag.yml`. It does not
+combine endpoints or credentials from different sources. The existing
+desktop-only `settings.yml` remains unchanged; a later GUI onboarding flow will
+migrate it.
 - `ESDIAG_KIBANA_URL`: Kibana URL used by `serve`, processing metadata, and host-omitted setup flows
 - `ESDIAG_KIBANA_SPACE`: optional Kibana space appended to generated Kibana links
 - `ESDIAG_MODE`: runtime mode for `serve` when `--mode` is omitted; valid values are `user` and `service`

--- a/docs/repository/organization.md
+++ b/docs/repository/organization.md
@@ -63,6 +63,7 @@ src/
 ├── job.rs
 ├── lib.rs
 ├── main.rs
+├── onboarding.rs
 ├── setup.rs
 └── uploader.rs
 ```
@@ -83,5 +84,6 @@ src/
 - `src/setup.rs`: Asset installation logic for Elasticsearch and Kibana setup flows.
 - `src/uploader.rs`: Upload logic for sending collected archives to the Elastic Upload Service.
 - `src/job.rs`: Saved job execution and management helpers.
+- `src/onboarding.rs`: Flow-neutral first-run configuration, persistence, and readiness operations shared by terminal and future GUI flows.
 - `src/env.rs`: Environment-variable defaults and lookup helpers.
 - `src/embeds.rs`: Embedded static asset wiring used by the application.

--- a/openspec/changes/add-first-run-onboarding/design.md
+++ b/openspec/changes/add-first-run-onboarding/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-Local ESDiag state is currently split across `hosts.yml`, `secrets.yml`, `jobs.yml`, unlock state, and a two-field `settings.yml` used primarily by desktop/user-mode server startup. There is no first-run command and no general persistent preference model. The Agent Skill consequently tries to detect and assemble missing state itself, which puts credential handling and application onboarding in prompt instructions.
+Local ESDiag state is currently split across `hosts.yml`, `secrets.yml`, `jobs.yml`, unlock state, and a two-field `settings.yml` used by desktop/user-mode server startup. There is no CLI first-run command or general persistent preference model. The Agent Skill consequently tries to detect and assemble missing state itself, which puts credential handling and CLI onboarding in prompt instructions.
 
 The existing domain model already separates concerns correctly. `KnownHost` stores non-secret endpoint metadata and a secret reference, the keystore owns authentication material, `SavedJobs` references known hosts, a send-role Elasticsearch host can identify its view-role Kibana host through `viewer`, and `Identifiers` already honors an explicit `--user` and `ESDIAG_USER`. Initialization should compose those models, not replace them.
 
@@ -10,12 +10,11 @@ The runtime environment also already represents one output deployment: `ESDIAG_O
 
 **Goals:**
 
-- Give a newly installed local user one secure, guided path to a successful repeatable workflow.
+- Give a newly installed CLI user one secure, terminal-guided path to a successful repeatable workflow.
 - Persist only non-secret preferences and references in one general `esdiag.yml` file.
 - Reuse `KnownHost`, viewer links, keystore secrets, saved jobs, and existing clients in process.
-- Resolve one canonical output deployment consistently across CLI, desktop, web user mode, and future Agent Builder commands.
+- Resolve one canonical output deployment consistently across CLI commands while exposing a reusable backend resolver for future GUI and Agent Builder consumers.
 - Default diagnostic user identifiers from persisted configuration after explicit CLI and environment values.
-- Offer installation of the running binary's version-matched ESDiag skill without making agent presence a prerequisite for initialization.
 - Make initialization resumable, idempotent, and safe around existing files.
 - Keep agents out of secret collection by making credential entry a terminal-native interaction.
 
@@ -29,6 +28,10 @@ The runtime environment also already represents one output deployment: `ESDIAG_O
 - Providing a non-interactive bootstrap language in the first iteration; existing commands and environment variables remain available for automation.
 - Performing Agent Builder conversations or diagnostic analysis.
 - Downloading agent skills or requiring any supported coding agent to be installed.
+- Providing a web or desktop onboarding flow.
+- Changing web/desktop user-mode startup, settings persistence, or service-mode behavior.
+- Migrating or removing the legacy desktop `settings.yml`; the GUI onboarding follow-on owns that transition.
+- Installing or managing coding-agent skills; the agent CLI change owns that command surface and behavior.
 
 ## Decisions
 
@@ -39,21 +42,25 @@ Introduce a versioned `ApplicationConfig` stored at `~/.esdiag/esdiag.yml`:
 ```yaml
 version: 1
 user: reno@example.com
-output: diagnostic-output
-default_job: production-standard
+output:
+  default: diagnostic-output
+  authenticated_on: "2026-08-12T20:00:00Z"
+  assets_version: "0.17.0-SNAPSHOT"
+job:
+  default: production-standard
 ```
 
-`output` names a saved Elasticsearch host with role `send`; that host's `viewer` names the saved Kibana host with role `view`. `default_job` names an entry in `jobs.yml`. Authentication remains a secret reference in each host and encrypted material remains in `secrets.yml`. The output Elasticsearch and Kibana hosts may share one secret identifier when they use the same credentials.
+`output.default` names a saved Elasticsearch host with role `send`; that host's `viewer` names the saved Kibana host with role `view`. `output.authenticated_on` records successful endpoint authentication, and `output.assets_version` records the ESDiag asset version after setup. `job.default` names an entry in `jobs.yml`. Authentication remains a secret reference in each host and encrypted material remains in `secrets.yml`. The output Elasticsearch and Kibana hosts may share one secret identifier when they use the same credentials.
 
 This makes configuration a small preference layer rather than a second inventory. Alternative considered: store both URLs and credentials in `esdiag.yml`. That duplicates `KnownHost`, creates another secret surface, and allows configuration to drift.
 
-### Replace, rather than supplement, desktop settings
+### Defer desktop settings migration to GUI onboarding
 
-Do not create `esdiag.yml` alongside a permanently supported `settings.yml`. On first user-mode load or `esdiag init`, inspect legacy `settings.yml` and migrate representable preferences into `ApplicationConfig`. Preserve a backup until the new file has been written and validated.
+This change adds `esdiag.yml` for CLI preferences without changing how existing web/desktop user mode reads or writes `settings.yml`. `esdiag init` does not delete, rewrite, or claim to migrate the desktop settings file. This temporary coexistence is an explicit sequencing boundary, not a permanent two-configuration design.
 
-An `active_target` that names a valid send host becomes `output`. A legacy `kibana_url` is representable only when it matches the selected send host's viewer; otherwise initialization asks the user to create or select the corresponding view host before completing migration. Ordinary startup reports an actionable migration error instead of silently pairing unrelated endpoints. Service mode neither reads nor writes either local file.
+The follow-on GUI onboarding change will use the same `ApplicationConfig` and `OutputDeployment` services, define how representable `active_target` and `kibana_url` values migrate, preserve a backup, and remove the legacy write path only after user-mode compatibility is covered. Until then, CLI output selection comes from explicit arguments, a complete environment deployment, or `esdiag.yml`; it does not infer preferences from `settings.yml`.
 
-Alternative considered: extend `settings.yml` indefinitely. Its name and current desktop-only shape obscure that the values affect all local CLI workflows, and retaining both names creates precedence ambiguity.
+Alternative considered: migrate desktop settings as part of CLI onboarding. That would change UI startup and persistence behavior without specifying the GUI onboarding experience, preventing the two flows from being reviewed and delivered independently.
 
 ### Resolve the output deployment as one atomic value
 
@@ -61,7 +68,7 @@ Add a shared `OutputDeployment` resolver that yields an Elasticsearch host, its 
 
 1. An explicit command target.
 2. A complete runtime environment deployment beginning with `ESDIAG_OUTPUT_URL`, with `ESDIAG_KIBANA_URL` required by operations that need Kibana.
-3. The `ApplicationConfig.output` saved-host reference.
+3. The `ApplicationConfig.output.default` saved-host reference.
 4. A configuration error.
 
 Once a source wins, all endpoints and credentials come from that source. A partial environment deployment fails closed; it is never completed with a saved host or preference from another deployment. `ESDIAG_OUTPUT_APIKEY` or the existing output username/password pair authenticates both environment-backed Elasticsearch and Kibana. No analysis-specific Elasticsearch URL or Kibana credential variables are introduced.
@@ -79,13 +86,12 @@ InspectExisting
     -> OutputDeployment
     -> CollectionHosts
     -> DefaultJob
-    -> AgentSkills
     -> Complete
 ```
 
-Each transition validates its resulting domain object before persisting it. Completed stages are detected on the next run and offered for reuse or explicit replacement. Files are written atomically where their existing APIs support it; initialization never shells out to another `esdiag` process.
+Each transition validates its resulting domain object before persisting it. Completed stages are detected on the next run and offered for reuse or explicit replacement. Files are written atomically where their existing APIs support it; initialization never shells out to another `esdiag` process. Stage services accept typed inputs and return typed results without terminal prompting so the follow-on GUI can compose the same backend operations.
 
-The wizard persists independently valid stages rather than attempting a transaction across four files. An interruption can therefore leave a valid keystore or host without falsely marking initialization complete. `ApplicationConfig` is written last and acts as the completion record.
+The wizard persists independently valid stages rather than attempting a transaction across four files. An interruption can therefore leave a valid keystore or host without falsely marking initialization complete. `ApplicationConfig` fields are written as their corresponding validated stages complete, but file existence alone is not a completion marker: readiness is derived from its required references and the referenced domain state. This keeps completion semantics independent of whether the CLI or a future GUI writes the shared configuration.
 
 ### Keep credential entry on the controlling terminal
 
@@ -110,7 +116,7 @@ Alternative considered: add a new deployment inventory type. The existing host-r
 
 After the output deployment is usable, initialization creates or selects at least one collect-role host, offers a loop for additional hosts, and builds the first saved job through the existing typed job model. The default successful path creates a processing job whose output is the configured send host, so running it produces indexed data rather than only a local archive. The user may explicitly select a collect-only job instead.
 
-The selected job name is stored as `default_job`; the job body remains solely in `jobs.yml`. Initialization may finish without additional hosts beyond the first, but it does not claim a repeatable diagnostic workflow is ready without a valid default job.
+The selected job name is stored as `job.default`; the job body remains solely in `jobs.yml`. Initialization may finish without additional hosts beyond the first, but it does not claim a repeatable diagnostic workflow is ready without a valid default job.
 
 ### Apply identifier precedence explicitly
 
@@ -122,42 +128,27 @@ Default user resolution becomes:
 
 The configured user is copied into the normal `Identifiers` value at workflow construction time. No global mutable environment value is synthesized.
 
-### Keep onboarding guidance separate from normal skill use
-
-Add `references/onboarding.md` to the canonical skill and generated packages. The main skill routes explicit first-install/configuration requests and missing-configuration failures to that reference. The reference explains the stages and asks the human to run `esdiag init` locally; it does not reproduce commands for writing secrets or files manually.
-
-### Offer embedded agent skill installation without gating success
-
-After the diagnostic workflow is configured, `init` asks whether to detect and install the embedded ESDiag skill for supported local coding agents. The stage calls the same in-process target detection and installation service exposed by `esdiag agent skills`; it does not spawn another ESDiag process, download a plugin, or duplicate path logic.
-
-The wizard shows detected targets and lets the user accept, select explicit additional targets, or decline. Declining completes initialization normally. A conflict or installation failure is recorded in the final outcome and gives the standalone recovery command, but it does not invalidate the already configured keystore, output deployment, hosts, or job. No skill-installation preference or target path is persisted in `esdiag.yml`; installed files and their ownership markers are the authoritative state.
-
-Alternative considered: install automatically whenever an agent is detected. Writing into multiple agent homes is a separate user-visible mutation and should remain opt-in even inside an onboarding wizard.
-
 ## Risks / Trade-offs
 
 - **Cross-file interruption leaves partial state** → Persist only independently valid stages, detect them on rerun, and write the completion configuration last.
-- **Legacy `kibana_url` cannot always be mapped automatically** → Require an explicit viewer selection during migration and preserve a backup until completion.
 - **Environment and saved configuration could identify different deployments** → Select one complete source atomically and fail on partial environment configuration.
 - **Initialization becomes a large interactive workflow** → Keep each stage backed by existing domain APIs and make the stage boundaries independently testable.
 - **Setup may require elevated cluster privileges or a license** → Validate first, ask explicitly before setup, and distinguish configured endpoints from provisioned assets.
 - **A shared API key might not be valid for both products** → Test both clients and allow explicitly selected distinct existing secret references while keeping shared credentials the default.
-- **Changing the settings filename affects desktop startup** → Provide one-time migration with backup and compatibility tests; do not silently discard unrepresentable values.
-- **Optional skill installation can fail after core initialization succeeds** → Keep it as a non-gating final stage, preserve per-target results, and provide `esdiag agent skills` as a resumable standalone action.
+- **`esdiag.yml` and legacy desktop `settings.yml` temporarily coexist** → Keep their consumers isolated in this change and make consolidation an explicit requirement of the GUI onboarding follow-on.
 
 ## Migration Plan
 
-1. Add `ApplicationConfig`, path resolution, atomic serialization, and validation without changing consumers.
-2. Add legacy `Settings` import and backup behavior with fixtures for representable and ambiguous configurations.
-3. Add atomic `OutputDeployment` resolution and migrate omitted-output CLI and user-mode consumers.
-4. Add persisted default-user resolution to identifier construction.
-5. Implement and test the staged `esdiag init` workflow using existing keystore, host, client, setup, job, and embedded-skill installer APIs.
-6. Update desktop/web user-mode settings to write `esdiag.yml`; retain service-mode isolation.
-7. Add and package `references/onboarding.md`, then update documentation and changelog.
-8. Remove legacy `settings.yml` writes after migration coverage passes.
+1. Add `ApplicationConfig`, path resolution, atomic serialization, and validation without changing web/desktop consumers.
+2. Add atomic `OutputDeployment` resolution and migrate omitted-output CLI consumers.
+3. Add persisted default-user resolution to identifier construction.
+4. Extract flow-neutral backend operations for configuration, credentials, hosts, jobs, endpoint validation, setup, and readiness.
+5. Implement and test the terminal-specific staged `esdiag init` orchestration over those operations.
+6. Update CLI and configuration documentation and the changelog.
+7. Leave web/desktop settings behavior unchanged for the GUI onboarding follow-on.
 
-Rollback restores the backed-up `settings.yml` and leaves `hosts.yml`, `secrets.yml`, and `jobs.yml` unchanged. `esdiag.yml` contains no secrets and can be ignored safely by older releases.
+Rollback leaves `settings.yml`, `hosts.yml`, `secrets.yml`, and `jobs.yml` unchanged. `esdiag.yml` contains no secrets and can be ignored safely by older releases.
 
 ## Open Questions
 
-None. Asset setup and agent skill installation are explicit offers rather than automatic initialization side effects, and the first version is intentionally interactive.
+None. Asset setup is an explicit offer rather than an automatic initialization side effect, and the first version is intentionally interactive.

--- a/openspec/changes/add-first-run-onboarding/proposal.md
+++ b/openspec/changes/add-first-run-onboarding/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-ESDiag persists hosts, secrets, jobs, and a small desktop-only settings record, but a newly installed user must discover and assemble those pieces manually. A first-run workflow and one general application configuration file can establish a secure, repeatable diagnostic workflow without moving credential entry or setup orchestration into an Agent Skill.
+ESDiag persists hosts, secrets, and jobs, but a newly installed CLI user must discover and assemble those pieces manually. A terminal-native first-run workflow and one general application configuration file can establish a secure, repeatable diagnostic workflow without moving credential entry or setup orchestration into an Agent Skill.
 
 ## What Changes
 
@@ -9,11 +9,9 @@ ESDiag persists hosts, secrets, jobs, and a small desktop-only settings record, 
 - Create or unlock the encrypted keystore through terminal-native secret prompts that do not expose credentials to an agent conversation or structured output.
 - Configure and validate the diagnostic output deployment as one Elasticsearch send host linked to one Kibana view host, sharing one keystore secret when their authentication is the same.
 - Create the first collect host, optionally add more collect hosts, and configure the first saved collection or processing job.
-- Optionally detect supported local coding agents and install the version-matched ESDiag skill embedded in the running binary through `esdiag agent skills`.
 - Introduce `~/.esdiag/esdiag.yml` as the general non-secret application configuration containing preference values and references such as the default user, output host, and saved job.
-- **BREAKING** Migrate user-mode settings from the narrow `settings.yml` record to `esdiag.yml`; do not retain two competing application configuration files.
 - Keep `ESDIAG_OUTPUT_*` and `ESDIAG_KIBANA_URL` as runtime/deployment overrides for the same output deployment, with shared output credentials, rather than creating analysis-specific URL or credential variables.
-- Add `references/onboarding.md` to the portable ESDiag skill so agents direct first-time users to the secure local wizard instead of collecting secrets or reconstructing setup in prompts.
+- Expose the configuration, deployment, credential, host, job, validation, and setup operations as flow-neutral backend services that a follow-on GUI onboarding flow can reuse.
 
 ## Capabilities
 
@@ -24,14 +22,13 @@ ESDiag persists hosts, secrets, jobs, and a small desktop-only settings record, 
 
 ### Modified Capabilities
 
-- `desktop-settings`: Store user-mode preferences in the common application configuration and resolve the same active output deployment as the CLI.
 - `collection-identifiers`: Use the persisted default user when an invocation does not provide a user through CLI or environment configuration.
 
 ## Impact
 
 - **Target Elastic products:** Initialization configures Elasticsearch as the processed-diagnostic destination and its attached Kibana instance; source hosts may be Elasticsearch, Kibana, or Logstash according to existing collection support.
-- **CLI:** Adds `esdiag init` and a shared configuration resolver used by normal CLI commands. Initialization may compose the native `esdiag agent skills` library operation in process as an optional stage. Interactive prompts remain human-oriented, while the final initialization result follows the standard structured CLI outcome contract when that change is available.
-- **Local state:** Adds `~/.esdiag/esdiag.yml`, migrates `settings.yml`, and composes existing `hosts.yml`, `secrets.yml`, and `jobs.yml` rather than duplicating their contents.
-- **Web UI/Desktop:** User mode reads and updates the common output preference. Service mode remains environment-driven and does not gain local credential persistence.
+- **CLI:** Adds `esdiag init` and a shared configuration resolver used by normal CLI commands. Interactive prompts remain human-oriented, while the final initialization result follows the standard structured CLI outcome contract when that change is available.
+- **Local state:** Adds `~/.esdiag/esdiag.yml` and composes existing `hosts.yml`, `secrets.yml`, and `jobs.yml` rather than duplicating their contents. Existing `settings.yml` behavior is unchanged until the GUI onboarding follow-on.
+- **Web UI/Desktop:** No onboarding or settings-flow behavior changes in this change. A follow-on GUI change will reuse the same backend services and define user-mode migration; service mode remains environment-driven.
 - **Core processing:** Identifier defaulting and omitted-output resolution gain configuration fallbacks; collection and processing behavior otherwise remains unchanged.
-- **Agent assets:** Adds onboarding reference documentation and an optional embedded-skill installation offer. Agents never receive keystore passwords, API keys, or other terminal-entered secrets.
+- **Agent CLI:** Agent skill installation and its command surface are out of scope and will be delivered by the agent CLI change.

--- a/openspec/changes/add-first-run-onboarding/specs/application-configuration/spec.md
+++ b/openspec/changes/add-first-run-onboarding/specs/application-configuration/spec.md
@@ -1,12 +1,13 @@
 ## ADDED Requirements
 
 ### Requirement: General Application Configuration
-The system SHALL persist local non-secret preferences in a versioned `~/.esdiag/esdiag.yml` file. The configuration SHALL contain a default user identifier, output-host reference, and default saved-job reference when configured, and MUST NOT contain endpoint credentials, decrypted secrets, authorization headers, or embedded host and job definitions.
+The system SHALL persist local non-secret preferences in a versioned `~/.esdiag/esdiag.yml` file. The configuration SHALL contain `user`, an `output` section with `default`, `authenticated_on`, and `assets_version` when applicable, and a `job` section with `default` when configured. `output.default` SHALL be the output-host reference, and `job.default` SHALL be the default saved-job reference. The configuration MUST NOT contain endpoint credentials, decrypted secrets, authorization headers, or embedded host and job definitions.
 
 #### Scenario: Configuration contains references only
 - **GIVEN** initialization configured an output deployment and default saved job
 - **WHEN** `esdiag.yml` is serialized
-- **THEN** it contains the output host name and default job name
+- **THEN** it contains the output host name at `output.default` and default job name at `job.default`
+- **AND** successful endpoint authentication and asset setup are recorded, when applicable, at `output.authenticated_on` and `output.assets_version`
 - **AND** the referenced host and job bodies remain in `hosts.yml` and `jobs.yml`
 - **AND** credential material remains only in `secrets.yml`
 
@@ -17,7 +18,7 @@ The system SHALL persist local non-secret preferences in a versioned `~/.esdiag/
 - **AND** no configuration file is rewritten
 
 ### Requirement: Canonical Output Deployment Resolution
-The system SHALL resolve the processed-diagnostic output as one atomic deployment containing an Elasticsearch send target, its Kibana view target when required, and authentication from the same configuration source. Resolution precedence SHALL be explicit command target, complete `ESDIAG_OUTPUT_*` and `ESDIAG_KIBANA_URL` runtime configuration, persisted output-host reference, then configuration failure.
+The system SHALL resolve the processed-diagnostic output as one atomic deployment containing an Elasticsearch send target, its Kibana view target when required, and authentication from the same configuration source. Resolution precedence SHALL be explicit command target, complete `ESDIAG_OUTPUT_*` and `ESDIAG_KIBANA_URL` runtime configuration, the persisted `output.default` host reference, then configuration failure.
 
 #### Scenario: Runtime deployment overrides persisted output
 - **GIVEN** `esdiag.yml` references a saved output host
@@ -49,19 +50,3 @@ Environment-backed output configuration SHALL use `ESDIAG_OUTPUT_APIKEY` or the 
 - **WHEN** the output deployment constructs its Elasticsearch and Kibana clients
 - **THEN** both clients use the configured output API key
 - **AND** no duplicate Kibana credential is required
-
-### Requirement: Legacy Settings Migration
-User mode SHALL migrate representable preferences from legacy `settings.yml` into `esdiag.yml` and SHALL stop writing `settings.yml` after successful migration. It SHALL preserve a backup until the new configuration validates and MUST require explicit resolution when a legacy Kibana URL cannot be associated with the selected output host's viewer.
-
-#### Scenario: Representable settings migrate
-- **GIVEN** `settings.yml` names a valid send host whose linked viewer matches its Kibana URL
-- **AND** `esdiag.yml` does not exist
-- **WHEN** local application configuration loads
-- **THEN** the active target is migrated to the output reference in `esdiag.yml`
-- **AND** the new configuration is validated before legacy writes stop
-
-#### Scenario: Ambiguous Kibana URL requires initialization
-- **GIVEN** legacy `settings.yml` contains a Kibana URL unrelated to the active send host's viewer
-- **WHEN** migration is attempted
-- **THEN** the system preserves the legacy file and reports that viewer selection is required
-- **AND** it does not silently pair endpoints from different deployments

--- a/openspec/changes/add-first-run-onboarding/specs/cli-first-run-onboarding/spec.md
+++ b/openspec/changes/add-first-run-onboarding/specs/cli-first-run-onboarding/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Interactive First-Run Workflow
-The CLI SHALL provide `esdiag init` as an interactive staged workflow covering default user identity, keystore creation or unlock, output deployment configuration, the first collect host, optional additional collect hosts, the first saved job, and an optional agent-skill installation offer. The workflow SHALL use in-process domain APIs and MUST NOT invoke another `esdiag` process or an external helper executable.
+The CLI SHALL provide `esdiag init` as an interactive staged workflow covering default user identity, keystore creation or unlock, output deployment configuration, the first collect host, optional additional collect hosts, and the first saved job. The workflow SHALL use in-process domain APIs and MUST NOT invoke another `esdiag` process or an external helper executable.
 
 #### Scenario: New user completes initialization
 - **GIVEN** no ESDiag local state exists
@@ -90,33 +90,3 @@ Initialization SHALL create or select a valid first saved job after at least one
 - **THEN** initialization identifies that the job produces an archive rather than indexed diagnostic data
 - **AND** persists it only after explicit confirmation
 
-### Requirement: Embedded Agent Skill Installation Is Optional
-After the required diagnostic workflow stages validate, initialization SHALL offer to detect supported coding agents and install the running binary's embedded version-matched ESDiag skill using the same in-process service as `esdiag agent skills`. It MUST NOT install without user approval, download skill content, duplicate agent path logic, or make successful skill installation a prerequisite for valid ESDiag configuration.
-
-#### Scenario: User accepts detected skill targets
-- **GIVEN** initialization has configured the default saved job
-- **AND** one or more supported agent homes are detected
-- **WHEN** the user approves skill installation
-- **THEN** the embedded skill installer processes the selected targets
-- **AND** the initialization result includes each target action and reload guidance
-
-#### Scenario: User declines skill installation
-- **WHEN** the user declines the optional agent-skill stage
-- **THEN** initialization completes successfully without modifying any agent home
-- **AND** reports `esdiag agent skills` as the later standalone installation command
-
-#### Scenario: Skill installation fails after configuration
-- **GIVEN** all required ESDiag configuration stages completed
-- **WHEN** one selected agent target conflicts or cannot be written
-- **THEN** the configured identity, keystore, output deployment, hosts, and job remain valid
-- **AND** initialization reports the per-target failure and standalone recovery command
-- **AND** does not claim that the core ESDiag configuration failed
-
-### Requirement: Skill Onboarding Is A Local Handoff
-The portable ESDiag skill SHALL include `references/onboarding.md` and SHALL direct first-install or missing-configuration cases to a human-run `esdiag init`. The onboarding reference SHALL also identify `esdiag agent skills` as the standalone offline installer for the skill embedded in the binary. The skill MUST NOT reproduce secret-entry steps, manually write ESDiag state files, or request that credentials be pasted into an agent conversation.
-
-#### Scenario: Agent encounters an uninitialized installation
-- **WHEN** normal skill use receives a structured missing-configuration outcome
-- **THEN** the skill explains that first-run initialization is required
-- **AND** directs the user to run `esdiag init` locally
-- **AND** does not ask for a password or API key

--- a/openspec/changes/add-first-run-onboarding/specs/cli-first-run-onboarding/spec.md
+++ b/openspec/changes/add-first-run-onboarding/specs/cli-first-run-onboarding/spec.md
@@ -16,7 +16,7 @@ The CLI SHALL provide `esdiag init` as an interactive staged workflow covering d
 - **AND** the user can finish the loop without adding another host
 
 ### Requirement: Initialization Is Resumable And Non-Destructive
-Initialization SHALL inspect existing state before each stage, reuse valid completed state by default, and require explicit confirmation before replacing a configured user preference, host, secret, or saved job. It SHALL persist only validated domain values and SHALL write `esdiag.yml` last as the completion record.
+Initialization SHALL inspect existing state before each stage, reuse valid completed state by default, and require explicit confirmation before replacing a configured user preference, host, secret, or saved job. It SHALL persist only validated domain values and SHALL write each applicable `esdiag.yml` field after its corresponding stage validates. Initialization readiness SHALL be derived from validated configuration references and referenced domain state, not from configuration-file existence alone.
 
 #### Scenario: Interrupted initialization resumes
 - **GIVEN** a prior initialization created the keystore and output hosts but stopped before creating a job
@@ -83,7 +83,7 @@ Initialization SHALL create or select a valid first saved job after at least one
 - **WHEN** the user accepts the default job shape
 - **THEN** the saved job collects from the selected collect host
 - **AND** processes to the configured output host
-- **AND** its name becomes `default_job` in `esdiag.yml`
+- **AND** its name becomes `job.default` in `esdiag.yml`
 
 #### Scenario: Collect-only job is explicit
 - **WHEN** the user selects a collect-only first job

--- a/openspec/changes/add-first-run-onboarding/tasks.md
+++ b/openspec/changes/add-first-run-onboarding/tasks.md
@@ -1,43 +1,41 @@
 ## 1. Application Configuration Foundation
 
-- [ ] 1.1 Add a versioned `ApplicationConfig` model for `user`, output-host reference, and default-job reference with atomic `esdiag.yml` load/save behavior under the ESDiag state directory.
-- [ ] 1.2 Add validation that referenced output hosts and jobs exist, output hosts have role `send`, and output viewers resolve to role-`view` Kibana hosts without loading secret values into configuration.
-- [ ] 1.3 Add fixtures proving configuration round trips, rejects unknown versions and invalid references, and never serializes credential material.
-- [ ] 1.4 Implement legacy `settings.yml` import, backup, representable migration, and explicit ambiguous-viewer failure without retaining a second write path.
+- [x] 1.1 Add a versioned `ApplicationConfig` model for `user`, `output.default` output-host reference, `output.authenticated_on` and `output.assets_version` metadata, and `job.default` saved-job reference with atomic `esdiag.yml` load/save behavior under the ESDiag state directory.
+- [x] 1.2 Add validation that referenced output hosts and jobs exist, output hosts have role `send`, and output viewers resolve to role-`view` Kibana hosts without loading secret values into configuration.
+- [x] 1.3 Add fixtures proving configuration round trips, rejects unknown versions and invalid references, and never serializes credential material.
+- [x] 1.4 Keep existing web/desktop `settings.yml` reads and writes unchanged and prove CLI configuration loading does not mutate or infer preferences from that file.
 
 ## 2. Canonical Output Deployment
 
-- [ ] 2.1 Implement an atomic `OutputDeployment` resolver for explicit targets, complete environment deployments, and persisted output references in the specified precedence order.
-- [ ] 2.2 Reuse `ESDIAG_OUTPUT_*` authentication for both environment-backed Elasticsearch and Kibana clients and remove any need for analysis-specific credential resolution.
-- [ ] 2.3 Add resolution tests for explicit, environment, and persisted sources, including partial-environment failure and prevention of cross-source endpoint mixing.
-- [ ] 2.4 Migrate omitted-output CLI and user-mode server/desktop startup paths to the shared resolver while preserving service-mode isolation.
+- [x] 2.1 Implement an atomic `OutputDeployment` resolver for explicit targets, complete environment deployments, and persisted output references in the specified precedence order.
+- [x] 2.2 Reuse `ESDIAG_OUTPUT_*` authentication for both environment-backed Elasticsearch and Kibana clients and remove any need for analysis-specific credential resolution.
+- [x] 2.3 Add resolution tests for explicit, environment, and persisted sources, including partial-environment failure and prevention of cross-source endpoint mixing.
+- [x] 2.4 Migrate omitted-output CLI paths to the shared resolver without changing user-mode server/desktop startup or service-mode behavior.
 
 ## 3. Identity And Existing State Integration
 
-- [ ] 3.1 Apply `--user`, `ESDIAG_USER`, then `ApplicationConfig.user` precedence when constructing collection and processing identifiers.
-- [ ] 3.2 Update user-mode settings reads and writes to use `esdiag.yml` output references and validate runtime exporter updates through the canonical deployment model.
-- [ ] 3.3 Add compatibility tests for desktop restart, CLI omitted-output reuse, service-mode non-persistence, and identifier precedence.
+- [x] 3.1 Apply `--user`, `ESDIAG_USER`, then `ApplicationConfig.user` precedence when constructing collection and processing identifiers.
+- [x] 3.2 Expose flow-neutral typed services for configuration, deployment resolution, credential storage, host/job persistence, endpoint validation, setup, and readiness without embedding terminal prompts.
+- [x] 3.3 Add tests for CLI omitted-output reuse, identifier precedence, and direct backend-service use independent of CLI presentation.
 
 ## 4. Initialization State Machine
 
-- [ ] 4.1 Add the `esdiag init` Clap surface and explicit inspect, identity, keystore, output, collection-host, default-job, optional agent-skills, and complete stages.
-- [ ] 4.2 Implement resumable existing-state inspection and explicit replacement confirmations, writing `ApplicationConfig` only after required stages validate.
-- [ ] 4.3 Implement hidden controlling-terminal prompts for keystore passwords and host credentials using existing keystore APIs, including non-TTY failure behavior and redaction tests.
-- [ ] 4.4 Implement output deployment creation/selection as a send-role Elasticsearch host linked to a view-role Kibana host, with shared-secret default and existing distinct-secret selection.
-- [ ] 4.5 Validate both output clients, inspect required ESDiag assets, and offer the existing setup operation only after explicit approval.
-- [ ] 4.6 Implement the repeatable collect-host loop and first saved-job creation, defaulting to `Collect` plus `Process` with the configured send-role Elasticsearch host as its export target while retaining explicit collect-and-save-only selection.
-- [ ] 4.7 Emit the standard safe initialization outcome when structured CLI output is available and add interrupted/resumed end-to-end wizard tests.
-- [ ] 4.8 Compose the embedded skill installer in process, present detected and explicit target choices, keep decline/failure non-gating, and include per-target results plus standalone recovery guidance.
+- [x] 4.1 Add the `esdiag init` Clap surface and explicit inspect, identity, keystore, output, collection-host, default-job, and complete stages.
+- [x] 4.2 Implement resumable existing-state inspection and explicit replacement confirmations, writing `ApplicationConfig` only after required stages validate and deriving readiness from validated references rather than file existence.
+- [x] 4.3 Implement hidden controlling-terminal prompts for keystore passwords and host credentials using existing keystore APIs, including non-TTY failure behavior and redaction tests.
+- [x] 4.4 Implement output deployment creation/selection as a send-role Elasticsearch host linked to a view-role Kibana host, with shared-secret default and existing distinct-secret selection.
+- [x] 4.5 Validate both output clients, inspect required ESDiag assets, and offer the existing setup operation only after explicit approval.
+- [x] 4.6 Implement the repeatable collect-host loop and first saved-job creation, defaulting to `Collect` plus `Process` with the configured send-role Elasticsearch host as its export target while retaining explicit collect-and-save-only selection.
+- [x] 4.7 Emit the standard safe initialization outcome when structured CLI output is available and add interrupted/resumed end-to-end wizard tests.
 
-## 5. Documentation And Agent Handoff
+## 5. Documentation
 
-- [ ] 5.1 Add `.agents/skills/esdiag/references/onboarding.md` covering the local `esdiag init` handoff and standalone offline `esdiag agent skills` installation without secret-entry commands or manual state-file edits.
-- [ ] 5.2 Update `SKILL.md`, generated plugin assets, CLI documentation, configuration documentation, and repository organization references for `esdiag.yml` and the initialization workflow.
-- [ ] 5.3 Update `CHANGELOG.md` using the repository changelog skill and add migration guidance from `settings.yml`.
+- [x] 5.1 Update CLI documentation, configuration documentation, and repository organization references for `esdiag.yml`, the initialization workflow, and the unchanged desktop settings boundary.
+- [x] 5.2 Update `CHANGELOG.md` using the repository changelog skill without claiming that web/desktop onboarding or `settings.yml` migration is included.
 
 ## 6. Verification
 
-- [ ] 6.1 Run formatting and targeted configuration, host, keystore, settings, identifier, saved-job, optional skill-installation, and initialization tests.
-- [ ] 6.2 Run `cargo clippy --all-targets --all-features -- -D warnings`.
-- [ ] 6.3 Run `cargo test --all-features`.
-- [ ] 6.4 Validate the generated portable skill and run strict OpenSpec validation for `add-first-run-onboarding`.
+- [x] 6.1 Run formatting and targeted configuration, host, keystore, identifier, saved-job, backend-service, and initialization tests.
+- [x] 6.2 Run `cargo clippy --all-targets --all-features -- -D warnings`.
+- [x] 6.3 Run `cargo test --all-features`.
+- [x] 6.4 Run strict OpenSpec validation for `add-first-run-onboarding`.

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -109,6 +109,12 @@ pub enum CliOutcome {
     JobDeleted {
         name: String,
     },
+    InitializationCompleted {
+        user: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        output: Option<String>,
+        job: String,
+    },
     SetupCompleted {
         targets: Vec<String>,
     },

--- a/src/data/application_config.rs
+++ b/src/data/application_config.rs
@@ -143,7 +143,7 @@ impl ApplicationConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::ApplicationConfig;
+    use super::{ApplicationConfig, JobConfig, OutputConfig};
     use crate::data::{Application, HostRole, KnownHostBuilder};
     use std::collections::BTreeMap;
     use url::Url;
@@ -172,8 +172,13 @@ mod tests {
         let config = ApplicationConfig {
             version: 1,
             user: Some("reno@example.com".to_string()),
-            default_diagnostics_cluster: Some("output-elasticsearch".to_string()),
-            default_job: Some("production-standard".to_string()),
+            output: OutputConfig {
+                default: Some("output-elasticsearch".to_string()),
+                ..OutputConfig::default()
+            },
+            job: JobConfig {
+                default: Some("production-standard".to_string()),
+            },
         };
 
         config.save().expect("save configuration");
@@ -181,8 +186,8 @@ mod tests {
         let loaded = ApplicationConfig::load().expect("load configuration");
 
         assert_eq!(loaded, config);
-        assert!(written.contains("default_diagnostics_cluster: output-elasticsearch"));
-        assert!(written.contains("default_job: production-standard"));
+        assert!(written.contains("default: output-elasticsearch"));
+        assert!(written.contains("default: production-standard"));
         for forbidden in ["apikey", "password", "authorization", "https://es.example"] {
             assert!(!written.contains(forbidden), "{forbidden} must not be serialized");
         }
@@ -214,7 +219,10 @@ mod tests {
         crate::data::KnownHost::write_hosts_yml(&linked_output_hosts()).expect("write hosts");
         let config = ApplicationConfig {
             version: 1,
-            default_diagnostics_cluster: Some("output-elasticsearch".to_string()),
+            output: OutputConfig {
+                default: Some("output-elasticsearch".to_string()),
+                ..OutputConfig::default()
+            },
             ..ApplicationConfig::new()
         };
 
@@ -226,7 +234,10 @@ mod tests {
         let _env = crate::TestEnv::new();
         let config = ApplicationConfig {
             version: 1,
-            default_diagnostics_cluster: Some("missing".to_string()),
+            output: OutputConfig {
+                default: Some("missing".to_string()),
+                ..OutputConfig::default()
+            },
             ..ApplicationConfig::new()
         };
 
@@ -243,7 +254,9 @@ mod tests {
         let _env = crate::TestEnv::new();
         let config = ApplicationConfig {
             version: 1,
-            default_job: Some("missing-job".to_string()),
+            job: JobConfig {
+                default: Some("missing-job".to_string()),
+            },
             ..ApplicationConfig::new()
         };
 

--- a/src/data/application_config.rs
+++ b/src/data/application_config.rs
@@ -152,7 +152,7 @@ mod tests {
         let loaded = ApplicationConfig::load().expect("load configuration");
 
         assert_eq!(loaded, config);
-        assert!(written.contains("output: output-elasticsearch"));
+        assert!(written.contains("default_diagnostics_cluster: output-elasticsearch"));
         assert!(written.contains("default_job: production-standard"));
         for forbidden in ["apikey", "password", "authorization", "https://es.example"] {
             assert!(!written.contains(forbidden), "{forbidden} must not be serialized");

--- a/src/data/application_config.rs
+++ b/src/data/application_config.rs
@@ -20,11 +20,40 @@ pub struct ApplicationConfig {
     pub version: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
+    #[serde(default, skip_serializing_if = "OutputConfig::is_empty")]
+    pub output: OutputConfig,
+    #[serde(default, skip_serializing_if = "JobConfig::is_empty")]
+    pub job: JobConfig,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OutputConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[serde(alias = "output")]
-    pub default_diagnostics_cluster: Option<String>,
+    pub default: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub default_job: Option<String>,
+    pub authenticated_on: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assets_version: Option<String>,
+}
+
+impl OutputConfig {
+    fn is_empty(&self) -> bool {
+        self.default.is_none() && self.authenticated_on.is_none() && self.assets_version.is_none()
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JobConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+}
+
+impl JobConfig {
+    fn is_empty(&self) -> bool {
+        self.default.is_none()
+    }
 }
 
 impl ApplicationConfig {
@@ -65,7 +94,7 @@ impl ApplicationConfig {
         self.validate_version()?;
 
         let hosts = KnownHost::parse_hosts_yml()?;
-        if let Some(output_name) = &self.default_diagnostics_cluster {
+        if let Some(output_name) = &self.output.default {
             let output = hosts
                 .get(output_name)
                 .ok_or_else(|| eyre!("Configured output host '{output_name}' was not found"))?;
@@ -91,7 +120,7 @@ impl ApplicationConfig {
             }
         }
 
-        if let Some(job_name) = &self.default_job {
+        if let Some(job_name) = &self.job.default {
             let jobs = load_saved_jobs()?;
             if !jobs.contains_key(job_name) {
                 return Err(eyre!("Configured default job '{job_name}' was not found"));

--- a/src/data/application_config.rs
+++ b/src/data/application_config.rs
@@ -1,0 +1,228 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+use super::{Application, HostRole, KnownHost, load_saved_jobs};
+use eyre::{Result, eyre};
+use serde::{Deserialize, Serialize};
+use std::{fs, path::PathBuf};
+
+const CURRENT_VERSION: u32 = 1;
+const FILE_NAME: &str = "esdiag.yml";
+
+/// Non-secret preferences shared by local ESDiag workflows.
+///
+/// Endpoint definitions remain in `hosts.yml`, saved workflow bodies remain in
+/// `jobs.yml`, and credentials remain encrypted in `secrets.yml`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ApplicationConfig {
+    pub version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "output")]
+    pub default_diagnostics_cluster: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_job: Option<String>,
+}
+
+impl ApplicationConfig {
+    pub fn new() -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            ..Self::default()
+        }
+    }
+
+    pub fn path() -> Result<PathBuf> {
+        let hosts_path = KnownHost::get_hosts_path();
+        let state_dir = hosts_path.parent().unwrap_or_else(|| std::path::Path::new("."));
+        Ok(state_dir.join(FILE_NAME))
+    }
+
+    pub fn load() -> Result<Self> {
+        let path = Self::path()?;
+        if !path.exists() {
+            return Ok(Self::new());
+        }
+
+        let content = fs::read_to_string(&path)?;
+        let config: Self = yaml_serde::from_str(&content)?;
+        config.validate_version()?;
+        Ok(config)
+    }
+
+    pub fn save(&self) -> Result<()> {
+        self.validate_version()?;
+        let path = Self::path()?;
+        super::keystore::write_yaml_atomic(&path, self)
+    }
+
+    /// Checks that persisted references still form a valid local workflow
+    /// without resolving any credential material.
+    pub fn validate_references(&self) -> Result<()> {
+        self.validate_version()?;
+
+        let hosts = KnownHost::parse_hosts_yml()?;
+        if let Some(output_name) = &self.default_diagnostics_cluster {
+            let output = hosts
+                .get(output_name)
+                .ok_or_else(|| eyre!("Configured output host '{output_name}' was not found"))?;
+            if !output.has_role(HostRole::Send) {
+                return Err(eyre!("Configured output host '{output_name}' must include role 'send'"));
+            }
+            if output.app() != Some(Application::Elasticsearch) {
+                return Err(eyre!(
+                    "Configured output host '{output_name}' must be an Elasticsearch host"
+                ));
+            }
+
+            let viewer_name = output
+                .viewer()
+                .ok_or_else(|| eyre!("Configured output host '{output_name}' has no Kibana viewer"))?;
+            let viewer = hosts.get(viewer_name).ok_or_else(|| {
+                eyre!("Configured output host '{output_name}' references unknown viewer host '{viewer_name}'")
+            })?;
+            if !viewer.has_role(HostRole::View) || viewer.app() != Some(Application::Kibana) {
+                return Err(eyre!(
+                    "Configured output host '{output_name}' viewer '{viewer_name}' must be a Kibana host with role 'view'"
+                ));
+            }
+        }
+
+        if let Some(job_name) = &self.default_job {
+            let jobs = load_saved_jobs()?;
+            if !jobs.contains_key(job_name) {
+                return Err(eyre!("Configured default job '{job_name}' was not found"));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn validate_version(&self) -> Result<()> {
+        if self.version != CURRENT_VERSION {
+            return Err(eyre!(
+                "Unsupported application configuration version {}; this ESDiag version supports version {CURRENT_VERSION}",
+                self.version
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ApplicationConfig;
+    use crate::data::{Application, HostRole, KnownHostBuilder};
+    use std::collections::BTreeMap;
+    use url::Url;
+
+    fn linked_output_hosts() -> BTreeMap<String, crate::data::KnownHost> {
+        let output = KnownHostBuilder::new(Url::parse("https://es.example:9200").expect("url"))
+            .application(Application::Elasticsearch)
+            .roles(vec![HostRole::Send])
+            .viewer(Some("output-kibana".to_string()))
+            .build()
+            .expect("output host");
+        let viewer = KnownHostBuilder::new(Url::parse("https://kb.example:5601").expect("url"))
+            .application(Application::Kibana)
+            .roles(vec![HostRole::View])
+            .build()
+            .expect("viewer host");
+        BTreeMap::from([
+            ("output-elasticsearch".to_string(), output),
+            ("output-kibana".to_string(), viewer),
+        ])
+    }
+
+    #[test]
+    fn config_round_trips_with_reference_values_only() {
+        let env = crate::TestEnv::new();
+        let config = ApplicationConfig {
+            version: 1,
+            user: Some("reno@example.com".to_string()),
+            default_diagnostics_cluster: Some("output-elasticsearch".to_string()),
+            default_job: Some("production-standard".to_string()),
+        };
+
+        config.save().expect("save configuration");
+        let written = std::fs::read_to_string(ApplicationConfig::path().expect("config path")).expect("read config");
+        let loaded = ApplicationConfig::load().expect("load configuration");
+
+        assert_eq!(loaded, config);
+        assert!(written.contains("output: output-elasticsearch"));
+        assert!(written.contains("default_job: production-standard"));
+        for forbidden in ["apikey", "password", "authorization", "https://es.example"] {
+            assert!(!written.contains(forbidden), "{forbidden} must not be serialized");
+        }
+        assert!(
+            !env.settings_path.exists(),
+            "application config must not write legacy settings"
+        );
+    }
+
+    #[test]
+    fn unknown_version_is_rejected_without_rewriting_configuration() {
+        let _env = crate::TestEnv::new();
+        let path = ApplicationConfig::path().expect("config path");
+        let content = "version: 2\nuser: future@example.com\n";
+        std::fs::write(&path, content).expect("write future config");
+
+        let err = ApplicationConfig::load().expect_err("future version must be rejected");
+
+        assert!(
+            err.to_string()
+                .contains("Unsupported application configuration version 2")
+        );
+        assert_eq!(std::fs::read_to_string(path).expect("read original config"), content);
+    }
+
+    #[test]
+    fn reference_validation_requires_a_linked_elasticsearch_output() {
+        let _env = crate::TestEnv::new();
+        crate::data::KnownHost::write_hosts_yml(&linked_output_hosts()).expect("write hosts");
+        let config = ApplicationConfig {
+            version: 1,
+            default_diagnostics_cluster: Some("output-elasticsearch".to_string()),
+            ..ApplicationConfig::new()
+        };
+
+        config.validate_references().expect("linked output must validate");
+    }
+
+    #[test]
+    fn reference_validation_rejects_unknown_output() {
+        let _env = crate::TestEnv::new();
+        let config = ApplicationConfig {
+            version: 1,
+            default_diagnostics_cluster: Some("missing".to_string()),
+            ..ApplicationConfig::new()
+        };
+
+        let err = config.validate_references().expect_err("unknown host must fail");
+
+        assert!(
+            err.to_string()
+                .contains("Configured output host 'missing' was not found")
+        );
+    }
+
+    #[test]
+    fn reference_validation_rejects_unknown_default_job() {
+        let _env = crate::TestEnv::new();
+        let config = ApplicationConfig {
+            version: 1,
+            default_job: Some("missing-job".to_string()),
+            ..ApplicationConfig::new()
+        };
+
+        let err = config.validate_references().expect_err("unknown default job must fail");
+
+        assert!(
+            err.to_string()
+                .contains("Configured default job 'missing-job' was not found")
+        );
+    }
+}

--- a/src/data/known_host.rs
+++ b/src/data/known_host.rs
@@ -1031,6 +1031,13 @@ impl KnownHost {
         self.roles().contains(&role)
     }
 
+    pub fn with_role(mut self, role: HostRole) -> Self {
+        if !self.roles.contains(&role) {
+            self.roles.push(role);
+        }
+        self
+    }
+
     pub fn viewer(&self) -> Option<&str> {
         self.viewer.as_deref()
     }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -4,12 +4,16 @@
 
 /// Elastic Stack application components (the application axis)
 mod application;
+/// Local non-secret workflow preferences
+mod application_config;
 /// Authentication methods
 mod auth;
 /// Encrypted secret storage
 mod keystore;
 /// Manage saving and loading hosts from a YAML file
 mod known_host;
+/// Canonical Elasticsearch and Kibana output-deployment resolution
+mod output_deployment;
 /// Deployment platforms (the platform axis)
 mod platform;
 /// Saved job configurations
@@ -20,6 +24,7 @@ pub mod settings;
 mod uri;
 
 pub use application::Application;
+pub use application_config::ApplicationConfig;
 pub use auth::{Auth, AuthType};
 #[cfg(all(feature = "server", feature = "keystore"))]
 pub(crate) use keystore::get_active_unlock_keystore_password;
@@ -38,6 +43,7 @@ pub use known_host::{
     CredentialDirection, ElasticCloud, HostRole, HostRoute, KnownHost, KnownHostBuilder, KnownHostCliUpdate,
     ResolvedKnownHost,
 };
+pub use output_deployment::{OutputDeployment, OutputDeploymentSource};
 pub use platform::Platform;
 pub use saved_jobs::{
     CollectMode, CollectSource, DraftTargetAvailability, Job, JobBuilder, JobDraft, JobDraftCollect, JobDraftProcess,

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -24,7 +24,7 @@ pub mod settings;
 mod uri;
 
 pub use application::Application;
-pub use application_config::ApplicationConfig;
+pub use application_config::{ApplicationConfig, JobConfig, OutputConfig};
 pub use auth::{Auth, AuthType};
 #[cfg(all(feature = "server", feature = "keystore"))]
 pub(crate) use keystore::get_active_unlock_keystore_password;

--- a/src/data/output_deployment.rs
+++ b/src/data/output_deployment.rs
@@ -119,15 +119,7 @@ impl OutputDeployment {
 }
 
 fn runtime_output_is_declared() -> bool {
-    [
-        "ESDIAG_OUTPUT_URL",
-        "ESDIAG_OUTPUT_APIKEY",
-        "ESDIAG_OUTPUT_USERNAME",
-        "ESDIAG_OUTPUT_PASSWORD",
-        "ESDIAG_KIBANA_URL",
-    ]
-    .iter()
-    .any(|name| env::var_os(name).is_some())
+    env::var_os("ESDIAG_OUTPUT_URL").is_some()
 }
 
 fn required_environment(name: &str) -> Result<String> {
@@ -283,6 +275,22 @@ mod tests {
                 .and_then(|host| host.concrete_url())
                 .map(Url::as_str),
             Some("https://saved-kb.example:5601/")
+        );
+    }
+
+    #[test]
+    fn credentials_without_an_output_url_do_not_override_persisted_output() {
+        let mut env = crate::TestEnv::new();
+        clear_output_environment(&mut env);
+        save_linked_hosts();
+        env.set("ESDIAG_OUTPUT_APIKEY", "runtime-key");
+
+        let deployment = OutputDeployment::resolve(None, true).expect("persisted deployment");
+
+        assert_eq!(deployment.source, OutputDeploymentSource::Persisted);
+        assert_eq!(
+            deployment.elasticsearch.concrete_url().map(Url::as_str),
+            Some("https://saved-es.example:9200/")
         );
     }
 

--- a/src/data/output_deployment.rs
+++ b/src/data/output_deployment.rs
@@ -47,7 +47,7 @@ impl OutputDeployment {
 
     fn from_persisted(require_kibana: bool) -> Result<Self> {
         let config = ApplicationConfig::load()?;
-        let output_name = config.default_diagnostics_cluster.ok_or_else(|| {
+        let output_name = config.output.default.ok_or_else(|| {
             eyre!("No output deployment is configured. Run `esdiag init` or provide an explicit output target.")
         })?;
         let output = KnownHost::get_known(&output_name)

--- a/src/data/output_deployment.rs
+++ b/src/data/output_deployment.rs
@@ -1,0 +1,317 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+use super::{Application, ApplicationConfig, Auth, CredentialDirection, HostRole, KnownHost, KnownHostBuilder};
+use eyre::{Result, eyre};
+use std::env;
+use url::Url;
+
+/// The source selected by output-deployment precedence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutputDeploymentSource {
+    Explicit,
+    Environment,
+    Persisted,
+}
+
+/// One Elasticsearch output target and its attached Kibana viewer.
+///
+/// The resolver selects every endpoint and credential from one source. It never
+/// fills an incomplete environment declaration from persisted state.
+#[derive(Clone, Debug)]
+pub struct OutputDeployment {
+    pub source: OutputDeploymentSource,
+    pub elasticsearch: KnownHost,
+    pub elasticsearch_auth: Auth,
+    pub kibana: Option<KnownHost>,
+    pub kibana_auth: Option<Auth>,
+}
+
+impl OutputDeployment {
+    pub fn resolve(explicit_target: Option<&str>, require_kibana: bool) -> Result<Self> {
+        if let Some(target) = explicit_target {
+            return Self::from_explicit(target, require_kibana);
+        }
+        if runtime_output_is_declared() {
+            return Self::from_environment(require_kibana);
+        }
+        Self::from_persisted(require_kibana)
+    }
+
+    fn from_explicit(target: &str, require_kibana: bool) -> Result<Self> {
+        let output = KnownHost::get_known(&target.to_string())
+            .ok_or_else(|| eyre!("Explicit output deployment target '{target}' must be a saved Elasticsearch host"))?;
+        Self::from_saved(OutputDeploymentSource::Explicit, output, require_kibana)
+    }
+
+    fn from_persisted(require_kibana: bool) -> Result<Self> {
+        let config = ApplicationConfig::load()?;
+        let output_name = config.default_diagnostics_cluster.ok_or_else(|| {
+            eyre!("No output deployment is configured. Run `esdiag init` or provide an explicit output target.")
+        })?;
+        let output = KnownHost::get_known(&output_name)
+            .ok_or_else(|| eyre!("Configured output host '{output_name}' was not found"))?;
+        Self::from_saved(OutputDeploymentSource::Persisted, output, require_kibana)
+    }
+
+    fn from_saved(source: OutputDeploymentSource, elasticsearch: KnownHost, require_kibana: bool) -> Result<Self> {
+        validate_send_host(&elasticsearch, "output deployment")?;
+        let elasticsearch_auth = elasticsearch.get_auth_for_direction(CredentialDirection::Output)?;
+
+        let (kibana, kibana_auth) = if require_kibana {
+            let viewer_name = elasticsearch
+                .viewer()
+                .ok_or_else(|| eyre!("Output deployment requires a linked Kibana viewer"))?;
+            let viewer = KnownHost::get_known(&viewer_name.to_string())
+                .ok_or_else(|| eyre!("Output deployment viewer '{viewer_name}' was not found"))?;
+            validate_view_host(&viewer, viewer_name)?;
+            let auth = viewer.get_auth_for_direction(CredentialDirection::Output)?;
+            (Some(viewer), Some(auth))
+        } else {
+            (None, None)
+        };
+
+        Ok(Self {
+            source,
+            elasticsearch,
+            elasticsearch_auth,
+            kibana,
+            kibana_auth,
+        })
+    }
+
+    fn from_environment(require_kibana: bool) -> Result<Self> {
+        let output_url = required_environment("ESDIAG_OUTPUT_URL")?;
+        let (apikey, username, password) = environment_auth()?;
+        let elasticsearch = KnownHostBuilder::new(Url::parse(&output_url)?)
+            .application(Application::Elasticsearch)
+            .roles(vec![HostRole::Send])
+            .apikey(apikey.clone())
+            .username(username.clone())
+            .password(password.clone())
+            .build()?;
+        let elasticsearch_auth = elasticsearch.get_auth_for_direction(CredentialDirection::Output)?;
+
+        let (kibana, kibana_auth) = if require_kibana {
+            let kibana_url = required_environment("ESDIAG_KIBANA_URL")?;
+            let kibana = KnownHostBuilder::new(Url::parse(&kibana_url)?)
+                .application(Application::Kibana)
+                .roles(vec![HostRole::View])
+                .apikey(apikey)
+                .username(username)
+                .password(password)
+                .build()?;
+            let auth = kibana.get_auth_for_direction(CredentialDirection::Output)?;
+            (Some(kibana), Some(auth))
+        } else {
+            (None, None)
+        };
+
+        Ok(Self {
+            source: OutputDeploymentSource::Environment,
+            elasticsearch,
+            elasticsearch_auth,
+            kibana,
+            kibana_auth,
+        })
+    }
+}
+
+fn runtime_output_is_declared() -> bool {
+    [
+        "ESDIAG_OUTPUT_URL",
+        "ESDIAG_OUTPUT_APIKEY",
+        "ESDIAG_OUTPUT_USERNAME",
+        "ESDIAG_OUTPUT_PASSWORD",
+        "ESDIAG_KIBANA_URL",
+    ]
+    .iter()
+    .any(|name| env::var_os(name).is_some())
+}
+
+fn required_environment(name: &str) -> Result<String> {
+    let value = env::var(name).map_err(|_| eyre!("{name} is not defined"))?;
+    if value.trim().is_empty() {
+        return Err(eyre!("{name} is empty"));
+    }
+    Ok(value)
+}
+
+fn environment_auth() -> Result<(Option<String>, Option<String>, Option<String>)> {
+    let apikey = env::var("ESDIAG_OUTPUT_APIKEY")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    let username = env::var("ESDIAG_OUTPUT_USERNAME")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    let password = env::var("ESDIAG_OUTPUT_PASSWORD")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+
+    match (&apikey, &username, &password) {
+        (Some(_), None, None) | (None, None, None) | (None, Some(_), Some(_)) => Ok((apikey, username, password)),
+        (Some(_), _, _) => Err(eyre!(
+            "ESDIAG_OUTPUT_APIKEY cannot be combined with ESDIAG_OUTPUT_USERNAME or ESDIAG_OUTPUT_PASSWORD"
+        )),
+        (None, Some(_), None) | (None, None, Some(_)) => Err(eyre!(
+            "ESDIAG_OUTPUT_USERNAME and ESDIAG_OUTPUT_PASSWORD must be configured together"
+        )),
+    }
+}
+
+fn validate_send_host(host: &KnownHost, context: &str) -> Result<()> {
+    if host.app() != Some(Application::Elasticsearch) || !host.has_role(HostRole::Send) {
+        return Err(eyre!("{context} must be an Elasticsearch host with role 'send'"));
+    }
+    Ok(())
+}
+
+fn validate_view_host(host: &KnownHost, name: &str) -> Result<()> {
+    if host.app() != Some(Application::Kibana) || !host.has_role(HostRole::View) {
+        return Err(eyre!(
+            "Output deployment viewer '{name}' must be a Kibana host with role 'view'"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OutputDeployment, OutputDeploymentSource};
+    use crate::data::{Application, ApplicationConfig, HostRole, KnownHostBuilder};
+    use std::collections::BTreeMap;
+    use url::Url;
+
+    fn clear_output_environment(env: &mut crate::TestEnv) {
+        for name in [
+            "ESDIAG_OUTPUT_URL",
+            "ESDIAG_OUTPUT_APIKEY",
+            "ESDIAG_OUTPUT_USERNAME",
+            "ESDIAG_OUTPUT_PASSWORD",
+            "ESDIAG_KIBANA_URL",
+        ] {
+            env.remove(name);
+        }
+    }
+
+    fn save_linked_hosts() {
+        let output = KnownHostBuilder::new(Url::parse("https://saved-es.example:9200").expect("url"))
+            .application(Application::Elasticsearch)
+            .roles(vec![HostRole::Send])
+            .viewer(Some("saved-kibana".to_string()))
+            .build()
+            .expect("output");
+        let viewer = KnownHostBuilder::new(Url::parse("https://saved-kb.example:5601").expect("url"))
+            .application(Application::Kibana)
+            .roles(vec![HostRole::View])
+            .build()
+            .expect("viewer");
+        crate::data::KnownHost::write_hosts_yml(&BTreeMap::from([
+            ("saved-output".to_string(), output),
+            ("saved-kibana".to_string(), viewer),
+        ]))
+        .expect("write hosts");
+        ApplicationConfig {
+            version: 1,
+            default_diagnostics_cluster: Some("saved-output".to_string()),
+            ..ApplicationConfig::new()
+        }
+        .save()
+        .expect("save app config");
+    }
+
+    #[test]
+    fn complete_environment_deployment_precedes_persisted_output() {
+        let mut env = crate::TestEnv::new();
+        clear_output_environment(&mut env);
+        save_linked_hosts();
+        env.set("ESDIAG_OUTPUT_URL", "https://runtime-es.example:9200");
+        env.set("ESDIAG_OUTPUT_APIKEY", "runtime-key");
+        env.set("ESDIAG_KIBANA_URL", "https://runtime-kb.example:5601");
+
+        let deployment = OutputDeployment::resolve(None, true).expect("environment deployment");
+
+        assert_eq!(deployment.source, OutputDeploymentSource::Environment);
+        assert_eq!(
+            deployment.elasticsearch.concrete_url().map(Url::as_str),
+            Some("https://runtime-es.example:9200/")
+        );
+        assert_eq!(
+            deployment
+                .kibana
+                .as_ref()
+                .and_then(|host| host.concrete_url())
+                .map(Url::as_str),
+            Some("https://runtime-kb.example:5601/")
+        );
+    }
+
+    #[test]
+    fn partial_environment_never_borrows_persisted_viewer() {
+        let mut env = crate::TestEnv::new();
+        clear_output_environment(&mut env);
+        save_linked_hosts();
+        env.set("ESDIAG_OUTPUT_URL", "https://runtime-es.example:9200");
+
+        let err = OutputDeployment::resolve(None, true).expect_err("missing Kibana config must fail");
+
+        assert!(err.to_string().contains("ESDIAG_KIBANA_URL is not defined"));
+        assert!(!err.to_string().contains("saved-kibana"));
+    }
+
+    #[test]
+    fn persisted_output_resolves_its_linked_viewer() {
+        let mut env = crate::TestEnv::new();
+        clear_output_environment(&mut env);
+        save_linked_hosts();
+
+        let deployment = OutputDeployment::resolve(None, true).expect("saved deployment");
+
+        assert_eq!(deployment.source, OutputDeploymentSource::Persisted);
+        assert_eq!(
+            deployment.elasticsearch.concrete_url().map(Url::as_str),
+            Some("https://saved-es.example:9200/")
+        );
+        assert_eq!(
+            deployment
+                .kibana
+                .as_ref()
+                .and_then(|host| host.concrete_url())
+                .map(Url::as_str),
+            Some("https://saved-kb.example:5601/")
+        );
+    }
+
+    #[test]
+    fn omitted_cli_output_uses_the_persisted_deployment() {
+        let mut env = crate::TestEnv::new();
+        clear_output_environment(&mut env);
+        save_linked_hosts();
+
+        let uri = crate::data::Uri::try_from(Option::<String>::None).expect("default output URI");
+
+        assert!(matches!(
+            uri,
+            crate::data::Uri::KnownHost(host)
+                if host.concrete_url().map(Url::as_str) == Some("https://saved-es.example:9200/")
+        ));
+    }
+
+    #[test]
+    fn explicit_target_precedes_runtime_and_persisted_deployments() {
+        let mut env = crate::TestEnv::new();
+        clear_output_environment(&mut env);
+        save_linked_hosts();
+        env.set("ESDIAG_OUTPUT_URL", "https://runtime-es.example:9200");
+        env.set("ESDIAG_KIBANA_URL", "https://runtime-kb.example:5601");
+
+        let deployment = OutputDeployment::resolve(Some("saved-output"), true).expect("explicit deployment");
+
+        assert_eq!(deployment.source, OutputDeploymentSource::Explicit);
+        assert_eq!(
+            deployment.elasticsearch.concrete_url().map(Url::as_str),
+            Some("https://saved-es.example:9200/")
+        );
+    }
+}

--- a/src/data/output_deployment.rs
+++ b/src/data/output_deployment.rs
@@ -214,7 +214,10 @@ mod tests {
         .expect("write hosts");
         ApplicationConfig {
             version: 1,
-            default_diagnostics_cluster: Some("saved-output".to_string()),
+            output: crate::data::OutputConfig {
+                default: Some("saved-output".to_string()),
+                ..crate::data::OutputConfig::default()
+            },
             ..ApplicationConfig::new()
         }
         .save()

--- a/src/data/uri.rs
+++ b/src/data/uri.rs
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-use super::{Application, ElasticCloud, KnownHost, KnownHostBuilder, ResolvedKnownHost};
+use super::{Application, ElasticCloud, KnownHost, KnownHostBuilder, OutputDeployment, ResolvedKnownHost};
 use eyre::{OptionExt, Report, Result, eyre};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
@@ -63,6 +63,13 @@ impl Uri {
             .password(password)
             .build()?;
         host.try_into()
+    }
+
+    /// Resolve the default output deployment without mixing runtime and saved
+    /// configuration sources. Explicit command targets continue to take
+    /// precedence through [`TryFrom<Option<String>>`].
+    pub fn try_from_default_output() -> Result<Self> {
+        OutputDeployment::resolve(None, false)?.elasticsearch.try_into()
     }
 
     /// Try creating a new Kibana Uri from the environment variables
@@ -265,7 +272,7 @@ impl TryFrom<Option<String>> for Uri {
     fn try_from(uri: Option<String>) -> Result<Self> {
         match uri {
             Some(uri) => Uri::try_from(uri),
-            None => Uri::try_from_output_env(),
+            None => Uri::try_from_default_output(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ pub mod env;
 pub mod exporter;
 /// Shared job runner for saved diagnostic jobs
 pub mod job;
+/// Flow-neutral first-run onboarding operations
+pub mod onboarding;
 /// Data transformation and processing logic
 pub mod processor;
 /// Receive data from various sources

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,14 +18,18 @@ use esdiag::setup;
 use esdiag::{
     client::Client,
     data::{
-        Application, HostRole, KnownHost, KnownHostBuilder, KnownHostCliUpdate, SecretAuth, Settings, Uri, add_secret,
-        clear_unlock_lease, collect_application, create_keystore, default_unlock_ttl, get_keystore_path,
-        get_password_for_secret_commands, get_unlock_status, keystore_exists, parse_unlock_ttl, remove_secret,
-        resolve_secret_auth, rotate_keystore_password, update_secret, validate_existing_keystore_password,
-        write_unlock_lease,
+        Application, HostRole, KnownHost, KnownHostBuilder, KnownHostCliUpdate, OutputDeployment, SecretAuth, Settings,
+        Uri, add_secret, clear_unlock_lease, collect_application, create_keystore, default_unlock_ttl,
+        get_keystore_path, get_password_for_secret_commands, get_unlock_status, keystore_exists, parse_unlock_ttl,
+        remove_secret, resolve_secret_auth, rotate_keystore_password, update_secret, upsert_secret_auth,
+        validate_existing_keystore_password, write_unlock_lease,
     },
     env::LOG_LEVEL,
     exporter::Exporter,
+    onboarding::{
+        CollectHostInput, OutputDeploymentInput, inspect as inspect_onboarding, save_collect_host, save_default_job,
+        save_default_processing_job, save_output_deployment, save_user,
+    },
     processor::{CollectionResult, DiagnosticOutcome, Identifiers, default_collect_archive_name},
     receiver::{
         ElasticCloudAdminRequestError, ElasticsearchRequestError, KibanaRequestError, LogstashRequestError, Receiver,
@@ -36,7 +40,8 @@ use eyre::{Result, eyre};
 use redact::Secret;
 use std::{
     io::{IsTerminal, Write},
-    process::ExitCode,
+    path::PathBuf,
+    process::{Command, ExitCode},
     str::FromStr,
     time::Duration,
 };
@@ -151,6 +156,8 @@ enum Commands {
         #[command(subcommand)]
         command: HostCommands,
     },
+    /// Interactively configure a repeatable local diagnostic workflow
+    Init,
     /// Manage encrypted secrets in the local keystore
     #[command(alias = "secret")]
     Keystore {
@@ -1011,6 +1018,7 @@ async fn run(cli: Cli, format: OutputFormat) -> Result<CommandResult> {
                     _ => Err(eyre!("Collect requires a known host")),
                 }
             }
+            Commands::Init => run_init_wizard().await,
             Commands::Host { command } => match command {
                 HostCommands::Add {
                     name,
@@ -1360,13 +1368,17 @@ async fn run(cli: Cli, format: OutputFormat) -> Result<CommandResult> {
                         targets: vec![client.to_string()],
                     }))
                 } else {
-                    tracing::debug!("Setting up assets with environment variables");
-                    let es_uri = Uri::try_from_output_env()?;
+                    tracing::debug!("Setting up assets with the resolved output deployment");
+                    let deployment = OutputDeployment::resolve(None, true)?;
+                    let es_uri = Uri::try_from(deployment.elasticsearch)?;
                     let es_client = Client::try_from(es_uri)?;
                     tracing::info!("Setting up assets in {es_client}");
                     setup::assets(&es_client).await?;
                     setup::ensure_agent_builder_license(&es_client).await?;
-                    let kb_uri = Uri::try_from_kibana_env()?;
+                    let kibana = deployment
+                        .kibana
+                        .ok_or_else(|| eyre!("Resolved output deployment is missing a Kibana viewer"))?;
+                    let kb_uri = Uri::try_from(kibana)?;
                     let kb_client = Client::try_from(kb_uri)?;
                     tracing::info!("Setting up Kibana assets in {kb_client}");
                     setup::assets(&kb_client).await?;
@@ -1772,6 +1784,18 @@ fn prompt_confirm(message: &str) -> Result<bool> {
     Ok(matches!(answer.as_str(), "y" | "yes"))
 }
 
+fn prompt_confirm_default_yes(message: &str) -> Result<bool> {
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        return Ok(false);
+    }
+    print!("{message}");
+    std::io::stdout().flush()?;
+    let mut line = String::new();
+    std::io::stdin().read_line(&mut line)?;
+    let answer = line.trim().to_ascii_lowercase();
+    Ok(!matches!(answer.as_str(), "n" | "no"))
+}
+
 fn prompt_new_keystore_password() -> Result<String> {
     if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
         return Err(eyre!("A new keystore password requires an interactive terminal."));
@@ -1804,6 +1828,372 @@ fn unlock_keystore(ttl: Duration) -> Result<std::path::PathBuf> {
     let keystore_password = prompt_new_keystore_password()?;
     create_keystore(&keystore_password)?;
     write_unlock_lease(&keystore_password, ttl)
+}
+
+async fn run_init_wizard() -> Result<CommandResult> {
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        return Err(eyre!("`esdiag init` requires an interactive controlling terminal."));
+    }
+
+    let initial = inspect_onboarding()?;
+    println!("ESDiag first-run initialization");
+    let mut output_name_for_defaults = esdiag::data::ApplicationConfig::load()?.default_diagnostics_cluster;
+    let mut output_url_for_defaults = output_name_for_defaults
+        .as_ref()
+        .and_then(KnownHost::get_known)
+        .and_then(|host| host.concrete_url().map(Url::to_string));
+    let mut most_recent_collect_host = None;
+    if initial.is_complete() && !prompt_confirm("A complete configuration already exists. Replace values? [y/N]: ")? {
+        return Ok(CommandResult::outcome(initialization_outcome()?));
+    }
+
+    let config = esdiag::data::ApplicationConfig::load()?;
+    let replace_user = match config.user.as_deref() {
+        Some(user) if !prompt_confirm_default_yes(&format!("Resume configuring user: {user} [Y/n]: "))? => {
+            prompt_confirm("Replace existing configuration? [y/N]: ")?
+        }
+        Some(_) => false,
+        None => true,
+    };
+    if replace_user {
+        save_user(prompt_with_default(
+            "Default diagnostic user",
+            &default_diagnostic_user(),
+        )?)?;
+    }
+
+    let config = esdiag::data::ApplicationConfig::load()?;
+    let configure_cluster = if config.default_diagnostics_cluster.is_some() {
+        prompt_confirm("Reconfigure the default diagnostics cluster? [y/N]: ")?
+    } else {
+        prompt_confirm_default_yes("Configure a diagnostics cluster now? [Y/n]: ")?
+    };
+    if configure_cluster {
+        unlock_keystore(default_unlock_ttl())?;
+        let keystore_password = get_password_for_secret_commands()?;
+        let local_preset = detected_esdiag_local_preset();
+        let output_name = prompt_with_default("Output host name", "localhost")?;
+        let output_url = prompt_url_with_default(
+            "Output Elasticsearch URL",
+            local_preset
+                .as_ref()
+                .map_or("http://localhost:9200", |preset| preset.elasticsearch_url.as_str()),
+        )?;
+        let viewer_name = format!("{output_name}-kb");
+        let viewer_url = prompt_url_with_default(
+            "Output Kibana URL",
+            local_preset
+                .as_ref()
+                .map_or("http://localhost:5601", |preset| preset.kibana_url.as_str()),
+        )?;
+        let secret_id = prompt_with_default("Shared output credential name", &output_name)?;
+        let auth = prompt_api_key("Output", local_preset.as_ref())?;
+        upsert_secret_auth(&secret_id, auth.clone(), &keystore_password)?;
+        let output_candidate = KnownHostBuilder::new(output_url.clone())
+            .application(Application::Elasticsearch)
+            .roles(vec![HostRole::Send])
+            .viewer(Some(viewer_name.clone()))
+            .secret(Some(secret_id.clone()))
+            .build_with_secret_auth(auth.clone())?;
+        let viewer_candidate = KnownHostBuilder::new(viewer_url.clone())
+            .application(Application::Kibana)
+            .roles(vec![HostRole::View])
+            .secret(Some(secret_id.clone()))
+            .build_with_secret_auth(auth.clone())?;
+        let output_client = Client::try_from(Uri::try_from(output_candidate)?)?;
+        let output_valid = match output_client.test_connection().await {
+            Ok(_) => true,
+            Err(err) => {
+                tracing::warn!("Output Elasticsearch validation failed: {err}");
+                false
+            }
+        };
+        let viewer_client = Client::try_from(Uri::try_from(viewer_candidate)?)?;
+        let viewer_valid = match viewer_client.test_connection().await {
+            Ok(_) => true,
+            Err(err) => {
+                tracing::warn!("Output Kibana validation failed: {err}");
+                false
+            }
+        };
+        output_name_for_defaults = Some(output_name.clone());
+        output_url_for_defaults = Some(output_url.to_string());
+        save_output_deployment(
+            OutputDeploymentInput {
+                output_name,
+                output_url,
+                viewer_name,
+                viewer_url,
+                secret_id,
+                auth,
+            },
+            &keystore_password,
+        )?;
+
+        #[cfg(feature = "setup")]
+        if output_valid && viewer_valid && prompt_confirm("Install or update ESDiag output assets now? [y/N]: ")? {
+            setup::assets(&output_client).await?;
+            setup::ensure_agent_builder_license(&output_client).await?;
+            setup::assets(&viewer_client).await?;
+        } else if !output_valid || !viewer_valid {
+            tracing::warn!("Skipping output asset setup until both endpoints validate successfully");
+        }
+        #[cfg(not(feature = "setup"))]
+        if !output_valid || !viewer_valid {
+            tracing::warn!("Output asset setup is unavailable and endpoint validation did not complete successfully");
+        }
+    }
+
+    if !initial.collect_host_configured || prompt_confirm("Add or replace a collect host? [y/N]: ")? {
+        loop {
+            let collect_name_default = output_name_for_defaults
+                .clone()
+                .unwrap_or_else(|| "collect".to_string());
+            let name = prompt_with_default("Collect host name", &collect_name_default)?;
+            let url = prompt_url_with_default(
+                "Collect Elasticsearch URL",
+                output_url_for_defaults.as_deref().unwrap_or("http://localhost:9200"),
+            )?;
+            let reuse_output_secret = output_name_for_defaults.is_some()
+                && prompt_confirm_default_yes("Reuse the output credential for this host? [Y/n]: ")?;
+            let secret_id = if reuse_output_secret {
+                esdiag::data::ApplicationConfig::load()?
+                    .default_diagnostics_cluster
+                    .and_then(|output| KnownHost::get_known(&output))
+                    .and_then(|host| host.secret)
+            } else {
+                Some(prompt_required("Collect-host credential name: ")?)
+            };
+            let auth = None;
+            save_collect_host(
+                CollectHostInput {
+                    name: name.clone(),
+                    app: Application::Elasticsearch,
+                    url,
+                    secret_id,
+                    auth,
+                },
+                None,
+            )?;
+            most_recent_collect_host = Some(name);
+            if !prompt_confirm("Add another collect host? [y/N]: ")? {
+                break;
+            }
+        }
+    }
+
+    let config = esdiag::data::ApplicationConfig::load()?;
+    if config.default_job.is_none() || prompt_confirm("Replace the default saved job? [y/N]: ")? {
+        let collect_host_default = most_recent_collect_host
+            .or_else(first_saved_collect_host)
+            .ok_or_else(|| eyre!("Add a collect host before creating the default job"))?;
+        let collect_host = prompt_with_default("Collect host for the default job", &collect_host_default)?;
+        let collect_job_name = format!("{collect_host}-collect");
+        let collect_job = esdiag::data::Job::builder()
+            .collect_from(collect_host.clone())?
+            .collect_to(format!("diagnostics/{collect_host}"))?;
+        save_default_job(collect_job_name, collect_job)?;
+        if let Some(output) = esdiag::data::ApplicationConfig::load()?.default_diagnostics_cluster {
+            let process_job_name = format!("{collect_host}-process-{output}");
+            save_default_processing_job(process_job_name, collect_host)?;
+        }
+    }
+
+    let readiness = inspect_onboarding()?;
+    if !readiness.is_complete() {
+        return Err(eyre!("Initialization did not produce a complete reusable workflow."));
+    }
+    Ok(CommandResult::outcome(initialization_outcome()?))
+}
+
+fn initialization_outcome() -> Result<CliOutcome> {
+    let config = esdiag::data::ApplicationConfig::load()?;
+    Ok(CliOutcome::InitializationCompleted {
+        user: config
+            .user
+            .ok_or_else(|| eyre!("Initialization completed without a configured user"))?,
+        output: config.default_diagnostics_cluster,
+        job: config
+            .default_job
+            .ok_or_else(|| eyre!("Initialization completed without a default job"))?,
+    })
+}
+
+fn prompt_required(message: &str) -> Result<String> {
+    print!("{message}");
+    std::io::stdout().flush()?;
+    let mut line = String::new();
+    std::io::stdin().read_line(&mut line)?;
+    let value = line.trim().to_string();
+    if value.is_empty() {
+        return Err(eyre!("A value is required."));
+    }
+    Ok(value)
+}
+
+fn prompt_with_default(message: &str, default: &str) -> Result<String> {
+    print!("{message} [{default}]: ");
+    std::io::stdout().flush()?;
+    let mut line = String::new();
+    std::io::stdin().read_line(&mut line)?;
+    let value = line.trim();
+    Ok(if value.is_empty() {
+        default.to_string()
+    } else {
+        value.to_string()
+    })
+}
+
+fn prompt_url_with_default(message: &str, default: &str) -> Result<Url> {
+    Url::parse(&prompt_with_default(message, default)?).map_err(Into::into)
+}
+
+fn first_saved_collect_host() -> Option<String> {
+    KnownHost::parse_hosts_yml()
+        .ok()?
+        .into_iter()
+        .find(|(_, host)| host.has_role(HostRole::Collect))
+        .map(|(name, _)| name)
+}
+
+#[derive(Clone)]
+struct EsdiagLocalPreset {
+    elasticsearch_url: String,
+    kibana_url: String,
+    apikey: Option<String>,
+}
+
+fn detected_esdiag_local_preset() -> Option<EsdiagLocalPreset> {
+    let state_dir = std::env::var_os("ESDIAG_LOCAL_DIR")
+        .map(PathBuf::from)
+        .or_else(default_esdiag_local_state_dir)?;
+    let contents = std::fs::read_to_string(state_dir.join(".env")).ok()?;
+    let values = contents
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            (!line.is_empty() && !line.starts_with('#'))
+                .then(|| line.split_once('='))
+                .flatten()
+        })
+        .collect::<std::collections::HashMap<_, _>>();
+    let elasticsearch_port = values.get("ESDIAG_ELASTICSEARCH_PORT").copied().unwrap_or("9200");
+    let kibana_port = values.get("ESDIAG_KIBANA_PORT").copied().unwrap_or("5601");
+    Some(EsdiagLocalPreset {
+        elasticsearch_url: format!("http://localhost:{elasticsearch_port}"),
+        kibana_url: format!("http://localhost:{kibana_port}"),
+        apikey: values
+            .get("ESDIAG_OUTPUT_APIKEY")
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty() && *value != "pending")
+            .map(str::to_string),
+    })
+}
+
+fn default_esdiag_local_state_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    let home = std::env::var_os("USERPROFILE")?;
+    #[cfg(not(target_os = "windows"))]
+    let home = std::env::var_os("HOME")?;
+    Some(PathBuf::from(home).join(".esdiag/local"))
+}
+
+fn prompt_api_key(label: &str, local_preset: Option<&EsdiagLocalPreset>) -> Result<SecretAuth> {
+    let default = if local_preset.and_then(|preset| preset.apikey.as_ref()).is_some() {
+        "3"
+    } else {
+        "4"
+    };
+    loop {
+        println!("{label} API key source:");
+        println!("  1. Read from a file");
+        println!("  2. Read from an environment variable");
+        println!("  3. Read from detected esdiag-local configuration");
+        println!("  4. Paste securely");
+        let source = prompt_with_default("Selection", default)?;
+        let apikey = match source.as_str() {
+            "1" | "file" => prompt_required("API key file path: ").and_then(|path| read_api_key_file(&path)),
+            "2" | "environment" | "env" => {
+                let name = prompt_with_default("API key environment variable", "ESDIAG_OUTPUT_APIKEY")?;
+                std::env::var(&name).map_err(|_| eyre!("{name} is not set"))
+            }
+            "3" | "esdiag-local" | "local" => local_preset
+                .and_then(|preset| preset.apikey.clone())
+                .ok_or_else(|| eyre!("No usable ESDiag local API key was detected")),
+            "4" | "paste" => prompt_missing_secret_value(&format!("Enter {label} API key: ")),
+            _ => Err(eyre!("Choose API key source 1, 2, 3, or 4")),
+        };
+        let apikey = match apikey {
+            Ok(apikey) => apikey.trim().to_string(),
+            Err(err) => {
+                print_api_key_source_warning(&format!("Unable to read API key source: {err}. Please try again."));
+                continue;
+            }
+        };
+        if apikey.is_empty() || apikey == "pending" || apikey.contains('\n') || apikey.contains('\r') {
+            print_api_key_source_warning(
+                "The selected API key source did not provide one usable API key. Please try again.",
+            );
+            continue;
+        }
+        return Ok(SecretAuth::apikey(apikey));
+    }
+}
+
+fn print_api_key_source_warning(message: &str) {
+    if std::io::stderr().is_terminal() {
+        eprintln!("\x1b[33mWarning:\x1b[0m {message}");
+    } else {
+        eprintln!("Warning: {message}");
+    }
+}
+
+fn read_api_key_file(path: &str) -> Result<String> {
+    let contents = std::fs::read_to_string(path)?;
+    let mut lines = contents.lines().map(str::trim).filter(|line| !line.is_empty());
+    let apikey = lines.next().ok_or_else(|| eyre!("API key file is empty"))?.to_string();
+    if lines.next().is_some() {
+        return Err(eyre!("API key file must contain exactly one non-empty line"));
+    }
+    Ok(apikey)
+}
+
+fn default_diagnostic_user() -> String {
+    detect_os_email()
+        .or_else(|| std::env::var("EMAIL").ok().filter(|email| email.contains('@')))
+        .or_else(|| std::env::var("USER").ok())
+        .or_else(|| std::env::var("USERNAME").ok())
+        .unwrap_or_else(|| "user".to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn detect_os_email() -> Option<String> {
+    let username = std::env::var("USER").ok()?;
+    let output = Command::new("dscl")
+        .args([".", "-read", &format!("/Users/{username}"), "EMailAddress"])
+        .output()
+        .ok()?;
+    String::from_utf8(output.stdout)
+        .ok()?
+        .split_whitespace()
+        .find(|value| value.contains('@'))
+        .map(str::to_string)
+}
+
+#[cfg(target_os = "windows")]
+fn detect_os_email() -> Option<String> {
+    let output = Command::new("whoami").arg("/upn").output().ok()?;
+    String::from_utf8(output.stdout)
+        .ok()?
+        .lines()
+        .map(str::trim)
+        .find(|value| value.contains('@'))
+        .map(str::to_string)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn detect_os_email() -> Option<String> {
+    None
 }
 
 fn format_epoch(epoch_seconds: i64) -> String {
@@ -2206,6 +2596,13 @@ mod tests {
             }
             _ => panic!("expected host command"),
         }
+    }
+
+    #[test]
+    fn parses_init_command() {
+        let cli = Cli::try_parse_from(["esdiag", "init"]).expect("parse init");
+
+        assert!(matches!(cli.command, Some(Commands::Init)));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1837,7 +1837,7 @@ async fn run_init_wizard() -> Result<CommandResult> {
 
     let initial = inspect_onboarding()?;
     println!("ESDiag first-run initialization");
-    let mut output_name_for_defaults = esdiag::data::ApplicationConfig::load()?.default_diagnostics_cluster;
+    let mut output_name_for_defaults = esdiag::data::ApplicationConfig::load()?.output.default;
     let mut output_url_for_defaults = output_name_for_defaults
         .as_ref()
         .and_then(KnownHost::get_known)
@@ -1863,7 +1863,7 @@ async fn run_init_wizard() -> Result<CommandResult> {
     }
 
     let config = esdiag::data::ApplicationConfig::load()?;
-    let configure_cluster = if config.default_diagnostics_cluster.is_some() {
+    let configure_cluster = if config.output.default.is_some() {
         prompt_confirm("Reconfigure the default diagnostics cluster? [y/N]: ")?
     } else {
         prompt_confirm_default_yes("Configure a diagnostics cluster now? [Y/n]: ")?
@@ -1930,18 +1930,23 @@ async fn run_init_wizard() -> Result<CommandResult> {
             &keystore_password,
         )?;
 
+        let mut output_config = esdiag::data::ApplicationConfig::load()?;
+        output_config.output.authenticated_on = (output_valid && viewer_valid).then(|| chrono::Utc::now().to_rfc3339());
         #[cfg(feature = "setup")]
         if output_valid && viewer_valid && prompt_confirm("Install or update ESDiag output assets now? [y/N]: ")? {
             setup::assets(&output_client).await?;
             setup::ensure_agent_builder_license(&output_client).await?;
             setup::assets(&viewer_client).await?;
+            output_config.output.assets_version = Some(env!("CARGO_PKG_VERSION").to_string());
         } else if !output_valid || !viewer_valid {
+            output_config.output.assets_version = None;
             tracing::warn!("Skipping output asset setup until both endpoints validate successfully");
         }
         #[cfg(not(feature = "setup"))]
         if !output_valid || !viewer_valid {
             tracing::warn!("Output asset setup is unavailable and endpoint validation did not complete successfully");
         }
+        output_config.save()?;
     }
 
     if !initial.collect_host_configured || prompt_confirm("Add or replace a collect host? [y/N]: ")? {
@@ -1956,7 +1961,8 @@ async fn run_init_wizard() -> Result<CommandResult> {
                 && prompt_confirm_default_yes("Reuse the output credential for this host? [Y/n]: ")?;
             let secret_id = if reuse_output_secret {
                 esdiag::data::ApplicationConfig::load()?
-                    .default_diagnostics_cluster
+                    .output
+                    .default
                     .and_then(|output| KnownHost::get_known(&output))
                     .and_then(|host| host.secret)
             } else {
@@ -1991,7 +1997,7 @@ async fn run_init_wizard() -> Result<CommandResult> {
     }
 
     let config = esdiag::data::ApplicationConfig::load()?;
-    if config.default_job.is_none() || prompt_confirm("Replace the default saved job? [y/N]: ")? {
+    if config.job.default.is_none() || prompt_confirm("Replace the default saved job? [y/N]: ")? {
         let collect_host_default = most_recent_collect_host
             .or_else(first_saved_collect_host)
             .ok_or_else(|| eyre!("Add a collect host before creating the default job"))?;
@@ -2001,7 +2007,7 @@ async fn run_init_wizard() -> Result<CommandResult> {
             .collect_from(collect_host.clone())?
             .collect_to(format!("diagnostics/{collect_host}"))?;
         save_default_job(collect_job_name, collect_job)?;
-        if let Some(output) = esdiag::data::ApplicationConfig::load()?.default_diagnostics_cluster {
+        if let Some(output) = esdiag::data::ApplicationConfig::load()?.output.default {
             let process_job_name = format!("{collect_host}-process-{output}");
             save_default_processing_job(process_job_name, collect_host)?;
         }
@@ -2020,9 +2026,10 @@ fn initialization_outcome() -> Result<CliOutcome> {
         user: config
             .user
             .ok_or_else(|| eyre!("Initialization completed without a configured user"))?,
-        output: config.default_diagnostics_cluster,
+        output: config.output.default,
         job: config
-            .default_job
+            .job
+            .default
             .ok_or_else(|| eyre!("Initialization completed without a default job"))?,
     })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3071,7 +3071,7 @@ mod tests {
 
     #[cfg(feature = "server")]
     #[test]
-    fn serve_exporter_requires_environment_when_output_is_omitted() {
+    fn serve_exporter_requires_configuration_when_output_is_omitted() {
         let _guard = env_lock().lock().expect("env lock");
         unsafe {
             std::env::remove_var("ESDIAG_OUTPUT_URL");
@@ -3081,10 +3081,10 @@ mod tests {
         }
 
         let err = match resolve_serve_exporter(None) {
-            Ok(_) => panic!("omitted output without environment must fail"),
+            Ok(_) => panic!("omitted output without a configured deployment must fail"),
             Err(err) => err,
         };
-        assert!(err.to_string().contains("ESDIAG_OUTPUT_URL is not defined"));
+        assert!(err.to_string().contains("No output deployment is configured"));
     }
 
     #[cfg(feature = "server")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ use redact::Secret;
 use std::{
     io::{IsTerminal, Write},
     path::PathBuf,
-    process::{Command, ExitCode},
+    process::ExitCode,
     str::FromStr,
     time::Duration,
 };
@@ -2174,41 +2174,18 @@ fn read_api_key_file(path: &str) -> Result<String> {
 }
 
 fn default_diagnostic_user() -> String {
-    detect_os_email()
-        .or_else(|| std::env::var("EMAIL").ok().filter(|email| email.contains('@')))
-        .or_else(|| std::env::var("USER").ok())
-        .or_else(|| std::env::var("USERNAME").ok())
+    default_diagnostic_user_from(|name| std::env::var(name).ok())
+}
+
+fn default_diagnostic_user_from<F>(get_environment: F) -> String
+where
+    F: Fn(&str) -> Option<String>,
+{
+    get_environment("EMAIL")
+        .filter(|email| email.contains('@'))
+        .or_else(|| get_environment("USER"))
+        .or_else(|| get_environment("USERNAME"))
         .unwrap_or_else(|| "user".to_string())
-}
-
-#[cfg(target_os = "macos")]
-fn detect_os_email() -> Option<String> {
-    let username = std::env::var("USER").ok()?;
-    let output = Command::new("dscl")
-        .args([".", "-read", &format!("/Users/{username}"), "EMailAddress"])
-        .output()
-        .ok()?;
-    String::from_utf8(output.stdout)
-        .ok()?
-        .split_whitespace()
-        .find(|value| value.contains('@'))
-        .map(str::to_string)
-}
-
-#[cfg(target_os = "windows")]
-fn detect_os_email() -> Option<String> {
-    let output = Command::new("whoami").arg("/upn").output().ok()?;
-    String::from_utf8(output.stdout)
-        .ok()?
-        .lines()
-        .map(str::trim)
-        .find(|value| value.contains('@'))
-        .map(str::to_string)
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
-fn detect_os_email() -> Option<String> {
-    None
 }
 
 fn format_epoch(epoch_seconds: i64) -> String {
@@ -2393,7 +2370,7 @@ fn resolve_serve_exporter(output: Option<String>) -> Result<Exporter> {
 mod tests {
     use super::{
         Cli, Commands, HostCommands, KeystoreCommands, classify_failure, colorize_keystore_lock_status,
-        command_owns_stdout, format_keystore_lock_status, format_keystore_lock_status_at,
+        command_owns_stdout, default_diagnostic_user_from, format_keystore_lock_status, format_keystore_lock_status_at,
         format_remaining_duration_from, host_connection_uses_receiver, is_agent_mode, resolve_host_secret_auth,
         resolve_secret_input_with_prompt, resolve_tracing_filter, should_error_for_missing_subcommand,
         structured_failure,
@@ -2470,6 +2447,22 @@ mod tests {
 
         let json = Cli::parse_from(["esdiag", "--format", "json", "keystore", "status"]);
         assert_eq!(json.format, OutputFormat::Json);
+    }
+
+    #[test]
+    fn default_diagnostic_user_uses_environment_without_spawning_processes() {
+        let email = default_diagnostic_user_from(|name| match name {
+            "EMAIL" => Some("operator@example.com".to_string()),
+            "USER" => Some("shell-user".to_string()),
+            _ => None,
+        });
+        let user = default_diagnostic_user_from(|name| match name {
+            "USER" => Some("shell-user".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(email, "operator@example.com");
+        assert_eq!(user, "shell-user");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1946,9 +1946,7 @@ async fn run_init_wizard() -> Result<CommandResult> {
 
     if !initial.collect_host_configured || prompt_confirm("Add or replace a collect host? [y/N]: ")? {
         loop {
-            let collect_name_default = output_name_for_defaults
-                .clone()
-                .unwrap_or_else(|| "collect".to_string());
+            let collect_name_default = output_name_for_defaults.clone().unwrap_or_else(|| "source".to_string());
             let name = prompt_with_default("Collect host name", &collect_name_default)?;
             let url = prompt_url_with_default(
                 "Collect Elasticsearch URL",
@@ -1962,9 +1960,19 @@ async fn run_init_wizard() -> Result<CommandResult> {
                     .and_then(|output| KnownHost::get_known(&output))
                     .and_then(|host| host.secret)
             } else {
-                Some(prompt_required("Collect-host credential name: ")?)
+                Some(prompt_with_default("Collect-host credential name", &name)?)
             };
-            let auth = None;
+            let auth = if reuse_output_secret {
+                None
+            } else {
+                Some(prompt_api_key("Collect-host", detected_esdiag_local_preset().as_ref())?)
+            };
+            let keystore_password = if auth.is_some() {
+                unlock_keystore(default_unlock_ttl())?;
+                Some(get_password_for_secret_commands()?)
+            } else {
+                None
+            };
             save_collect_host(
                 CollectHostInput {
                     name: name.clone(),
@@ -1973,7 +1981,7 @@ async fn run_init_wizard() -> Result<CommandResult> {
                     secret_id,
                     auth,
                 },
-                None,
+                keystore_password.as_deref(),
             )?;
             most_recent_collect_host = Some(name);
             if !prompt_confirm("Add another collect host? [y/N]: ")? {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3133,9 +3133,9 @@ mod tests {
     fn serve_exporter_rejects_partial_runtime_environment_without_leaking_secrets() {
         let _guard = env_lock().lock().expect("env lock");
         unsafe {
-            std::env::remove_var("ESDIAG_OUTPUT_URL");
-            std::env::set_var("ESDIAG_OUTPUT_APIKEY", "do-not-print-this-secret");
-            std::env::remove_var("ESDIAG_OUTPUT_USERNAME");
+            std::env::set_var("ESDIAG_OUTPUT_URL", "http://localhost:9200");
+            std::env::remove_var("ESDIAG_OUTPUT_APIKEY");
+            std::env::set_var("ESDIAG_OUTPUT_USERNAME", "do-not-print-this-secret");
             std::env::remove_var("ESDIAG_OUTPUT_PASSWORD");
         }
 
@@ -3144,11 +3144,12 @@ mod tests {
             Err(err) => err,
         };
         let message = err.to_string();
-        assert!(message.contains("ESDIAG_OUTPUT_URL is not defined"));
+        assert!(message.contains("ESDIAG_OUTPUT_USERNAME and ESDIAG_OUTPUT_PASSWORD"));
         assert!(!message.contains("do-not-print-this-secret"));
 
         unsafe {
-            std::env::remove_var("ESDIAG_OUTPUT_APIKEY");
+            std::env::remove_var("ESDIAG_OUTPUT_URL");
+            std::env::remove_var("ESDIAG_OUTPUT_USERNAME");
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2386,10 +2386,7 @@ fn resolve_serve_runtime_mode(mode: Option<RuntimeMode>) -> Result<RuntimeMode> 
 
 #[cfg(feature = "server")]
 fn resolve_serve_exporter(output: Option<String>) -> Result<Exporter> {
-    match output {
-        Some(output) => Exporter::try_from(Uri::try_from(output)?),
-        None => Exporter::try_from(Uri::try_from_output_env()?),
-    }
+    Exporter::try_from(Uri::try_from(output)?)
 }
 
 #[cfg(test)]

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -114,6 +114,13 @@ pub fn save_output_deployment(input: OutputDeploymentInput, keystore_password: &
 
 pub fn save_collect_host(input: CollectHostInput, keystore_password: Option<&str>) -> Result<()> {
     validate_name(&input.name, "collect host")?;
+    let mut hosts = KnownHost::parse_hosts_yml()?;
+    if let Some(existing) = hosts.get(&input.name).cloned() {
+        hosts.insert(input.name, existing.with_role(HostRole::Collect));
+        KnownHost::write_hosts_yml(&hosts)?;
+        return Ok(());
+    }
+
     match (&input.secret_id, &input.auth, keystore_password) {
         (Some(secret_id), Some(auth), Some(password)) => upsert_secret_auth(secret_id, auth.clone(), password)?,
         (Some(_), None, _) | (None, None, _) => {}
@@ -132,12 +139,6 @@ pub fn save_collect_host(input: CollectHostInput, keystore_password: Option<&str
         Some(auth) => builder.build_with_secret_auth(auth)?,
         None => builder.build()?,
     };
-    let mut hosts = KnownHost::parse_hosts_yml()?;
-    if let Some(existing) = hosts.get(&input.name).cloned() {
-        hosts.insert(input.name, existing.with_role(HostRole::Collect));
-        KnownHost::write_hosts_yml(&hosts)?;
-        return Ok(());
-    }
     hosts.insert(input.name, host);
     KnownHost::write_hosts_yml(&hosts)?;
     Ok(())
@@ -199,7 +200,11 @@ mod tests {
         CollectHostInput, OnboardingReadiness, OutputDeploymentInput, inspect, save_collect_host,
         save_default_processing_job, save_output_deployment, save_user,
     };
-    use crate::data::{Application, ApplicationConfig, SecretAuth, create_keystore};
+    use crate::data::{
+        Application, ApplicationConfig, HostRole, KnownHost, KnownHostBuilder, SecretAuth, create_keystore,
+        resolve_secret_auth, upsert_secret_auth,
+    };
+    use std::collections::BTreeMap;
     use url::Url;
 
     #[test]
@@ -274,5 +279,46 @@ mod tests {
         save_default_processing_job("default".to_string(), "collect-es".to_string()).expect("save default job");
 
         assert!(inspect().expect("completed readiness").is_complete());
+    }
+
+    #[test]
+    fn existing_collect_host_does_not_update_unrelated_credentials() {
+        let _env = crate::TestEnv::new();
+        create_keystore("pw").expect("create keystore");
+        upsert_secret_auth("existing-secret", SecretAuth::apikey("existing-key"), "pw").expect("save secret");
+        let existing = KnownHostBuilder::new(Url::parse("https://existing.example:9200").expect("url"))
+            .application(Application::Elasticsearch)
+            .secret(Some("existing-secret".to_string()))
+            .build()
+            .expect("host");
+        KnownHost::write_hosts_yml(&BTreeMap::from([("existing".to_string(), existing)])).expect("write host");
+
+        save_collect_host(
+            CollectHostInput {
+                name: "existing".to_string(),
+                app: Application::Elasticsearch,
+                url: Url::parse("https://replacement.example:9200").expect("url"),
+                secret_id: Some("replacement-secret".to_string()),
+                auth: Some(SecretAuth::apikey("replacement-key")),
+            },
+            Some("pw"),
+        )
+        .expect("mark existing host collectable");
+
+        let host = KnownHost::get_known(&"existing".to_string()).expect("existing host");
+        assert!(host.has_role(HostRole::Collect));
+        assert_eq!(host.secret_reference(), Some("existing-secret"));
+        assert_eq!(
+            host.concrete_url().map(Url::as_str),
+            Some("https://existing.example:9200/")
+        );
+        assert_eq!(
+            resolve_secret_auth("existing-secret", "pw").expect("resolve existing secret"),
+            Some(SecretAuth::apikey("existing-key"))
+        );
+        assert_eq!(
+            resolve_secret_auth("replacement-secret", "pw").expect("resolve replacement secret"),
+            None
+        );
     }
 }

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -51,11 +51,12 @@ pub fn inspect() -> Result<OnboardingReadiness> {
     let jobs = crate::data::load_saved_jobs()?;
 
     let output_configured = config
-        .default_diagnostics_cluster
+        .output
+        .default
         .as_ref()
         .is_some_and(|name| hosts.get(name).is_some_and(valid_output_host));
     let collect_host_configured = hosts.values().any(|host| host.has_role(HostRole::Collect));
-    let default_job_configured = config.default_job.as_ref().is_some_and(|name| jobs.contains_key(name));
+    let default_job_configured = config.job.default.as_ref().is_some_and(|name| jobs.contains_key(name));
 
     Ok(OnboardingReadiness {
         user_configured: config.user.as_deref().is_some_and(|user| !user.trim().is_empty()),
@@ -106,7 +107,7 @@ pub fn save_output_deployment(input: OutputDeploymentInput, keystore_password: &
     KnownHost::write_hosts_yml(&hosts)?;
 
     let mut config = ApplicationConfig::load()?;
-    config.default_diagnostics_cluster = Some(input.output_name);
+    config.output.default = Some(input.output_name);
     config.save()?;
     Ok(config)
 }
@@ -153,7 +154,8 @@ pub fn save_default_processing_job(name: String, collect_host: String) -> Result
     }
     let config = ApplicationConfig::load()?;
     let output = config
-        .default_diagnostics_cluster
+        .output
+        .default
         .clone()
         .ok_or_else(|| eyre!("A validated output deployment is required before creating a default job"))?;
     let job = Job::builder()
@@ -169,7 +171,7 @@ pub fn save_default_job(name: String, job: Job) -> Result<ApplicationConfig> {
     save_saved_jobs(&jobs)?;
 
     let mut config = ApplicationConfig::load()?;
-    config.default_job = Some(name);
+    config.job.default = Some(name);
     config.validate_references()?;
     config.save()?;
     Ok(config)

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -1,0 +1,276 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//! Flow-neutral operations used by terminal and future GUI onboarding.
+
+use crate::data::{
+    Application, ApplicationConfig, HostRole, Job, JobOutput, KnownHost, KnownHostBuilder, SavedJobs, SecretAuth,
+    keystore_exists, save_saved_jobs, upsert_secret_auth,
+};
+use eyre::{Result, eyre};
+use url::Url;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct OnboardingReadiness {
+    pub user_configured: bool,
+    pub keystore_ready: bool,
+    pub output_configured: bool,
+    pub collect_host_configured: bool,
+    pub default_job_configured: bool,
+}
+
+impl OnboardingReadiness {
+    pub fn is_complete(&self) -> bool {
+        self.user_configured && self.collect_host_configured && self.default_job_configured
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct OutputDeploymentInput {
+    pub output_name: String,
+    pub output_url: Url,
+    pub viewer_name: String,
+    pub viewer_url: Url,
+    pub secret_id: String,
+    pub auth: SecretAuth,
+}
+
+#[derive(Clone, Debug)]
+pub struct CollectHostInput {
+    pub name: String,
+    pub app: Application,
+    pub url: Url,
+    pub secret_id: Option<String>,
+    pub auth: Option<SecretAuth>,
+}
+
+pub fn inspect() -> Result<OnboardingReadiness> {
+    let config = ApplicationConfig::load()?;
+    let hosts = KnownHost::parse_hosts_yml()?;
+    let jobs = crate::data::load_saved_jobs()?;
+
+    let output_configured = config
+        .default_diagnostics_cluster
+        .as_ref()
+        .is_some_and(|name| hosts.get(name).is_some_and(valid_output_host));
+    let collect_host_configured = hosts.values().any(|host| host.has_role(HostRole::Collect));
+    let default_job_configured = config.default_job.as_ref().is_some_and(|name| jobs.contains_key(name));
+
+    Ok(OnboardingReadiness {
+        user_configured: config.user.as_deref().is_some_and(|user| !user.trim().is_empty()),
+        keystore_ready: keystore_exists()?,
+        output_configured,
+        collect_host_configured,
+        default_job_configured,
+    })
+}
+
+pub fn save_user(user: String) -> Result<ApplicationConfig> {
+    let user = user.trim();
+    if user.is_empty() {
+        return Err(eyre!("A default diagnostic user is required"));
+    }
+    let mut config = ApplicationConfig::load()?;
+    config.user = Some(user.to_string());
+    config.save()?;
+    Ok(config)
+}
+
+/// Persists one linked Elasticsearch/Kibana deployment after the caller has
+/// completed any remote validation it requires.
+pub fn save_output_deployment(input: OutputDeploymentInput, keystore_password: &str) -> Result<ApplicationConfig> {
+    validate_name(&input.output_name, "output host")?;
+    validate_name(&input.viewer_name, "Kibana viewer")?;
+    validate_name(&input.secret_id, "secret")?;
+    if input.output_name == input.viewer_name {
+        return Err(eyre!("Output host and Kibana viewer names must differ"));
+    }
+
+    upsert_secret_auth(&input.secret_id, input.auth.clone(), keystore_password)?;
+    let output = KnownHostBuilder::new(input.output_url)
+        .application(Application::Elasticsearch)
+        .roles(vec![HostRole::Send])
+        .viewer(Some(input.viewer_name.clone()))
+        .secret(Some(input.secret_id.clone()))
+        .build_with_secret_auth(input.auth.clone())?;
+    let viewer = KnownHostBuilder::new(input.viewer_url)
+        .application(Application::Kibana)
+        .roles(vec![HostRole::View])
+        .secret(Some(input.secret_id))
+        .build_with_secret_auth(input.auth)?;
+
+    let mut hosts = KnownHost::parse_hosts_yml()?;
+    hosts.insert(input.output_name.clone(), output);
+    hosts.insert(input.viewer_name, viewer);
+    KnownHost::write_hosts_yml(&hosts)?;
+
+    let mut config = ApplicationConfig::load()?;
+    config.default_diagnostics_cluster = Some(input.output_name);
+    config.save()?;
+    Ok(config)
+}
+
+pub fn save_collect_host(input: CollectHostInput, keystore_password: Option<&str>) -> Result<()> {
+    validate_name(&input.name, "collect host")?;
+    match (&input.secret_id, &input.auth, keystore_password) {
+        (Some(secret_id), Some(auth), Some(password)) => upsert_secret_auth(secret_id, auth.clone(), password)?,
+        (Some(_), None, _) | (None, None, _) => {}
+        _ => {
+            return Err(eyre!(
+                "Collect-host credentials require a secret id, authentication value, and unlocked keystore"
+            ));
+        }
+    }
+
+    let builder = KnownHostBuilder::new(input.url)
+        .application(input.app)
+        .roles(vec![HostRole::Collect])
+        .secret(input.secret_id);
+    let host = match input.auth {
+        Some(auth) => builder.build_with_secret_auth(auth)?,
+        None => builder.build()?,
+    };
+    let mut hosts = KnownHost::parse_hosts_yml()?;
+    if let Some(existing) = hosts.get(&input.name).cloned() {
+        hosts.insert(input.name, existing.with_role(HostRole::Collect));
+        KnownHost::write_hosts_yml(&hosts)?;
+        return Ok(());
+    }
+    hosts.insert(input.name, host);
+    KnownHost::write_hosts_yml(&hosts)?;
+    Ok(())
+}
+
+pub fn save_default_processing_job(name: String, collect_host: String) -> Result<ApplicationConfig> {
+    validate_name(&name, "default job")?;
+    let collect = KnownHost::get_known(&collect_host)
+        .ok_or_else(|| eyre!("Configured collect host '{collect_host}' was not found"))?;
+    if !collect.has_role(HostRole::Collect) {
+        return Err(eyre!(
+            "Configured collect host '{collect_host}' must include role 'collect'"
+        ));
+    }
+    let config = ApplicationConfig::load()?;
+    let output = config
+        .default_diagnostics_cluster
+        .clone()
+        .ok_or_else(|| eyre!("A validated output deployment is required before creating a default job"))?;
+    let job = Job::builder()
+        .collect_from(collect_host)?
+        .process_to(JobOutput::KnownHost { name: output })?;
+    save_default_job(name, job)
+}
+
+pub fn save_default_job(name: String, job: Job) -> Result<ApplicationConfig> {
+    validate_name(&name, "default job")?;
+    let mut jobs: SavedJobs = crate::data::load_saved_jobs()?;
+    jobs.insert(name.clone(), job);
+    save_saved_jobs(&jobs)?;
+
+    let mut config = ApplicationConfig::load()?;
+    config.default_job = Some(name);
+    config.validate_references()?;
+    config.save()?;
+    Ok(config)
+}
+
+fn valid_output_host(host: &KnownHost) -> bool {
+    host.app() == Some(Application::Elasticsearch)
+        && host.has_role(HostRole::Send)
+        && host
+            .viewer()
+            .and_then(|name| KnownHost::get_known(&name.to_string()))
+            .is_some_and(|viewer| viewer.app() == Some(Application::Kibana) && viewer.has_role(HostRole::View))
+}
+
+fn validate_name(name: &str, kind: &str) -> Result<()> {
+    if name.trim().is_empty() {
+        return Err(eyre!("{kind} name cannot be empty"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CollectHostInput, OnboardingReadiness, OutputDeploymentInput, inspect, save_collect_host,
+        save_default_processing_job, save_output_deployment, save_user,
+    };
+    use crate::data::{Application, ApplicationConfig, SecretAuth, create_keystore};
+    use url::Url;
+
+    #[test]
+    fn onboarding_operations_persist_a_linked_output_and_collect_host() {
+        let _env = crate::TestEnv::new();
+        create_keystore("pw").expect("create keystore");
+        save_output_deployment(
+            OutputDeploymentInput {
+                output_name: "output-es".to_string(),
+                output_url: Url::parse("https://es.example:9200").expect("url"),
+                viewer_name: "output-kibana".to_string(),
+                viewer_url: Url::parse("https://kb.example:5601").expect("url"),
+                secret_id: "output-auth".to_string(),
+                auth: SecretAuth::apikey("secret"),
+            },
+            "pw",
+        )
+        .expect("save output");
+        save_collect_host(
+            CollectHostInput {
+                name: "collect-es".to_string(),
+                app: Application::Elasticsearch,
+                url: Url::parse("https://collect.example:9200").expect("url"),
+                secret_id: None,
+                auth: None,
+            },
+            None,
+        )
+        .expect("save collect host");
+
+        let config = ApplicationConfig::load().expect("load config");
+        let readiness = inspect().expect("inspect readiness");
+
+        assert_eq!(config.default_diagnostics_cluster.as_deref(), Some("output-es"));
+        assert!(readiness.keystore_ready);
+        assert!(readiness.output_configured);
+        assert!(readiness.collect_host_configured);
+        assert!(!OnboardingReadiness::is_complete(&readiness));
+    }
+
+    #[test]
+    fn readiness_resumes_after_independently_persisted_stages() {
+        let _env = crate::TestEnv::new();
+        create_keystore("pw").expect("create keystore");
+        save_output_deployment(
+            OutputDeploymentInput {
+                output_name: "output-es".to_string(),
+                output_url: Url::parse("https://es.example:9200").expect("url"),
+                viewer_name: "output-kibana".to_string(),
+                viewer_url: Url::parse("https://kb.example:5601").expect("url"),
+                secret_id: "output-auth".to_string(),
+                auth: SecretAuth::apikey("secret"),
+            },
+            "pw",
+        )
+        .expect("save output");
+        save_collect_host(
+            CollectHostInput {
+                name: "collect-es".to_string(),
+                app: Application::Elasticsearch,
+                url: Url::parse("https://collect.example:9200").expect("url"),
+                secret_id: None,
+                auth: None,
+            },
+            None,
+        )
+        .expect("save collect host");
+
+        assert!(!inspect().expect("partial readiness").is_complete());
+
+        save_user("operator@example.com".to_string()).expect("save user");
+        save_default_processing_job("default".to_string(), "collect-es".to_string()).expect("save default job");
+
+        assert!(inspect().expect("completed readiness").is_complete());
+    }
+}

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -233,7 +233,7 @@ mod tests {
         let config = ApplicationConfig::load().expect("load config");
         let readiness = inspect().expect("inspect readiness");
 
-        assert_eq!(config.default_diagnostics_cluster.as_deref(), Some("output-es"));
+        assert_eq!(config.output.default.as_deref(), Some("output-es"));
         assert!(readiness.keystore_ready);
         assert!(readiness.output_configured);
         assert!(readiness.collect_host_configured);

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -4,7 +4,7 @@
 
 use super::super::elasticsearch::{ClusterMetadata, License as ElasticsearchLicense};
 use super::{DiagnosticManifest, DiagnosticMetadata, Lookup};
-use crate::data::{Application, Platform};
+use crate::data::{Application, ApplicationConfig, Platform};
 use eyre::{OptionExt, Report, Result, eyre};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{NoneAsEmptyString, serde_as, skip_serializing_none};
@@ -160,7 +160,7 @@ impl Identifiers {
             case_number: normalize_identifier(case_number),
             filename: normalize_identifier(filename),
             opportunity: normalize_identifier(opportunity),
-            user: normalize_identifier(user).or_else(|| normalize_identifier(std::env::var("ESDIAG_USER").ok())),
+            user: resolve_default_user(user),
             parent_id: None,
             platform: None,
         }
@@ -201,7 +201,7 @@ impl Identifiers {
 
 impl Default for Identifiers {
     fn default() -> Self {
-        let user = normalize_identifier(std::env::var("ESDIAG_USER").ok());
+        let user = resolve_default_user(None);
         Self {
             account: None,
             case_number: None,
@@ -212,6 +212,16 @@ impl Default for Identifiers {
             platform: None,
         }
     }
+}
+
+fn resolve_default_user(explicit: Option<String>) -> Option<String> {
+    normalize_identifier(explicit)
+        .or_else(|| normalize_identifier(std::env::var("ESDIAG_USER").ok()))
+        .or_else(|| {
+            ApplicationConfig::load()
+                .ok()
+                .and_then(|config| normalize_identifier(config.user))
+        })
 }
 
 fn normalize_identifier(value: Option<String>) -> Option<String> {
@@ -975,6 +985,58 @@ impl TryFrom<String> for Origin {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::data::ApplicationConfig;
+
+    #[test]
+    fn configured_user_supplies_an_omitted_identifier() {
+        let mut env = crate::TestEnv::new();
+        env.remove("ESDIAG_USER");
+        ApplicationConfig {
+            version: 1,
+            user: Some("configured@example.com".to_string()),
+            ..ApplicationConfig::new()
+        }
+        .save()
+        .expect("save application config");
+
+        let identifiers = Identifiers::new(None, None, None, None, None);
+
+        assert_eq!(identifiers.user.as_deref(), Some("configured@example.com"));
+    }
+
+    #[test]
+    fn environment_user_precedes_configured_user() {
+        let mut env = crate::TestEnv::new();
+        env.set("ESDIAG_USER", "environment@example.com");
+        ApplicationConfig {
+            version: 1,
+            user: Some("configured@example.com".to_string()),
+            ..ApplicationConfig::new()
+        }
+        .save()
+        .expect("save application config");
+
+        let identifiers = Identifiers::new(None, None, None, None, None);
+
+        assert_eq!(identifiers.user.as_deref(), Some("environment@example.com"));
+    }
+
+    #[test]
+    fn explicit_user_precedes_environment_and_configured_user() {
+        let mut env = crate::TestEnv::new();
+        env.set("ESDIAG_USER", "environment@example.com");
+        ApplicationConfig {
+            version: 1,
+            user: Some("configured@example.com".to_string()),
+            ..ApplicationConfig::new()
+        }
+        .save()
+        .expect("save application config");
+
+        let identifiers = Identifiers::new(None, None, None, None, Some("explicit@example.com".to_string()));
+
+        assert_eq!(identifiers.user.as_deref(), Some("explicit@example.com"));
+    }
 
     #[test]
     fn test_lookup_parsed_status() {


### PR DESCRIPTION
## Summary
- add interactive CLI onboarding with persisted local configuration and output resolution
- support collection-only and diagnostics-cluster processing workflows with secure credential sources
- add first-run OpenSpec artifacts and documentation

## Test plan
- [x] `cargo test --all-features`
- [x] `cargo check --all-features`
- [x] strict OpenSpec validation


Made with [Cursor](https://cursor.com)