### PR TITLE
Release 0.16.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ published release notes, maintenance branches, and tagged history.
 
 ## [Unreleased]
 
+## [0.16.5] - 2026-08-20
+
+### Fixed
+
+- Fixed the shared web statistics counter so completed jobs add their processed documents (#380).
+- Fixed web processing with an explicit `serve` output so it no longer requires `ESDIAG_OUTPUT_URL`.
+
 ## [0.16.4] - 2026-08-07
 
 ### Changed
@@ -225,7 +232,8 @@ published release notes, maintenance branches, and tagged history.
   fail on invalid zip paths (#177).
 - Fixed ECK diagnostic path handling for correctly structured archives (#179).
 
-[Unreleased]: https://github.com/elastic/esdiag/compare/0.16.4...0.16
+[Unreleased]: https://github.com/elastic/esdiag/compare/0.16.5...0.16
+[0.16.5]: https://github.com/elastic/esdiag/compare/0.16.4...0.16.5
 [0.16.4]: https://github.com/elastic/esdiag/compare/0.16.2...0.16.4
 [0.16.2]: https://github.com/elastic/esdiag/compare/0.16.1...0.16.2
 [0.16.1]: https://github.com/elastic/esdiag/compare/0.16.0...0.16.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "esdiag"
-version = "0.16.4"
+version = "0.16.5"
 dependencies = [
  "aes-gcm-siv",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esdiag"
-version = "0.16.4"
+version = "0.16.5"
 description = "Elastic Stack diagnostic collector and processor"
 repository = "https://github.com/elastic/esdiag"
 homepage = "https://github.com/elastic/esdiag"

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -5958,7 +5958,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Elastic License 2.0
 
 #### Used by
-- [esdiag]( https://github.com/elastic/esdiag ) 0.16.4
+- [esdiag]( https://github.com/elastic/esdiag ) 0.16.5
 
 #### License
 ```

--- a/bin/esdiag-local
+++ b/bin/esdiag-local
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-readonly ESDIAG_VERSION="0.16.4"
+readonly ESDIAG_VERSION="0.16.5"
 readonly ELASTIC_VERSION="9.4.2"
 readonly STATE_SCHEMA_VERSION="2"
 readonly DEFAULT_ESDIAG_IMAGE="docker.elastic.co/esdiag/esdiag:${ESDIAG_VERSION}"

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -612,8 +612,8 @@ The Job Builder flag only controls web UI routes. CLI saved-job commands such as
 
 `serve` uses the same output target rules as `process`. User mode does not add
 an implicit stdout fallback: omit the output only when `ESDIAG_OUTPUT_*` defines
-a valid target. The web workflow represents an omitted explicit output as
-`Default` and resolves it through those environment variables.
+a valid target. The web workflow uses the output configured when the server
+started; `Default` resolves to that active target.
 
 ### Examples
 

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -105,9 +105,9 @@ Several commands accept an optional output target. The current resolution rules 
 - `-` means stdout
 - A string matching a saved host name resolves to that known host
 - Any other non-empty string is treated as a local filesystem target
-- If output is omitted entirely, `esdiag` falls back to `ESDIAG_OUTPUT_URL` plus optional auth env vars
-- In the web workflow, the `Default` remote output sends no explicit target and uses the same environment fallback
-- If neither an explicit target nor a valid environment output is available, processing fails instead of using stdout
+- `process` falls back to `ESDIAG_OUTPUT_URL` plus optional auth environment variables when output is omitted
+- `serve` requires either an explicit output or `ESDIAG_OUTPUT_*` when it starts; its web workflow `Default` output uses that active server target
+- `process` and `serve` fail instead of using stdout when neither an explicit target nor a valid environment output is available
 
 This applies to:
 

--- a/example.env
+++ b/example.env
@@ -11,7 +11,7 @@
 # environment variables are used to create a `~/.esdiag` user directory to
 # save configuration and debug information.
 
-export ESDIAG_VERSION="0.16.4"
+export ESDIAG_VERSION="0.16.5"
 
 ########################## esdiag #################################
 

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -802,6 +802,7 @@ fn terminal_job_event(replace_existing_entry: bool, job_id: u64, template: impl 
 async fn select_processed_exporter(state: Arc<ServerState>, signals: &JobRunSignals) -> Result<Exporter> {
     match signals.job.send.mode {
         SendMode::Remote => {
+            let configured = state.exporter.read().await.clone();
             let Some(target) = signals
                 .job
                 .send
@@ -810,10 +811,9 @@ async fn select_processed_exporter(state: Arc<ServerState>, signals: &JobRunSign
                 .map(str::trim)
                 .filter(|target| !target.is_empty())
             else {
-                return Exporter::try_from(Uri::try_from_output_env()?);
+                return Ok(configured);
             };
 
-            let configured = state.exporter.read().await.clone();
             if target == configured.target_uri() {
                 Ok(configured)
             } else {
@@ -1142,8 +1142,8 @@ async fn cleanup_local_path(path: &Path) {
 #[allow(clippy::await_holding_lock)]
 mod tests {
     use super::{
-        download_service_link_to_path, run_job, select_processed_exporter, validate_job_request,
-        validate_local_send_uri, validate_remote_send_uri,
+        download_service_link_to_path, select_processed_exporter, validate_job_request, validate_local_send_uri,
+        validate_remote_send_uri,
     };
     use crate::{
         data::{HostRole, KnownHostBuilder, Product, Uri},
@@ -1159,7 +1159,7 @@ mod tests {
         sync::{Arc, Mutex},
     };
     use tokio::net::TcpListener;
-    use tokio::sync::{RwLock, broadcast, mpsc, watch};
+    use tokio::sync::{RwLock, broadcast, watch};
     use url::Url;
 
     fn env_lock() -> &'static Mutex<()> {
@@ -1286,113 +1286,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remote_send_without_ui_target_uses_output_environment() {
+    async fn remote_send_without_ui_target_uses_configured_directory_exporter() {
         let _guard = env_lock().lock().expect("env lock");
         unsafe {
-            std::env::set_var("ESDIAG_OUTPUT_URL", "http://localhost:9200");
-            std::env::set_var("ESDIAG_OUTPUT_APIKEY", "runtime-secret");
+            std::env::remove_var("ESDIAG_OUTPUT_URL");
+            std::env::remove_var("ESDIAG_OUTPUT_APIKEY");
             std::env::remove_var("ESDIAG_OUTPUT_USERNAME");
             std::env::remove_var("ESDIAG_OUTPUT_PASSWORD");
         }
 
         let state = Arc::new(test_state(RuntimeMode::User));
+        let output_dir = tempfile::tempdir().expect("output directory");
+        let configured =
+            Exporter::try_from(Uri::try_from(output_dir.path().to_string_lossy().to_string()).expect("output URI"))
+                .expect("configured exporter");
+        *state.exporter.write().await = configured.clone();
         let mut signals = JobRunSignals::default();
         signals.job.send.mode = SendMode::Remote;
         signals.job.send.remote_target = None;
 
         let selected = select_processed_exporter(state, &signals)
             .await
-            .expect("select environment exporter");
-        assert_eq!(selected.target_uri(), "http://localhost:9200/");
-
-        unsafe {
-            std::env::remove_var("ESDIAG_OUTPUT_URL");
-            std::env::remove_var("ESDIAG_OUTPUT_APIKEY");
-        }
-    }
-
-    #[tokio::test]
-    async fn remote_send_without_ui_target_or_environment_fails() {
-        let _guard = env_lock().lock().expect("env lock");
-        unsafe {
-            std::env::remove_var("ESDIAG_OUTPUT_URL");
-            std::env::remove_var("ESDIAG_OUTPUT_APIKEY");
-            std::env::remove_var("ESDIAG_OUTPUT_USERNAME");
-            std::env::remove_var("ESDIAG_OUTPUT_PASSWORD");
-        }
-
-        let state = Arc::new(test_state(RuntimeMode::User));
-        let mut signals = JobRunSignals::default();
-        signals.job.send.mode = SendMode::Remote;
-        signals.job.send.remote_target = None;
-
-        let err = match select_processed_exporter(state, &signals).await {
-            Ok(_) => panic!("missing UI target and environment must fail"),
-            Err(err) => err,
-        };
-        assert!(err.to_string().contains("ESDIAG_OUTPUT_URL is not defined"));
-    }
-
-    #[tokio::test]
-    #[allow(clippy::await_holding_lock)]
-    async fn remote_setup_failure_replaces_processing_entry_and_clears_ui_state() {
-        let _guard = env_lock().lock().expect("env lock");
-        unsafe {
-            std::env::remove_var("ESDIAG_OUTPUT_URL");
-            std::env::remove_var("ESDIAG_OUTPUT_APIKEY");
-            std::env::remove_var("ESDIAG_OUTPUT_USERNAME");
-            std::env::remove_var("ESDIAG_OUTPUT_PASSWORD");
-        }
-
-        let host = KnownHostBuilder::new(Url::parse("http://cluster.example:9200").unwrap())
-            .roles(vec![HostRole::Collect])
-            .build()
-            .unwrap();
-        let mut signals = JobRunSignals::default();
-        signals.job.collect.source = CollectSource::ApiKey;
-        signals.job.send.mode = SendMode::Remote;
-        signals.job.send.remote_target = None;
-        let job = JobRequest {
-            identifiers: Default::default(),
-            input: JobInput::FromRemoteHost {
-                source: "http://cluster.example:9200".to_string(),
-                host,
-                diagnostic_type: "standard".to_string(),
-            },
-        };
-        let (tx, mut rx) = mpsc::channel(8);
-
-        run_job(
-            Arc::new(test_state(RuntimeMode::User)),
-            signals,
-            42,
-            "Anonymous".to_string(),
-            tx,
-            job,
-            false,
-        )
-        .await;
-
-        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
-        assert!(matches!(
-            events.first(),
-            Some(ServerEvent::JobFeed(html))
-                if html.contains("id=\"job-42\"") && html.contains("Processing")
-        ));
-        assert!(events.iter().any(|event| matches!(
-            event,
-            ServerEvent::ReplaceSelector { selector, html }
-                if selector == "#job-42"
-                    && html.contains("id=\"job-42\"")
-                    && html.contains("Processing Failed")
-                    && html.contains("ESDIAG_OUTPUT_URL is not defined")
-        )));
-        assert!(events.iter().any(|event| matches!(
-            event,
-            ServerEvent::Signals(payload)
-                if payload.contains(r#""loading":false"#)
-                    && payload.contains(r#""processing":false"#)
-        )));
+            .expect("select configured exporter");
+        assert_eq!(selected.target_uri(), configured.target_uri());
     }
 
     #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -284,7 +284,7 @@ impl Server {
     pub async fn start_with_web_features(
         bind_addr: [u8; 4],
         port: u16,
-        mut exporter: Exporter,
+        exporter: Exporter,
         kibana_url: String,
         runtime_mode: RuntimeMode,
         web_features: Option<&str>,
@@ -292,7 +292,6 @@ impl Server {
         let (_, rx) = mpsc::channel::<(Identifiers, Bytes)>(1);
         let rx = Arc::new(RwLock::new(rx));
         let rx_clone = rx.clone();
-        let docs_rx = exporter.get_docs_rx();
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let (stats_updates_tx, stats_updates_rx) = watch::channel(0u64);
 
@@ -318,14 +317,6 @@ impl Server {
         });
 
         stats::spawn_stats_publisher(state.clone(), state.event_sender());
-
-        let docs_state = state.clone();
-        tokio::spawn(async move {
-            let mut docs_rx = docs_rx;
-            while let Some(doc_count) = docs_rx.recv().await {
-                docs_state.add_docs_count(doc_count).await;
-            }
-        });
 
         let handle = axum_server::Handle::new();
         let handle_clone = handle.clone();
@@ -595,8 +586,9 @@ impl ServerState {
         Ok((has_header, email))
     }
 
-    pub async fn record_success(&self, _docs: u32, errors: u32) {
+    pub async fn record_success(&self, docs: u32, errors: u32) {
         let mut stats = self.stats.write().await;
+        stats.docs.total += docs as usize;
         stats.docs.errors += errors as usize;
         stats.jobs.total += 1;
         stats.jobs.success += 1;
@@ -614,13 +606,6 @@ impl ServerState {
         if stats.jobs.active > 0 {
             stats.jobs.active -= 1;
         }
-        drop(stats);
-        self.notify_stats_changed();
-    }
-
-    pub async fn add_docs_count(&self, doc_count: usize) {
-        let mut stats = self.stats.write().await;
-        stats.docs.total += doc_count;
         drop(stats);
         self.notify_stats_changed();
     }
@@ -1495,6 +1480,16 @@ mod tests {
         let result = test();
         drop(env_guard);
         result
+    }
+
+    #[tokio::test]
+    async fn successful_job_records_processed_documents_in_shared_stats() {
+        let state = test_server_state();
+
+        state.record_success(4636, 0).await;
+
+        let stats = state.get_stats().await;
+        assert_eq!(stats.docs.total, 4636);
     }
 
     #[test]

--- a/tests/bin/esdiag-control.sh
+++ b/tests/bin/esdiag-control.sh
@@ -12,7 +12,7 @@ assert_not_contains() { ! grep -Fq -- "$2" "$1" || fail "$1 contains unexpected 
 mkdir -p "$tmp/repo/bin" "$tmp/repo/docker" "$tmp/bin"
 cp "$root/bin/esdiag-control" "$tmp/repo/bin/esdiag-control"
 chmod 755 "$tmp/repo/bin/esdiag-control"
-printf '%s\n' '[package]' 'version = "0.16.4"' >"$tmp/repo/Cargo.toml"
+printf '%s\n' '[package]' 'version = "0.16.5"' >"$tmp/repo/Cargo.toml"
 : >"$tmp/repo/docker/Dockerfile"
 cat >"$tmp/repo/bin/esdiag-local" <<'EOF'
 #!/usr/bin/env bash
@@ -35,15 +35,15 @@ if (cd "$tmp/repo" && PATH="$tmp/bin:$PATH" bin/esdiag-control up --runtime podm
 assert_contains "$tmp/insecure-error" 'Unknown option: --insecure'
 
 (cd "$tmp/repo" && PATH="$tmp/bin:$PATH" bin/esdiag-control up --runtime podman --open-browser=false)
-assert_contains "$tmp/runtime.log" 'build --file docker/Dockerfile . --tag esdiag:latest --tag esdiag:0.16.4'
-assert_contains "$tmp/delegate.log" 'image=esdiag:0.16.4'
+assert_contains "$tmp/runtime.log" 'build --file docker/Dockerfile . --tag esdiag:latest --tag esdiag:0.16.5'
+assert_contains "$tmp/delegate.log" 'image=esdiag:0.16.5'
 assert_contains "$tmp/delegate.log" 'args=up'
 assert_contains "$tmp/delegate.log" '--pull never'
 assert_contains "$tmp/delegate.log" 'repo/target/esdiag-local'
 
 : >"$tmp/delegate.log"
 (cd "$tmp/repo" && PATH="$tmp/bin:$PATH" ESDIAG_LOCAL_DIR="$tmp/custom state" bin/esdiag-control setup --runtime podman)
-assert_contains "$tmp/delegate.log" 'image=esdiag:0.16.4'
+assert_contains "$tmp/delegate.log" 'image=esdiag:0.16.5'
 assert_contains "$tmp/delegate.log" 'args=setup'
 assert_contains "$tmp/delegate.log" '--pull never'
 assert_contains "$tmp/delegate.log" "--state-dir $tmp/custom state"

--- a/tests/esdiag-local.sh
+++ b/tests/esdiag-local.sh
@@ -73,7 +73,7 @@ export FAKE_CLIPBOARD="$tmp/clipboard" FAKE_UI_LOG="$tmp/ui.log"
 
 # Shell, help, platform adapters, and repository-independent execution.
 bash -n "$script"
-[[ "$($script version)" == "0.16.4" ]] || fail version
+[[ "$($script version)" == "0.16.5" ]] || fail version
 PATH="$fake_bin:$PATH" ESDIAG_TEST_OS=Darwin "$script" help >"$tmp/help-macos"
 PATH="$fake_bin:$PATH" ESDIAG_TEST_OS=Linux "$script" help >"$tmp/help-linux"
 PATH="$fake_bin:$PATH" ESDIAG_TEST_OS=Linux ESDIAG_TEST_WSL=true "$script" help >"$tmp/help-wsl"


### PR DESCRIPTION
## Summary
- Release 0.16.5 with the shared web document-statistics fix (#380).
- Use the active `serve` output for web processing when no job-specific output is selected.
- Align release metadata, local-stack image tags, generated notices, and tests to 0.16.5.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check`
- [x] `cargo test`
- [x] `shellcheck bin/esdiag-local`
- [x] `bash tests/esdiag-local.sh`
- [x] `bash tests/bin/esdiag-control.sh`

Made with [Cursor](https://cursor.com)