### PR TITLE
Make Homebrew update a release completion gate

### DIFF
--- a/.agents/skills/esdiag-release/SKILL.md
+++ b/.agents/skills/esdiag-release/SKILL.md
@@ -64,8 +64,9 @@ Read only the target references required by the release:
    becomes public. Never change those assets after publication.
 7. Stop for explicit approval before publishing crates.io or changing a GitHub
    release from draft to public. A human publishes the GitHub release.
-8. Update the Homebrew Formula only after the GitHub release is public, stable,
-   complete, and immutable.
+8. Complete the Homebrew target only after the GitHub release is public,
+   stable, complete, and immutable. Follow its reference through the checked
+   tap PR and include that PR in the release handoff.
 
 ## Shared Invariants
 

--- a/.agents/skills/esdiag-release/references/homebrew.md
+++ b/.agents/skills/esdiag-release/references/homebrew.md
@@ -84,9 +84,16 @@ brew install --build-from-source elastic/tools/esdiag
 brew test elastic/tools/esdiag
 ```
 
-Commit the Formula update and open a PR against `elastic/homebrew-tools`. No
-bottle publication is required: Apple Silicon macOS and Linux use verified
-upstream binaries, while Intel macOS builds the locked tagged source.
+Create a branch from the current `elastic/homebrew-tools` `main`, commit only
+the Formula update, and open the PR using the release operator's GitHub
+identity. Wait for the normal pull-request checks and require every check to
+pass. Record the PR URL in the release handoff. The Homebrew target is complete
+when that PR exists and its checks pass.
+
+The release operator supplies the exact `VERSION`; release discovery does not
+run on a schedule. No bottle publication is required: Apple Silicon macOS and
+Linux use verified upstream binaries, while Intel macOS builds the locked
+tagged source.
 
 If a public release has missing or incorrect assets, cut a new patch release;
 do not mutate the published release.


### PR DESCRIPTION
## Summary
- make the Homebrew tap PR and passing checks part of ESDiag release completion
- require the release operator to use an explicit version and human GitHub identity
- remove scheduled release discovery from the documented process

## Test plan
- [x] Run `git diff --check`
- [x] Review the release skill and Homebrew target instructions together


Made with [Cursor](https://cursor.com)