### PR TITLE
feat: add elasticrc configuration library

### DIFF
--- a/.agents/skills/esdiag-release/SKILL.md
+++ b/.agents/skills/esdiag-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: esdiag-release
-description: Prepare and verify ESDiag numbered releases, with explicit human approval for publication. Use when cutting a maintenance branch, setting a stable version, drafting notes, publishing containers or the crates.io crate, creating a numeric tag, attaching native Homebrew assets, updating the elastic/tools Formula, or validating a draft GitHub release.
+description: Prepare and verify ESDiag numbered releases, with explicit human approval for publication. Use when cutting a maintenance branch, setting a stable version, drafting notes, publishing containers or crates.io crates, creating a numeric tag, attaching native Homebrew assets, updating the elastic/tools Formula, or validating a draft GitHub release.
 ---
 
 # ESDiag Release
@@ -24,7 +24,13 @@ HOMEBREW_REPO=$HOME/Development/elastic/homebrew-tools
 ```
 
 ESDiag uses numeric tags without a leading `v`. Keep `VERSION`, the Cargo
-package version, `bin/esdiag-local`, the full image tag, and `TAG` aligned.
+package version, `bin/esdiag-local`, the full image tag, and `TAG` aligned for
+an ESDiag application release. `elasticrc` has an independent version when it
+is released as a standalone crate.
+
+Set `CRATE` to the selected Cargo package before following the crates.io
+target. Publishing `elasticrc` does not publish `esdiag` or require changing
+the ESDiag application version.
 
 ## Target References
 
@@ -34,8 +40,8 @@ Read only the target references required by the release:
   draft workflow, publication gate, and GitHub recovery.
 - [Containers](references/containers.md): multi-architecture image build,
   registry aliases, manifest inspection, and runtime verification.
-- [crates.io](references/crates-io.md): package validation, dry-run, approved
-  publication, and immutable-version recovery.
+- [crates.io](references/crates-io.md): independent package selection,
+  validation, dry-run, approved publication, and immutable-version recovery.
 - [Homebrew](references/homebrew.md): native assets, checksum contract,
   draft-release upload, Formula update, and tap PR.
 
@@ -45,7 +51,9 @@ Read only the target references required by the release:
 2. Fetch `upstream` and `origin` with pruning. Fast-forward local `main` to
    `upstream/main`; push `origin/main` when the fork is behind.
 3. Set the stable version on `BRANCH`, update all version-sensitive files and
-   `NOTICE.txt`, then run the baseline validation:
+   `NOTICE.txt`, then run the baseline validation. For a standalone crate
+   target, update and validate only that package's version and follow the
+   crates.io reference:
 
    ```bash
    cargo fmt --all -- --check
@@ -62,8 +70,9 @@ Read only the target references required by the release:
    manifests before creating `TAG` when the release includes images.
 6. Attach every Homebrew release asset to the draft before the GitHub release
    becomes public. Never change those assets after publication.
-7. Stop for explicit approval before publishing crates.io or changing a GitHub
-   release from draft to public. A human publishes the GitHub release.
+7. Stop for explicit approval before publishing any crates.io package or
+   changing a GitHub release from draft to public. A human publishes the
+   GitHub release.
 8. Complete the Homebrew target only after the GitHub release is public,
    stable, complete, and immutable. Follow its reference through the checked
    tap PR and include that PR in the release handoff.

--- a/.agents/skills/esdiag-release/references/crates-io.md
+++ b/.agents/skills/esdiag-release/references/crates-io.md
@@ -1,14 +1,31 @@
 # crates.io Release Target
 
-Use this reference when validating or publishing the `esdiag` Cargo crate.
+Use this reference when validating or publishing either workspace crate:
+`esdiag` or `elasticrc`.
+
+## Independent Package Selection
+
+Set `CRATE` to the package being released.
+
+```bash
+CRATE=elasticrc
+VERSION=0.1.0
+```
+
+The `elasticrc` version is independent from the ESDiag application version.
+A standalone `elasticrc` release does not publish `esdiag` or change its
+version-sensitive release files.
+
+Always pass the selected package to workspace Cargo commands. Do not publish
+the workspace without `--package`.
 
 ## Package Validation
 
 Run these from the clean release branch after setting `VERSION`:
 
 ```bash
-cargo package --locked
-cargo publish --dry-run --locked
+cargo package --locked --package "$CRATE"
+cargo publish --dry-run --locked --package "$CRATE"
 ```
 
 These commands validate the actual registry package and metadata. Resolve any
@@ -21,7 +38,7 @@ crate-specific token without printing or committing it:
 
 ```bash
 CARGO_REGISTRY_TOKEN="$(<"$HOME/.config/apikey/esdiag.crates.io")" \
-  cargo publish --locked
+  cargo publish --locked --package "$CRATE"
 cargo info "$CRATE@$VERSION"
 ```
 

--- a/.github/workflows/elasticrc.yml
+++ b/.github/workflows/elasticrc.yml
@@ -1,0 +1,55 @@
+name: elasticrc
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/elasticrc.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/elasticrc/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/elasticrc.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/elasticrc/**"
+
+permissions:
+  contents: read
+
+jobs:
+  platforms:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test -p elasticrc
+
+  msrv:
+    name: Rust 1.89
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.89.0
+      - run: cargo check -p elasticrc --all-targets
+
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test -p elasticrc
+      - run: cargo test -p elasticrc --doc
+      - run: cargo doc -p elasticrc --no-deps
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+      - run: cargo package -p elasticrc
+      - run: cargo run --manifest-path crates/elasticrc/tests/external-consumer/Cargo.toml
+      - run: cargo publish --dry-run -p elasticrc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,8 +31,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -42,8 +53,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
 dependencies = [
  "aead",
- "aes",
- "cipher",
+ "aes 0.8.4",
+ "cipher 0.4.4",
  "ctr",
  "polyval",
  "subtle",
@@ -144,6 +155,17 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "apple-native-keyring-store"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b350bfd03649e07aa05c0a81b3e15934374e585c98204a57e20b9d49f49bb9a"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
 
 [[package]]
 name = "askama"
@@ -348,13 +370,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -535,6 +557,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
 dependencies = [
  "async-channel",
  "async-task",
@@ -588,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "serde_core",
@@ -677,7 +708,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -691,10 +722,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.4.1"
+name = "cbc"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9066c49992464636f92905fa096ec58baaa4d57ec19a5c096c68d3e25ef3d136"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -737,12 +777,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -765,7 +805,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -799,7 +849,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -809,6 +859,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,9 +872,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -858,9 +914,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cookie"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
 dependencies = [
  "time",
  "version_check",
@@ -917,6 +973,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,18 +989,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1042,7 +1104,16 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1109,6 +1180,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1260,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1201,7 +1304,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1295,9 +1398,26 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
+name = "elasticrc"
+version = "0.1.0"
+dependencies = [
+ "apple-native-keyring-store",
+ "keyring-core",
+ "redact",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+ "url",
+ "windows-native-keyring-store",
+ "yaml_serde",
+ "zbus-secret-service-keyring-store",
+]
 
 [[package]]
 name = "elasticsearch"
@@ -1422,7 +1542,7 @@ dependencies = [
  "eyre",
  "flate2",
  "futures",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "json-patch 4.2.0",
  "kibana-sync",
  "mimalloc",
@@ -1479,10 +1599,11 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.12"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+checksum = "c08309dbcc659c5549a24ddb9b27027640641b282ef5768267c7e675558986a3"
 dependencies = [
+ "autocfg",
  "indenter",
  "once_cell",
 ]
@@ -1524,18 +1645,19 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1577,7 +1699,7 @@ checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1613,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1628,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1638,15 +1760,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1655,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -1674,32 +1796,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2028,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2038,7 +2160,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2093,12 +2215,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2133,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2167,9 +2307,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2279,9 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2293,9 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2306,9 +2446,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2320,16 +2460,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2340,15 +2481,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2438,9 +2579,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2464,6 +2605,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2527,6 +2678,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,9 +2786,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2612,7 +2816,7 @@ dependencies = [
  "jsonptr 0.7.1",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2654,6 +2858,15 @@ dependencies = [
  "bitflags 2.13.1",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2764,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "libc",
 ]
@@ -2785,9 +2998,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -2800,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "markup5ever"
@@ -2881,6 +3094,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2908,7 +3131,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
 
@@ -2995,10 +3218,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -3246,9 +3532,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cfef937e9c486488c7e3d949ae31c0f1d06bdacd75b99c086cb35356e30408"
+checksum = "ade3be4664bc1ef537ce133015f04c176b737815c2ba9fd60edf212d6e90dd55"
 dependencies = [
  "dunce",
  "is-wsl",
@@ -3375,7 +3661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -3456,9 +3742,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
@@ -3467,7 +3753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "quick-xml",
  "serde",
  "time",
@@ -3483,7 +3769,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -3496,7 +3782,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -3526,19 +3812,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "portpicker"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
 dependencies = [
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -3619,9 +3920,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr3"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
+checksum = "9e564d14133360e1ae169ffde5da25881b5fa47261665b8e5713c212c27799da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3629,14 +3930,14 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error3"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
+checksum = "8f0d4471b3436c22106b21913b1dda531558918ae9b7ec55d58aa84b43552233"
 dependencies = [
  "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3699,9 +4000,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -3771,6 +4072,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "redact"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcecefd225c2fb69914585a7a6f8878929feb316a7ecb61c07d79e361d46d8ac"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3787,27 +4094,27 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3949,12 +4256,12 @@ dependencies = [
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+checksum = "9a1efe12a1469752d0e6ff5ebec0b6ef4924cc5c4c71046b0ec730040535819d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4047,9 +4354,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4144,6 +4451,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secret-service"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5107b24b91445dd2aa449a258a1807b63240942157292354dc5bfdbeb8bc6db8"
+dependencies = [
+ "aes 0.9.3",
+ "cbc",
+ "futures-util",
+ "getrandom 0.4.3",
+ "hkdf",
+ "hybrid-array",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2 0.11.0",
+ "zbus",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4234,7 +4560,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4280,7 +4606,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4315,16 +4641,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
+ "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
  "serde_core",
@@ -4335,9 +4662,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4351,7 +4678,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "itoa",
  "ryu",
  "serde",
@@ -4407,7 +4734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -4568,9 +4895,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4057c98e2e852d51fdcfca832aac7b571f6b351ad159f9eda5db1655f8d0c4d7"
+checksum = "e45c444e496845d3f2a351146bff59aae4975b2280238df1dfaa0c7d1846f38e"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -4600,9 +4927,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4771,7 +5098,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tray-icon",
  "url",
@@ -4824,7 +5151,7 @@ dependencies = [
  "sha2 0.10.9",
  "syn 2.0.119",
  "tauri-utils",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "url",
  "uuid",
@@ -4877,7 +5204,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "url",
  "windows",
  "zbus",
@@ -4901,7 +5228,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "url",
  "webkit2gtk",
  "webview2-com",
@@ -4964,7 +5291,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "swift-rs",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
  "url",
  "urlpattern",
@@ -5016,11 +5343,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -5036,13 +5363,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5086,9 +5413,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5133,7 +5460,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5210,7 +5537,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -5225,7 +5552,7 @@ version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -5267,7 +5594,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -5278,7 +5605,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
@@ -5291,7 +5618,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.4",
@@ -5443,7 +5770,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
 
@@ -5620,9 +5947,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -5717,9 +6044,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5730,9 +6057,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5740,9 +6067,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5750,9 +6077,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5763,9 +6090,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -5785,9 +6112,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5795,9 +6122,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -5880,7 +6207,7 @@ version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "windows",
  "windows-core 0.61.2",
 ]
@@ -6023,6 +6350,19 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -6298,9 +6638,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wry"
@@ -6335,7 +6675,7 @@ dependencies = [
  "sha2 0.10.9",
  "soup3",
  "tao-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "url",
  "webkit2gtk",
  "webkit2gtk-sys",
@@ -6369,11 +6709,11 @@ dependencies = [
 
 [[package]]
 name = "yaml_serde"
-version = "0.10.4"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+checksum = "33b729a08a9a6be689bbad3e2bf8015926db54b6622cc89c3a5f7dc174b9e918"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "itoa",
  "libyaml-rs",
  "ryu",
@@ -6405,9 +6745,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.18.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -6439,15 +6779,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "zbus_macros"
-version = "5.18.0"
+name = "zbus-secret-service-keyring-store"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+checksum = "74801d001b9e7729adb4f1825b67b398185fed424749aa3d8bacf70417137d9a"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -6462,6 +6813,15 @@ dependencies = [
  "serde",
  "winnow 1.0.4",
  "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6513,9 +6873,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6524,9 +6884,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6535,13 +6895,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6552,10 +6912,16 @@ checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "flate2",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "memchr",
  "typed-path",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
@@ -6593,40 +6959,41 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.13.1"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "winnow 1.0.4",
+ "zcheapstr",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.13.1"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.5.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.119",
+ "syn 3.0.4",
  "winnow 1.0.4",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2024"
 rust-version = "1.89"
 license = "Elastic-2.0"
 
+[workspace]
+members = [".", "crates/elasticrc"]
+resolver = "3"
+
 [features]
 default = ["full"]
 full = ["server", "setup", "keystore"]

--- a/crates/elasticrc/Cargo.toml
+++ b/crates/elasticrc/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "elasticrc"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.89"
+license = "Apache-2.0"
+description = "Read and resolve Elastic CLI context configuration"
+repository = "https://github.com/elastic/esdiag"
+homepage = "https://github.com/elastic/esdiag/tree/main/crates/elasticrc"
+documentation = "https://docs.rs/elasticrc"
+readme = "README.md"
+keywords = ["elastic", "configuration", "keyring", "cli"]
+categories = ["config", "authentication"]
+include = [
+    "src/**",
+    "tests/*.rs",
+    "tests/fixtures/**",
+    "examples/**",
+    "LICENSE",
+    "NOTICE.txt",
+    "README.md",
+]
+
+[dependencies]
+keyring-core = "1.0.0"
+redact = "0.1.11"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.150"
+tracing = "0.1"
+url = { version = "2.5.8", features = ["serde"] }
+yaml_serde = "0.10.4"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+apple-native-keyring-store = { version = "1.0.0", features = ["keychain"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-native-keyring-store = "1.1.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+zbus-secret-service-keyring-store = { version = "1.0.0", features = ["crypto-rust"] }
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/crates/elasticrc/LICENSE
+++ b/crates/elasticrc/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/elasticrc/NOTICE.txt
+++ b/crates/elasticrc/NOTICE.txt
@@ -1,0 +1,2 @@
+elasticrc: Rust library for Elastic CLI context configuration
+Copyright 2026 Elasticsearch B.V.

--- a/crates/elasticrc/README.md
+++ b/crates/elasticrc/README.md
@@ -1,0 +1,57 @@
+# elasticrc
+
+`elasticrc` lets Rust programs use connections configured for the Elastic CLI.
+It discovers the user's config file, selects an Elasticsearch, Kibana, or
+Cloud service from the current or a named context, and resolves that service's
+URL and authentication.
+
+The library is intended for Elastic CLI extensions and other integrations that
+need context-aware connections without invoking the CLI, duplicating its
+resolver behavior, or copying credentials into another configuration store.
+It reads `.elasticrc`, `.elasticrc.json`, `.elasticrc.yaml`, and
+`.elasticrc.yml`; it never modifies them.
+
+## Usage
+
+```rust
+use elasticrc::{ConfigFile, ServiceKind};
+
+let config = ConfigFile::load_with_options(None, None)?;
+let elasticsearch =
+    config.resolve_current_service(ServiceKind::Elasticsearch)?;
+
+println!("Connecting to {}", elasticsearch.url);
+
+# Ok::<(), elasticrc::Error>(())
+```
+
+Loading a config parses and validates its structure without executing resolver
+expressions. `resolve_service` and `resolve_current_service` evaluate only the
+requested service.
+
+Supported resolvers:
+
+- `env`, `file`, and `cmd`
+- `pass`
+- macOS `keychain`
+- Linux `secret_service`
+- Windows `credential_manager`
+
+## Security
+
+API keys and passwords are redacted in debug output. Accessing a resolved
+secret requires an explicit `expose_secret()` call.
+
+`cmd` and `pass` run programs directly, without shell interpretation. They have
+execution time and output limits, and child processes do not inherit Elastic
+CLI credential variables. Use command resolvers only from trusted config files.
+
+## Compatibility
+
+The crate follows semantic versioning and declares its minimum Rust version in
+`Cargo.toml`. The upstream Elastic CLI config format remains experimental, so
+new supported config fields may be added in minor releases.
+
+## License
+
+[Apache License 2.0](LICENSE). See [NOTICE.txt](NOTICE.txt) for attribution.

--- a/crates/elasticrc/examples/inspect.rs
+++ b/crates/elasticrc/examples/inspect.rs
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use elasticrc::{ConfigFile, ResolvedAuth, ServiceKind};
+use std::{env, path::PathBuf, process::ExitCode};
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("elasticrc example failed: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), elasticrc::Error> {
+    let explicit_path = env::args_os().nth(1).map(PathBuf::from);
+    let config = ConfigFile::load_with_options(explicit_path.as_deref(), None)?;
+    let service = config.resolve_current_service(ServiceKind::Elasticsearch)?;
+
+    println!("context: {}", config.current_context);
+    println!("service: {}", service.kind);
+    println!("url: {}", service.url);
+    println!(
+        "authentication: {}",
+        match service.auth {
+            ResolvedAuth::ApiKey(_) => "api_key",
+            ResolvedAuth::Basic { .. } => "basic",
+            ResolvedAuth::None => "none",
+        }
+    );
+    Ok(())
+}

--- a/crates/elasticrc/src/lib.rs
+++ b/crates/elasticrc/src/lib.rs
@@ -1,0 +1,1739 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Read-only discovery, parsing, and lazy resolution of Elastic CLI contexts.
+//!
+//! Loading a [`ConfigFile`] validates only its top-level shape and never executes
+//! resolver expressions. Call [`ConfigFile::resolve_service`] or
+//! [`ConfigFile::resolve_current_service`] to resolve one selected service.
+//!
+//! Resolved credentials use [`SecretString`] so common debug formatting does not
+//! reveal secret values. Callers should keep those values runtime-only.
+//!
+//! ```
+//! use elasticrc::{ConfigFile, ServiceKind};
+//!
+//! # fn example() -> Result<(), elasticrc::Error> {
+//! let config = ConfigFile::load_with_options(None, None)?;
+//! let elasticsearch = config.resolve_current_service(ServiceKind::Elasticsearch)?;
+//! println!("Elasticsearch URL: {}", elasticsearch.url);
+//! # Ok(())
+//! # }
+//! ```
+
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows", test))]
+use keyring_core::api::CredentialStoreApi;
+use serde::{Deserialize, Serialize};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::{
+    collections::BTreeMap,
+    env,
+    fmt::Display,
+    fs,
+    io::{self, Read},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    str::FromStr,
+    thread,
+    time::{Duration, Instant},
+};
+use url::Url;
+
+/// A string whose `Debug` representation redacts its contents.
+pub type SecretString = redact::Secret<String>;
+const FILE_RESOLVER_MAX_BYTES: u64 = 1024 * 1024;
+const COMMAND_RESOLVER_TIMEOUT: Duration = Duration::from_secs(5);
+const ELASTIC_CREDENTIAL_ENV_VARS: [&str; 9] = [
+    "ELASTIC_ES_API_KEY",
+    "ELASTIC_ES_USERNAME",
+    "ELASTIC_ES_PASSWORD",
+    "ELASTIC_KIBANA_API_KEY",
+    "ELASTIC_KIBANA_USERNAME",
+    "ELASTIC_KIBANA_PASSWORD",
+    "ELASTIC_CLOUD_API_KEY",
+    "ELASTIC_CLOUD_USERNAME",
+    "ELASTIC_CLOUD_PASSWORD",
+];
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Raw Elastic CLI configuration.
+///
+/// Secret fields may contain inline values or unresolved expressions. Resolver
+/// expressions are evaluated only when a service is explicitly resolved.
+pub struct ConfigFile {
+    pub current_context: String,
+    pub contexts: BTreeMap<String, Context>,
+}
+
+impl ConfigFile {
+    /// Load a JSON or YAML Elastic CLI config from an explicit path.
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, Error> {
+        load_config_file(path)
+    }
+
+    /// Discover and load the first readable config in an explicit home directory.
+    pub fn load_from_home(home_dir: impl AsRef<Path>) -> Result<Self, Error> {
+        let path = discover_config_path(home_dir.as_ref()).ok_or_else(|| Error::ConfigNotFound {
+            home_dir: home_dir.as_ref().to_path_buf(),
+        })?;
+        Self::load(path)
+    }
+
+    /// Load from an explicit path, `ELASTIC_CLI_CONFIG_FILE`, or home discovery.
+    pub fn load_with_options(explicit_path: Option<&Path>, home_dir: Option<&Path>) -> Result<Self, Error> {
+        if let Some(path) = explicit_path {
+            return Self::load(path);
+        }
+        if let Some(path) = env::var_os("ELASTIC_CLI_CONFIG_FILE") {
+            return Self::load(PathBuf::from(path));
+        }
+        let home_dir = home_dir
+            .map(Path::to_path_buf)
+            .or_else(home_dir_from_env)
+            .ok_or(Error::HomeDirectoryUnavailable)?;
+        Self::load_from_home(home_dir)
+    }
+
+    /// Validate all raw service blocks without evaluating resolver expressions.
+    pub fn validate(&self) -> Result<(), Error> {
+        self.validate_shape()?;
+        for (context_name, context) in &self.contexts {
+            context.validate(context_name)?;
+        }
+        Ok(())
+    }
+
+    fn validate_shape(&self) -> Result<(), Error> {
+        if self.current_context.trim().is_empty() {
+            return Err(Error::InvalidShape("current_context must not be empty".to_string()));
+        }
+        if self.contexts.is_empty() {
+            return Err(Error::InvalidShape("contexts must not be empty".to_string()));
+        }
+        Ok(())
+    }
+
+    /// Resolve and validate one service from a named context.
+    pub fn resolve_service(&self, context_name: &str, kind: ServiceKind) -> Result<ResolvedService, Error> {
+        let context = self.contexts.get(context_name).ok_or_else(|| Error::MissingContext {
+            name: context_name.to_string(),
+            available: self.contexts.keys().cloned().collect(),
+        })?;
+        let service = context.service(kind).ok_or_else(|| Error::MissingService {
+            context: context_name.to_string(),
+            service: kind,
+        })?;
+        let mut service = service.clone();
+        service.resolve_expressions(context_name, kind)?;
+        service.validate(context_name, kind)?;
+        service.resolve(kind)
+    }
+
+    /// Resolve and validate one service from `current_context`.
+    pub fn resolve_current_service(&self, kind: ServiceKind) -> Result<ResolvedService, Error> {
+        self.resolve_service(&self.current_context, kind)
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+/// Services configured for one Elastic CLI context.
+pub struct Context {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elasticsearch: Option<ServiceBlock>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kibana: Option<ServiceBlock>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cloud: Option<ServiceBlock>,
+}
+
+impl Context {
+    /// Return a raw service block without evaluating its resolver expressions.
+    pub fn service(&self, kind: ServiceKind) -> Option<&ServiceBlock> {
+        match kind {
+            ServiceKind::Elasticsearch => self.elasticsearch.as_ref(),
+            ServiceKind::Kibana => self.kibana.as_ref(),
+            ServiceKind::Cloud => self.cloud.as_ref(),
+        }
+    }
+
+    fn validate(&self, context_name: &str) -> Result<(), Error> {
+        for (kind, service) in [
+            (ServiceKind::Elasticsearch, self.elasticsearch.as_ref()),
+            (ServiceKind::Kibana, self.kibana.as_ref()),
+            (ServiceKind::Cloud, self.cloud.as_ref()),
+        ] {
+            if let Some(service) = service {
+                service.validate(context_name, kind)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Raw URL and optional authentication for one context service.
+pub struct ServiceBlock {
+    pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth: Option<AuthBlock>,
+}
+
+impl ServiceBlock {
+    fn validate(&self, context_name: &str, kind: ServiceKind) -> Result<(), Error> {
+        let url = Url::parse(&self.url).map_err(|source| Error::InvalidServiceUrl {
+            context: context_name.to_string(),
+            service: kind,
+            value: self.url.clone(),
+            source,
+        })?;
+        if !matches!(url.scheme(), "http" | "https") {
+            return Err(Error::InvalidServiceUrlScheme {
+                context: context_name.to_string(),
+                service: kind,
+                value: self.url.clone(),
+            });
+        }
+        if let Some(auth) = &self.auth {
+            auth.validate(context_name, kind)?;
+        }
+        Ok(())
+    }
+
+    fn resolve(&self, kind: ServiceKind) -> Result<ResolvedService, Error> {
+        Ok(ResolvedService {
+            kind,
+            url: Url::parse(&self.url).map_err(|source| Error::InvalidServiceUrl {
+                context: "<resolved>".to_string(),
+                service: kind,
+                value: self.url.clone(),
+                source,
+            })?,
+            auth: self
+                .auth
+                .as_ref()
+                .map(AuthBlock::resolve)
+                .transpose()?
+                .unwrap_or_default(),
+        })
+    }
+
+    fn resolve_expressions(&mut self, context_name: &str, kind: ServiceKind) -> Result<(), Error> {
+        self.url = resolve_string_expressions(&self.url, &format!("{context_name}.{kind}.url"))?;
+        if let Some(auth) = &mut self.auth {
+            auth.resolve_expressions(context_name, kind)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+/// Raw authentication configuration.
+///
+/// Debug output redacts API keys and passwords, including inline values.
+pub struct AuthBlock {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+}
+
+impl std::fmt::Debug for AuthBlock {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AuthBlock")
+            .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
+            .field("username", &self.username)
+            .field("password", &self.password.as_ref().map(|_| "[REDACTED]"))
+            .finish()
+    }
+}
+
+impl AuthBlock {
+    fn validate(&self, context_name: &str, kind: ServiceKind) -> Result<(), Error> {
+        match (&self.api_key, &self.username, &self.password) {
+            (Some(_), None, None) | (None, None, None) | (None, Some(_), Some(_)) => Ok(()),
+            (Some(_), _, _) => Err(Error::InvalidAuth {
+                context: context_name.to_string(),
+                service: kind,
+                message: "api_key cannot be combined with username or password".to_string(),
+            }),
+            (None, Some(_), None) | (None, None, Some(_)) => Err(Error::InvalidAuth {
+                context: context_name.to_string(),
+                service: kind,
+                message: "basic authentication requires both username and password".to_string(),
+            }),
+        }
+    }
+
+    fn resolve(&self) -> Result<ResolvedAuth, Error> {
+        match (&self.api_key, &self.username, &self.password) {
+            (Some(api_key), None, None) => Ok(ResolvedAuth::api_key(api_key.clone())),
+            (None, Some(username), Some(password)) => Ok(ResolvedAuth::basic(username.clone(), password.clone())),
+            (None, None, None) => Ok(ResolvedAuth::None),
+            _ => Err(Error::InvalidShape("invalid auth block".to_string())),
+        }
+    }
+
+    fn resolve_expressions(&mut self, context_name: &str, kind: ServiceKind) -> Result<(), Error> {
+        if let Some(api_key) = &mut self.api_key {
+            *api_key = resolve_string_expressions(api_key, &format!("{context_name}.{kind}.auth.api_key"))?;
+        }
+        if let Some(username) = &mut self.username {
+            *username = resolve_string_expressions(username, &format!("{context_name}.{kind}.auth.username"))?;
+        }
+        if let Some(password) = &mut self.password {
+            *password = resolve_string_expressions(password, &format!("{context_name}.{kind}.auth.password"))?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+/// Service blocks supported by the Elastic CLI configuration schema.
+pub enum ServiceKind {
+    Elasticsearch,
+    Kibana,
+    Cloud,
+}
+
+impl ServiceKind {
+    /// Parse a canonical service name or supported short alias.
+    pub fn parse_alias(value: &str) -> Option<Self> {
+        match value {
+            "elasticsearch" | "es" => Some(Self::Elasticsearch),
+            "kibana" | "kb" => Some(Self::Kibana),
+            "cloud" => Some(Self::Cloud),
+            _ => None,
+        }
+    }
+
+    /// Return the canonical Elastic CLI service name.
+    pub fn canonical_name(self) -> &'static str {
+        match self {
+            Self::Elasticsearch => "elasticsearch",
+            Self::Kibana => "kibana",
+            Self::Cloud => "cloud",
+        }
+    }
+}
+
+impl Display for ServiceKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.canonical_name())
+    }
+}
+
+impl FromStr for ServiceKind {
+    type Err = UnknownService;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse_alias(value).ok_or_else(|| UnknownService(value.to_string()))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// Error returned when parsing an unsupported service name.
+pub struct UnknownService(String);
+
+impl Display for UnknownService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unknown Elastic CLI service '{}'", self.0)
+    }
+}
+
+impl std::error::Error for UnknownService {}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// Parsed `.service` or `.context.service` reference.
+pub struct ContextServiceReference {
+    pub context: Option<String>,
+    pub service: ServiceKind,
+}
+
+impl ContextServiceReference {
+    /// Parse a leading-dot service reference.
+    pub fn parse(value: &str) -> Option<Self> {
+        let value = value.strip_prefix('.')?;
+        if value.is_empty() || value.contains('/') || value.contains('\\') {
+            return None;
+        }
+        let (context, service) = match value.rsplit_once('.') {
+            Some((context, service)) => {
+                if context.is_empty() {
+                    return None;
+                }
+                (Some(context.to_string()), service)
+            }
+            None => (None, value),
+        };
+        Some(Self {
+            context,
+            service: ServiceKind::parse_alias(service)?,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// A validated service with lazily resolved authentication.
+pub struct ResolvedService {
+    pub kind: ServiceKind,
+    pub url: Url,
+    pub auth: ResolvedAuth,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Authentication resolved for a selected service.
+pub enum ResolvedAuth {
+    ApiKey(SecretString),
+    Basic {
+        username: String,
+        password: SecretString,
+    },
+    #[default]
+    None,
+}
+
+impl ResolvedAuth {
+    /// Construct redacted API key authentication.
+    pub fn api_key(api_key: impl Into<String>) -> Self {
+        Self::ApiKey(SecretString::new(api_key.into()))
+    }
+
+    /// Construct basic authentication with a redacted password.
+    pub fn basic(username: impl Into<String>, password: impl Into<String>) -> Self {
+        Self::Basic {
+            username: username.into(),
+            password: SecretString::new(password.into()),
+        }
+    }
+}
+
+#[derive(Debug)]
+/// Errors produced while discovering, parsing, validating, or resolving config.
+pub enum Error {
+    ConfigNotFound {
+        home_dir: PathBuf,
+    },
+    ExecutableConfigUnsupported {
+        path: PathBuf,
+    },
+    HomeDirectoryUnavailable,
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    Json {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    Yaml {
+        path: PathBuf,
+        source: yaml_serde::Error,
+    },
+    InvalidShape(String),
+    MissingContext {
+        name: String,
+        available: Vec<String>,
+    },
+    MissingService {
+        context: String,
+        service: ServiceKind,
+    },
+    InvalidServiceUrl {
+        context: String,
+        service: ServiceKind,
+        value: String,
+        source: url::ParseError,
+    },
+    InvalidServiceUrlScheme {
+        context: String,
+        service: ServiceKind,
+        value: String,
+    },
+    InvalidAuth {
+        context: String,
+        service: ServiceKind,
+        message: String,
+    },
+    InvalidResolverExpression {
+        field: String,
+        value: String,
+    },
+    UnknownResolver {
+        resolver: String,
+        field: String,
+    },
+    ShellSyntaxUnsupported {
+        resolver: String,
+        field: String,
+    },
+    ResolverFailed {
+        resolver: String,
+        field: String,
+        message: String,
+    },
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConfigNotFound { home_dir } => {
+                write!(f, "no Elastic CLI config file found in {}", home_dir.display())
+            }
+            Self::ExecutableConfigUnsupported { path } => {
+                write!(
+                    f,
+                    "executable Elastic CLI config format is not supported: {}",
+                    path.display()
+                )
+            }
+            Self::HomeDirectoryUnavailable => write!(f, "home directory is unavailable"),
+            Self::Io { path, source } => write!(f, "failed to read {}: {source}", path.display()),
+            Self::Json { path, source } => write!(f, "failed to parse JSON config {}: {source}", path.display()),
+            Self::Yaml { path, source } => write!(f, "failed to parse YAML config {}: {source}", path.display()),
+            Self::InvalidShape(message) => write!(f, "invalid Elastic CLI config shape: {message}"),
+            Self::MissingContext { name, available } => {
+                write!(f, "Elastic CLI context '{name}' was not found")?;
+                if !available.is_empty() {
+                    write!(f, "; available contexts: {}", available.join(", "))?;
+                }
+                Ok(())
+            }
+            Self::MissingService { context, service } => {
+                write!(f, "Elastic CLI context '{context}' does not define service '{service}'")
+            }
+            Self::InvalidServiceUrl {
+                context,
+                service,
+                value,
+                source,
+            } => write!(
+                f,
+                "invalid URL for Elastic CLI context '{context}' service '{service}' ({value}): {source}"
+            ),
+            Self::InvalidServiceUrlScheme {
+                context,
+                service,
+                value,
+            } => write!(
+                f,
+                "invalid URL scheme for Elastic CLI context '{context}' service '{service}' ({value}); expected http or https"
+            ),
+            Self::InvalidAuth {
+                context,
+                service,
+                message,
+            } => write!(
+                f,
+                "invalid auth for Elastic CLI context '{context}' service '{service}': {message}"
+            ),
+            Self::InvalidResolverExpression { field, value } => {
+                write!(f, "invalid resolver expression in field '{field}': {value}")
+            }
+            Self::UnknownResolver { resolver, field } => {
+                write!(f, "unknown resolver '{resolver}' in field '{field}'")
+            }
+            Self::ShellSyntaxUnsupported { resolver, field } => write!(
+                f,
+                "resolver '{resolver}' in field '{field}' requires shell interpretation, which is unsupported"
+            ),
+            Self::ResolverFailed {
+                resolver,
+                field,
+                message,
+            } => write!(f, "resolver '{resolver}' failed for field '{field}': {message}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Find the first readable Elastic CLI config in its documented discovery order.
+pub fn discover_config_path(home_dir: &Path) -> Option<PathBuf> {
+    [".elasticrc", ".elasticrc.json", ".elasticrc.yaml", ".elasticrc.yml"]
+        .into_iter()
+        .map(|name| home_dir.join(name))
+        .find(|path| path.is_file() && fs::File::open(path).is_ok())
+}
+
+fn load_config_file(path: impl AsRef<Path>) -> Result<ConfigFile, Error> {
+    let path = path.as_ref();
+    reject_executable_config(path)?;
+    let contents = fs::read_to_string(path).map_err(|source| Error::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let config: ConfigFile = if path.extension().and_then(|ext| ext.to_str()) == Some("json") {
+        serde_json::from_str(&contents).map_err(|source| Error::Json {
+            path: path.to_path_buf(),
+            source,
+        })?
+    } else {
+        yaml_serde::from_str(&contents).map_err(|source| Error::Yaml {
+            path: path.to_path_buf(),
+            source,
+        })?
+    };
+    if let Some(warning) = inline_secret_permission_warning(path, &config) {
+        tracing::warn!("{warning}");
+    }
+    config.validate_shape()?;
+    Ok(config)
+}
+
+fn reject_executable_config(path: &Path) -> Result<(), Error> {
+    if matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("js" | "ts" | "mjs" | "cjs")
+    ) {
+        return Err(Error::ExecutableConfigUnsupported {
+            path: path.to_path_buf(),
+        });
+    }
+    Ok(())
+}
+
+fn home_dir_from_env() -> Option<PathBuf> {
+    match std::env::consts::OS {
+        "windows" => env::var_os("USERPROFILE").map(PathBuf::from),
+        "linux" | "macos" => env::var_os("HOME").map(PathBuf::from),
+        _ => None,
+    }
+}
+
+/// Return a warning when inline secrets are stored with loose Unix permissions.
+///
+/// Returns `None` on platforms without Unix permission bits.
+pub fn inline_secret_permission_warning(path: &Path, config: &ConfigFile) -> Option<String> {
+    if !config.contains_inline_secret() {
+        return None;
+    }
+    loose_permissions(path).then(|| {
+        format!(
+            "Elastic CLI config {} contains inline secrets and has permissions broader than 0600/0400.",
+            path.display()
+        )
+    })
+}
+
+impl ConfigFile {
+    fn contains_inline_secret(&self) -> bool {
+        self.contexts.values().any(Context::contains_inline_secret)
+    }
+}
+
+impl Context {
+    fn contains_inline_secret(&self) -> bool {
+        [&self.elasticsearch, &self.kibana, &self.cloud]
+            .into_iter()
+            .flatten()
+            .any(ServiceBlock::contains_inline_secret)
+    }
+}
+
+impl ServiceBlock {
+    fn contains_inline_secret(&self) -> bool {
+        self.auth.as_ref().is_some_and(AuthBlock::contains_inline_secret)
+    }
+}
+
+impl AuthBlock {
+    fn contains_inline_secret(&self) -> bool {
+        [&self.api_key, &self.password]
+            .into_iter()
+            .flatten()
+            .any(|value| !is_resolver_expression(value))
+    }
+}
+
+fn is_resolver_expression(value: &str) -> bool {
+    let value = value.trim();
+    value.starts_with("$(") && value.ends_with(')')
+}
+
+#[cfg(unix)]
+fn loose_permissions(path: &Path) -> bool {
+    fs::metadata(path)
+        .map(|metadata| metadata.permissions().mode() & 0o177 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn loose_permissions(_path: &Path) -> bool {
+    false
+}
+
+fn resolve_string_expressions(value: &str, field: &str) -> Result<String, Error> {
+    let mut output = String::with_capacity(value.len());
+    let mut remaining = value;
+    while let Some(start) = remaining.find("$(") {
+        output.push_str(&remaining[..start]);
+        let after_start = &remaining[start + 2..];
+        let Some(end) = after_start.find(')') else {
+            return Err(Error::InvalidResolverExpression {
+                field: field.to_string(),
+                value: value.to_string(),
+            });
+        };
+        let expression = &after_start[..end];
+        output.push_str(&resolve_expression(expression, field)?);
+        remaining = &after_start[end + 1..];
+    }
+    output.push_str(remaining);
+    Ok(output)
+}
+
+fn resolve_expression(expression: &str, field: &str) -> Result<String, Error> {
+    let (resolver, params) = expression
+        .split_once(':')
+        .ok_or_else(|| Error::InvalidResolverExpression {
+            field: field.to_string(),
+            value: format!("$({expression})"),
+        })?;
+    match resolver {
+        "env" => env::var(params).map_err(|source| Error::ResolverFailed {
+            resolver: resolver.to_string(),
+            field: field.to_string(),
+            message: source.to_string(),
+        }),
+        "file" => resolve_file_expression(params, resolver, field),
+        "cmd" => {
+            tracing::warn!("Elastic CLI config is executing a command-backed resolver for {field}");
+            resolve_command_expression(params, resolver, field).map(|output| output.trim().to_string())
+        }
+        "pass" => {
+            tracing::warn!("Elastic CLI config is executing a command-backed resolver for {field}");
+            resolve_pass_expression(params, resolver, field)
+        }
+        "keychain" => resolve_keyring_expression(params, resolver, field),
+        "secret_service" => resolve_keyring_expression(params, resolver, field),
+        "credential_manager" => resolve_keyring_expression(params, resolver, field),
+        _ => Err(Error::UnknownResolver {
+            resolver: resolver.to_string(),
+            field: field.to_string(),
+        }),
+    }
+}
+
+fn resolve_file_expression(path: &str, resolver: &str, field: &str) -> Result<String, Error> {
+    let path = Path::new(path);
+    let metadata = fs::metadata(path).map_err(|source| Error::ResolverFailed {
+        resolver: resolver.to_string(),
+        field: field.to_string(),
+        message: source.to_string(),
+    })?;
+    if !metadata.is_file() {
+        return Err(Error::ResolverFailed {
+            resolver: resolver.to_string(),
+            field: field.to_string(),
+            message: format!("{} is not a regular file", path.display()),
+        });
+    }
+    if metadata.len() > FILE_RESOLVER_MAX_BYTES {
+        return Err(Error::ResolverFailed {
+            resolver: resolver.to_string(),
+            field: field.to_string(),
+            message: format!("{} exceeds resolver size limit", path.display()),
+        });
+    }
+    let file = fs::File::open(path).map_err(|source| Error::ResolverFailed {
+        resolver: resolver.to_string(),
+        field: field.to_string(),
+        message: source.to_string(),
+    })?;
+    read_file_resolver_value(file, path, resolver, field)
+}
+
+fn read_file_resolver_value(reader: impl Read, path: &Path, resolver: &str, field: &str) -> Result<String, Error> {
+    let mut contents = Vec::new();
+    let bytes_read = reader
+        .take(FILE_RESOLVER_MAX_BYTES + 1)
+        .read_to_end(&mut contents)
+        .map_err(|source| Error::ResolverFailed {
+            resolver: resolver.to_string(),
+            field: field.to_string(),
+            message: source.to_string(),
+        })?;
+    if bytes_read as u64 > FILE_RESOLVER_MAX_BYTES {
+        return Err(Error::ResolverFailed {
+            resolver: resolver.to_string(),
+            field: field.to_string(),
+            message: format!("{} exceeds resolver size limit", path.display()),
+        });
+    }
+    String::from_utf8(contents)
+        .map(|value| value.trim().to_string())
+        .map_err(|source| Error::ResolverFailed {
+            resolver: resolver.to_string(),
+            field: field.to_string(),
+            message: source.to_string(),
+        })
+}
+
+fn resolve_pass_expression(path: &str, resolver: &str, field: &str) -> Result<String, Error> {
+    let args = vec!["show".to_string(), path.to_string()];
+    let output = run_command("pass", &args, resolver, field)?;
+    Ok(output.lines().next().unwrap_or_default().trim().to_string())
+}
+
+fn resolve_command_expression(command: &str, resolver: &str, field: &str) -> Result<String, Error> {
+    let argv = parse_command_argv(command, resolver, field)?;
+    let (program, args) = argv.split_first().ok_or_else(|| Error::ResolverFailed {
+        resolver: resolver.to_string(),
+        field: field.to_string(),
+        message: "command resolver is empty".to_string(),
+    })?;
+    run_command(program, args, resolver, field)
+}
+
+fn parse_command_argv(command: &str, resolver: &str, field: &str) -> Result<Vec<String>, Error> {
+    let mut argv = Vec::new();
+    let mut current = String::new();
+    let mut quote = None;
+    let mut token_started = false;
+
+    let mut chars = command.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match quote {
+            Some(quote_char) if ch == quote_char => {
+                quote = None;
+            }
+            Some(_) if ch == '\\' => {
+                if let Some(next) = chars.next_if(|next| next.is_whitespace() || matches!(next, '\'' | '"' | '\\')) {
+                    current.push(next);
+                } else {
+                    current.push(ch);
+                }
+                token_started = true;
+            }
+            Some(_) => {
+                current.push(ch);
+                token_started = true;
+            }
+            None if ch == '\'' || ch == '"' => {
+                quote = Some(ch);
+                token_started = true;
+            }
+            None if ch == '\\' => {
+                if let Some(next) = chars.next_if(|next| next.is_whitespace() || matches!(next, '\'' | '"' | '\\')) {
+                    current.push(next);
+                } else {
+                    current.push(ch);
+                }
+                token_started = true;
+            }
+            None if matches!(
+                ch,
+                '|' | '&' | ';' | '<' | '>' | '(' | ')' | '{' | '}' | '`' | '\n' | '\r'
+            ) =>
+            {
+                return Err(Error::ShellSyntaxUnsupported {
+                    resolver: resolver.to_string(),
+                    field: field.to_string(),
+                });
+            }
+            None if ch.is_whitespace() => {
+                if token_started {
+                    argv.push(std::mem::take(&mut current));
+                    token_started = false;
+                }
+            }
+            None => {
+                current.push(ch);
+                token_started = true;
+            }
+        }
+    }
+
+    if quote.is_some() {
+        return Err(Error::ResolverFailed {
+            resolver: resolver.to_string(),
+            field: field.to_string(),
+            message: "command resolver contains an unterminated quote".to_string(),
+        });
+    }
+    if token_started {
+        argv.push(current);
+    }
+    Ok(argv)
+}
+
+fn read_command_output(mut reader: impl Read, stream: &str) -> io::Result<Vec<u8>> {
+    let mut output = Vec::new();
+    let mut buffer = [0; 8192];
+    let max_bytes = FILE_RESOLVER_MAX_BYTES as usize;
+
+    loop {
+        let bytes_read = reader.read(&mut buffer)?;
+        if bytes_read == 0 {
+            return Ok(output);
+        }
+        if output.len().saturating_add(bytes_read) > max_bytes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("command {stream} exceeded {max_bytes} bytes"),
+            ));
+        }
+        output.extend_from_slice(&buffer[..bytes_read]);
+    }
+}
+
+fn run_command(program: &str, args: &[String], resolver: &str, field: &str) -> Result<String, Error> {
+    run_command_with_timeout(program, args, resolver, field, COMMAND_RESOLVER_TIMEOUT)
+}
+
+fn run_command_with_timeout(
+    program: &str,
+    args: &[String],
+    resolver: &str,
+    field: &str,
+    timeout: Duration,
+) -> Result<String, Error> {
+    let mut command = Command::new(program);
+    command
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for name in ELASTIC_CREDENTIAL_ENV_VARS {
+        command.env_remove(name);
+    }
+    let mut child = command.spawn().map_err(|source| Error::ResolverFailed {
+        resolver: resolver.to_string(),
+        field: field.to_string(),
+        message: source.to_string(),
+    })?;
+    let stdout = child.stdout.take().expect("stdout pipe");
+    let stderr = child.stderr.take().expect("stderr pipe");
+    let stdout_reader = thread::spawn(move || read_command_output(stdout, "stdout"));
+    let stderr_reader = thread::spawn(move || read_command_output(stderr, "stderr"));
+
+    let start = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait().map_err(|source| Error::ResolverFailed {
+            resolver: resolver.to_string(),
+            field: field.to_string(),
+            message: source.to_string(),
+        })? {
+            break status;
+        }
+        if start.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = stdout_reader.join();
+            let _ = stderr_reader.join();
+            return Err(Error::ResolverFailed {
+                resolver: resolver.to_string(),
+                field: field.to_string(),
+                message: "command timed out".to_string(),
+            });
+        }
+        thread::sleep(Duration::from_millis(10));
+    };
+
+    let stdout = stdout_reader
+        .join()
+        .map_err(|_| Error::ResolverFailed {
+            resolver: resolver.to_string(),
+            field: field.to_string(),
+            message: "stdout reader panicked".to_string(),
+        })?
+        .map_err(|source| Error::ResolverFailed {
+            resolver: resolver.to_string(),
+            field: field.to_string(),
+            message: source.to_string(),
+        })?;
+    let _stderr = stderr_reader
+        .join()
+        .map_err(|_| Error::ResolverFailed {
+            resolver: resolver.to_string(),
+            field: field.to_string(),
+            message: "stderr reader panicked".to_string(),
+        })?
+        .map_err(|source| Error::ResolverFailed {
+            resolver: resolver.to_string(),
+            field: field.to_string(),
+            message: source.to_string(),
+        })?;
+
+    if !status.success() {
+        return Err(Error::ResolverFailed {
+            resolver: resolver.to_string(),
+            field: field.to_string(),
+            message: format!(
+                "command exited with {status}; stderr omitted because resolver output may contain secrets"
+            ),
+        });
+    }
+    String::from_utf8(stdout).map_err(|source| Error::ResolverFailed {
+        resolver: resolver.to_string(),
+        field: field.to_string(),
+        message: source.to_string(),
+    })
+}
+
+fn parse_keyring_params(params: &str, resolver: &str, field: &str) -> Result<(String, String), Error> {
+    let (service, account) = params.split_once('/').ok_or_else(|| Error::ResolverFailed {
+        resolver: resolver.to_string(),
+        field: field.to_string(),
+        message: "expected service/account".to_string(),
+    })?;
+    if service.is_empty() || account.is_empty() {
+        return Err(Error::ResolverFailed {
+            resolver: resolver.to_string(),
+            field: field.to_string(),
+            message: "expected non-empty service/account".to_string(),
+        });
+    }
+    Ok((service.to_string(), account.to_string()))
+}
+
+fn resolve_keyring_expression(params: &str, resolver: &str, field: &str) -> Result<String, Error> {
+    let (service, account) = parse_keyring_params(params, resolver, field)?;
+    resolve_platform_keyring_secret(resolver, &service, &account).map_err(|message| Error::ResolverFailed {
+        resolver: resolver.to_string(),
+        field: field.to_string(),
+        message,
+    })
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows", test))]
+fn read_keyring_store(
+    store: &(impl CredentialStoreApi + ?Sized),
+    service: &str,
+    account: &str,
+) -> Result<String, String> {
+    store
+        .build(service, account, None)
+        .and_then(|entry| entry.get_password())
+        .map_err(|err| err.to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_platform_keyring_secret(resolver: &str, service: &str, account: &str) -> Result<String, String> {
+    if resolver != "keychain" {
+        return Err(format!("resolver '{resolver}' is not supported on macOS"));
+    }
+    use apple_native_keyring_store::keychain;
+    let store = keychain::Store::new().map_err(|err| err.to_string())?;
+    read_keyring_store(store.as_ref(), service, account)
+}
+
+#[cfg(target_os = "linux")]
+fn resolve_platform_keyring_secret(resolver: &str, service: &str, account: &str) -> Result<String, String> {
+    if resolver != "secret_service" {
+        return Err(format!("resolver '{resolver}' is not supported on Linux"));
+    }
+    let store = zbus_secret_service_keyring_store::Store::new().map_err(|err| err.to_string())?;
+    read_keyring_store(store.as_ref(), service, account)
+}
+
+#[cfg(target_os = "windows")]
+fn resolve_platform_keyring_secret(resolver: &str, service: &str, account: &str) -> Result<String, String> {
+    if resolver != "credential_manager" {
+        return Err(format!("resolver '{resolver}' is not supported on Windows"));
+    }
+    let store = windows_native_keyring_store::Store::new().map_err(|err| err.to_string())?;
+    read_keyring_store(store.as_ref(), service, account)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+fn resolve_platform_keyring_secret(resolver: &str, _service: &str, _account: &str) -> Result<String, String> {
+    Err(format!("resolver '{resolver}' is not supported on this platform"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ConfigFile, ContextServiceReference, ELASTIC_CREDENTIAL_ENV_VARS, Error, FILE_RESOLVER_MAX_BYTES, ResolvedAuth,
+        ServiceKind, discover_config_path, inline_secret_permission_warning, parse_command_argv, read_command_output,
+        read_file_resolver_value, read_keyring_store,
+    };
+    #[cfg(unix)]
+    use super::{run_command, run_command_with_timeout};
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use std::{
+        fs,
+        io::ErrorKind,
+        path::Path,
+        str::FromStr,
+        sync::{Mutex, OnceLock},
+        time::{Duration, Instant},
+    };
+    use tempfile::TempDir;
+
+    fn write(path: &Path, contents: &str) {
+        fs::write(path, contents).expect("write config");
+    }
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn service_kind_parses_supported_aliases() {
+        assert_eq!(ServiceKind::from_str("elasticsearch"), Ok(ServiceKind::Elasticsearch));
+        assert_eq!(ServiceKind::from_str("es"), Ok(ServiceKind::Elasticsearch));
+        assert_eq!(ServiceKind::from_str("kibana"), Ok(ServiceKind::Kibana));
+        assert_eq!(ServiceKind::from_str("kb"), Ok(ServiceKind::Kibana));
+        assert_eq!(ServiceKind::from_str("cloud"), Ok(ServiceKind::Cloud));
+    }
+
+    #[test]
+    fn service_kind_rejects_unsupported_aliases() {
+        assert!(ServiceKind::from_str("ls").is_err());
+        assert!(ServiceKind::from_str("logstash").is_err());
+    }
+
+    #[test]
+    fn context_service_reference_parses_active_context_service() {
+        assert_eq!(
+            ContextServiceReference::parse(".es"),
+            Some(ContextServiceReference {
+                context: None,
+                service: ServiceKind::Elasticsearch,
+            })
+        );
+    }
+
+    #[test]
+    fn context_service_reference_parses_named_context_from_rightmost_segment() {
+        assert_eq!(
+            ContextServiceReference::parse(".prod.us-west.es"),
+            Some(ContextServiceReference {
+                context: Some("prod.us-west".to_string()),
+                service: ServiceKind::Elasticsearch,
+            })
+        );
+    }
+
+    #[test]
+    fn context_service_reference_ignores_unknown_service_segments() {
+        assert_eq!(ContextServiceReference::parse(".prod.ls"), None);
+        assert_eq!(ContextServiceReference::parse(".unknown"), None);
+        assert_eq!(ContextServiceReference::parse("./.es"), None);
+    }
+
+    #[test]
+    fn resolved_auth_debug_redacts_api_key() {
+        let auth = super::ResolvedAuth::api_key("super-secret");
+        let rendered = format!("{auth:?}");
+
+        assert!(rendered.contains("[REDACTED"));
+        assert!(!rendered.contains("super-secret"));
+    }
+
+    #[test]
+    fn resolved_auth_debug_redacts_basic_password() {
+        let auth = super::ResolvedAuth::basic("elastic", "super-secret");
+        let rendered = format!("{auth:?}");
+
+        assert!(rendered.contains("elastic"));
+        assert!(rendered.contains("[REDACTED"));
+        assert!(!rendered.contains("super-secret"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn command_resolver_child_omits_elastic_credentials() {
+        let _guard = env_lock().lock().expect("env lock");
+        for name in ELASTIC_CREDENTIAL_ENV_VARS {
+            unsafe {
+                std::env::set_var(name, "must-not-leak");
+            }
+        }
+
+        let output = run_command("env", &[], "cmd", "test").expect("run env");
+
+        for name in ELASTIC_CREDENTIAL_ENV_VARS {
+            assert!(!output.contains(name), "{name} leaked to resolver child");
+            unsafe {
+                std::env::remove_var(name);
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn command_resolver_kills_timed_out_process() {
+        let start = Instant::now();
+
+        let error = run_command_with_timeout(
+            "sleep",
+            &["30".to_string()],
+            "cmd",
+            "contexts.prod.elasticsearch.auth.api_key",
+            Duration::from_millis(50),
+        )
+        .expect_err("sleep must time out");
+
+        assert!(start.elapsed() < Duration::from_secs(2));
+        assert!(error.to_string().contains("command timed out"));
+    }
+
+    #[test]
+    fn keyring_reader_returns_secret_without_mutating_global_store() {
+        let store = keyring_core::mock::Store::new().expect("mock store");
+        let entry = keyring_core::api::CredentialStoreApi::build(store.as_ref(), "elastic-cli", "production", None)
+            .expect("mock entry");
+        entry.set_password("keyring-secret").expect("set secret");
+
+        let secret = read_keyring_store(store.as_ref(), "elastic-cli", "production").expect("read secret");
+
+        assert_eq!(secret, "keyring-secret");
+        assert!(keyring_core::get_default_store().is_none());
+    }
+
+    #[test]
+    fn raw_auth_debug_redacts_inline_secrets() {
+        let auth = super::AuthBlock {
+            api_key: Some("inline-api-key".to_string()),
+            username: Some("elastic".to_string()),
+            password: Some("inline-password".to_string()),
+        };
+
+        let rendered = format!("{auth:?}");
+
+        assert!(rendered.contains("elastic"));
+        assert!(rendered.contains("[REDACTED]"));
+        assert!(!rendered.contains("inline-api-key"));
+        assert!(!rendered.contains("inline-password"));
+    }
+
+    #[test]
+    fn discovers_default_config_in_elastic_cli_order() {
+        let tmp = TempDir::new().expect("temp dir");
+        write(
+            &tmp.path().join(".elasticrc.yml"),
+            "current_context: later\ncontexts: {}\n",
+        );
+        write(&tmp.path().join(".elasticrc"), "current_context: first\ncontexts: {}\n");
+
+        assert_eq!(discover_config_path(tmp.path()), Some(tmp.path().join(".elasticrc")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discovery_skips_unreadable_config_candidate() {
+        let tmp = TempDir::new().expect("temp dir");
+        let unreadable = tmp.path().join(".elasticrc");
+        let readable = tmp.path().join(".elasticrc.yml");
+        write(&unreadable, "current_context: first\ncontexts: {}\n");
+        write(&readable, "current_context: later\ncontexts: {}\n");
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).expect("set permissions");
+
+        assert_eq!(discover_config_path(tmp.path()), Some(readable));
+    }
+
+    #[test]
+    fn loads_yaml_config_and_resolves_service() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.yml");
+        write(
+            &path,
+            r#"
+current_context: prod
+contexts:
+  prod:
+    elasticsearch:
+      url: https://es.example:9200
+      auth:
+        api_key: es-key
+    kibana:
+      url: https://kb.example:5601
+"#,
+        );
+
+        let config = ConfigFile::load(&path).expect("load config");
+        let service = config
+            .resolve_service("prod", ServiceKind::Elasticsearch)
+            .expect("resolve service");
+
+        assert_eq!(service.url.as_str(), "https://es.example:9200/");
+        assert!(matches!(service.auth, ResolvedAuth::ApiKey(ref key) if key.expose_secret() == "es-key"));
+    }
+
+    #[test]
+    fn loads_json_config() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.json");
+        write(
+            &path,
+            r#"{
+  "current_context": "prod",
+  "contexts": {
+    "prod": {
+      "elasticsearch": {
+        "url": "https://es.example:9200",
+        "auth": {
+          "username": "elastic",
+          "password": "changeme"
+        }
+      }
+    }
+  }
+}"#,
+        );
+
+        let config = ConfigFile::load(&path).expect("load config");
+        let service = config
+            .resolve_current_service(ServiceKind::Elasticsearch)
+            .expect("resolve service");
+
+        assert!(matches!(
+            service.auth,
+            ResolvedAuth::Basic { ref username, ref password }
+                if username == "elastic" && password.expose_secret() == "changeme"
+        ));
+    }
+
+    #[test]
+    fn uses_explicit_path_before_environment_override() {
+        let tmp = TempDir::new().expect("temp dir");
+        let explicit = tmp.path().join("explicit.yml");
+        let env_path = tmp.path().join("env.yml");
+        write(
+            &explicit,
+            "current_context: explicit\ncontexts:\n  explicit:\n    elasticsearch:\n      url: https://explicit.example:9200\n",
+        );
+        write(
+            &env_path,
+            "current_context: env\ncontexts:\n  env:\n    elasticsearch:\n      url: https://env.example:9200\n",
+        );
+        unsafe {
+            std::env::set_var("ELASTIC_CLI_CONFIG_FILE", &env_path);
+        }
+
+        let config = ConfigFile::load_with_options(Some(&explicit), None).expect("load config");
+
+        assert_eq!(config.current_context, "explicit");
+        unsafe {
+            std::env::remove_var("ELASTIC_CLI_CONFIG_FILE");
+        }
+    }
+
+    #[test]
+    fn uses_environment_config_override_before_home_discovery() {
+        let tmp = TempDir::new().expect("temp dir");
+        let home = tmp.path().join("home");
+        fs::create_dir(&home).expect("home dir");
+        let env_path = tmp.path().join("env.yml");
+        write(
+            &home.join(".elasticrc.yml"),
+            "current_context: home\ncontexts:\n  home:\n    elasticsearch:\n      url: https://home.example:9200\n",
+        );
+        write(
+            &env_path,
+            "current_context: env\ncontexts:\n  env:\n    elasticsearch:\n      url: https://env.example:9200\n",
+        );
+        unsafe {
+            std::env::set_var("ELASTIC_CLI_CONFIG_FILE", &env_path);
+        }
+
+        let config = ConfigFile::load_with_options(None, Some(&home)).expect("load config");
+
+        assert_eq!(config.current_context, "env");
+        unsafe {
+            std::env::remove_var("ELASTIC_CLI_CONFIG_FILE");
+        }
+    }
+
+    #[test]
+    fn rejects_executable_config_format() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.js");
+        write(&path, "module.exports = {};");
+
+        let err = ConfigFile::load(&path).expect_err("executable config should fail");
+
+        assert!(matches!(err, Error::ExecutableConfigUnsupported { .. }));
+    }
+
+    #[test]
+    fn rejects_empty_contexts() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.yml");
+        write(&path, "current_context: prod\ncontexts: {}\n");
+
+        let err = ConfigFile::load(&path).expect_err("empty contexts should fail");
+
+        assert!(matches!(err, Error::InvalidShape(_)));
+    }
+
+    #[test]
+    fn rejects_missing_context() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.yml");
+        write(
+            &path,
+            "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: https://es.example:9200\n",
+        );
+        let config = ConfigFile::load(&path).expect("load config");
+
+        let err = config
+            .resolve_service("diag", ServiceKind::Elasticsearch)
+            .expect_err("missing context should fail");
+
+        assert!(matches!(err, Error::MissingContext { name, .. } if name == "diag"));
+    }
+
+    #[test]
+    fn rejects_missing_service() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.yml");
+        write(
+            &path,
+            "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: https://es.example:9200\n",
+        );
+        let config = ConfigFile::load(&path).expect("load config");
+
+        let err = config
+            .resolve_service("prod", ServiceKind::Kibana)
+            .expect_err("missing service should fail");
+
+        assert!(matches!(
+            err,
+            Error::MissingService {
+                service: ServiceKind::Kibana,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_service_url() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.yml");
+        write(
+            &path,
+            "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: file:///tmp/es\n",
+        );
+
+        let config = ConfigFile::load(&path).expect("load config");
+        let err = config
+            .resolve_current_service(ServiceKind::Elasticsearch)
+            .expect_err("invalid url should fail");
+
+        assert!(matches!(
+            err,
+            Error::InvalidServiceUrlScheme {
+                service: ServiceKind::Elasticsearch,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_auth_shape() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.yml");
+        write(
+            &path,
+            "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: https://es.example:9200\n      auth:\n        username: elastic\n",
+        );
+
+        let config = ConfigFile::load(&path).expect("load config");
+        let err = config
+            .resolve_current_service(ServiceKind::Elasticsearch)
+            .expect_err("invalid auth should fail");
+
+        assert!(matches!(
+            err,
+            Error::InvalidAuth {
+                service: ServiceKind::Elasticsearch,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn resolves_environment_expression() {
+        let _guard = env_lock().lock().expect("env lock");
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.yml");
+        unsafe {
+            std::env::set_var("ELASTICRC_TEST_API_KEY", "env-key");
+        }
+        write(
+            &path,
+            "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: https://es.example:9200\n      auth:\n        api_key: $(env:ELASTICRC_TEST_API_KEY)\n",
+        );
+
+        let config = ConfigFile::load(&path).expect("load config");
+        let service = config
+            .resolve_current_service(ServiceKind::Elasticsearch)
+            .expect("resolve service");
+
+        assert!(matches!(service.auth, ResolvedAuth::ApiKey(ref key) if key.expose_secret() == "env-key"));
+        unsafe {
+            std::env::remove_var("ELASTICRC_TEST_API_KEY");
+        }
+    }
+
+    #[test]
+    fn loaded_config_keeps_resolver_backed_secret_raw() {
+        let _guard = env_lock().lock().expect("env lock");
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.yml");
+        unsafe {
+            std::env::set_var("ELASTICRC_TEST_API_KEY", "env-key");
+        }
+        write(
+            &path,
+            "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: https://es.example:9200\n      auth:\n        api_key: $(env:ELASTICRC_TEST_API_KEY)\n",
+        );
+
+        let config = ConfigFile::load(&path).expect("load config");
+        let api_key = config
+            .contexts
+            .get("prod")
+            .and_then(|context| context.elasticsearch.as_ref())
+            .and_then(|service| service.auth.as_ref())
+            .and_then(|auth| auth.api_key.as_deref());
+
+        assert_eq!(api_key, Some("$(env:ELASTICRC_TEST_API_KEY)"));
+        assert!(!format!("{config:?}").contains("env-key"));
+        unsafe {
+            std::env::remove_var("ELASTICRC_TEST_API_KEY");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolving_one_service_does_not_execute_other_service_resolvers() {
+        let tmp = TempDir::new().expect("temp dir");
+        let marker = tmp.path().join("kibana-resolver-ran");
+        let config_path = tmp.path().join(".elasticrc.yml");
+        write(
+            &config_path,
+            &format!(
+                "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: https://es.example:9200\n    kibana:\n      url: https://kb.example:5601\n      auth:\n        api_key: $(cmd:touch {})\n",
+                marker.display()
+            ),
+        );
+
+        let config = ConfigFile::load(&config_path).expect("load config");
+        config
+            .resolve_current_service(ServiceKind::Elasticsearch)
+            .expect("resolve Elasticsearch");
+
+        assert!(!marker.exists(), "unselected Kibana resolver must remain lazy");
+    }
+
+    #[test]
+    fn resolves_file_expression() {
+        let tmp = TempDir::new().expect("temp dir");
+        let secret = tmp.path().join("secret.txt");
+        let config = tmp.path().join(".elasticrc.yml");
+        write(&secret, "file-key\n");
+        write(
+            &config,
+            &format!(
+                "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: https://es.example:9200\n      auth:\n        api_key: $(file:{})\n",
+                secret.display()
+            ),
+        );
+
+        let config = ConfigFile::load(&config).expect("load config");
+        let service = config
+            .resolve_current_service(ServiceKind::Elasticsearch)
+            .expect("resolve service");
+
+        assert!(matches!(service.auth, ResolvedAuth::ApiKey(ref key) if key.expose_secret() == "file-key"));
+    }
+
+    #[test]
+    fn resolves_command_expression_without_shell() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.yml");
+        write(
+            &path,
+            "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: https://es.example:9200\n      auth:\n        api_key: $(cmd:printf cmd-key)\n",
+        );
+
+        let config = ConfigFile::load(&path).expect("load config");
+        let service = config
+            .resolve_current_service(ServiceKind::Elasticsearch)
+            .expect("resolve service");
+
+        assert!(matches!(service.auth, ResolvedAuth::ApiKey(ref key) if key.expose_secret() == "cmd-key"));
+    }
+
+    #[test]
+    fn command_argv_parser_supports_quotes_and_escapes() {
+        let argv = parse_command_argv(r#"printf "%s" "my key" escaped\ value"#, "cmd", "field").expect("parse argv");
+
+        assert_eq!(argv, vec!["printf", "%s", "my key", "escaped value"]);
+    }
+
+    #[test]
+    fn command_argv_parser_preserves_literal_backslashes() {
+        let argv =
+            parse_command_argv(r#""C:\Program Files\tool.exe" --path=C:\tmp\x"#, "cmd", "field").expect("parse argv");
+
+        assert_eq!(argv, vec![r#"C:\Program Files\tool.exe"#, r#"--path=C:\tmp\x"#]);
+    }
+
+    #[test]
+    fn command_argv_parser_allows_quoted_metacharacters() {
+        let argv = parse_command_argv(r#"printf "%s" "a|b" "x>y""#, "cmd", "field").expect("parse argv");
+
+        assert_eq!(argv, vec!["printf", "%s", "a|b", "x>y"]);
+    }
+
+    #[test]
+    fn command_output_reader_limits_captured_bytes() {
+        let output = vec![b'x'; FILE_RESOLVER_MAX_BYTES as usize + 1];
+
+        let err =
+            read_command_output(std::io::Cursor::new(output), "stdout").expect_err("oversized output should fail");
+
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+        assert!(err.to_string().contains("command stdout exceeded"));
+    }
+
+    #[test]
+    fn file_resolver_reader_limits_captured_bytes() {
+        let output = vec![b'x'; FILE_RESOLVER_MAX_BYTES as usize + 1];
+
+        let err = read_file_resolver_value(
+            std::io::Cursor::new(output),
+            Path::new("secret.txt"),
+            "file",
+            "auth.api_key",
+        )
+        .expect_err("oversized output should fail");
+
+        assert!(
+            matches!(err, Error::ResolverFailed { message, .. } if message.contains("exceeds resolver size limit"))
+        );
+    }
+
+    #[test]
+    fn rejects_command_expression_that_requires_shell() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.yml");
+        write(
+            &path,
+            "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: https://es.example:9200\n      auth:\n        api_key: $(cmd:printf secret | cat)\n",
+        );
+
+        let config = ConfigFile::load(&path).expect("load config");
+        let err = config
+            .resolve_current_service(ServiceKind::Elasticsearch)
+            .expect_err("shell syntax should fail");
+
+        assert!(matches!(err, Error::ShellSyntaxUnsupported { .. }));
+    }
+
+    #[test]
+    fn rejects_unknown_resolver() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.yml");
+        write(
+            &path,
+            "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: https://es.example:9200\n      auth:\n        api_key: $(unknown:value)\n",
+        );
+
+        let config = ConfigFile::load(&path).expect("load config");
+        let err = config
+            .resolve_current_service(ServiceKind::Elasticsearch)
+            .expect_err("unknown resolver should fail");
+
+        assert!(matches!(err, Error::UnknownResolver { resolver, .. } if resolver == "unknown"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn loose_inline_secret_config_warns() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.yml");
+        write(
+            &path,
+            "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: https://es.example:9200\n      auth:\n        api_key: inline-key\n",
+        );
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).expect("set permissions");
+        let config = ConfigFile::load(&path).expect("load config");
+
+        let warning = inline_secret_permission_warning(&path, &config).expect("warning");
+
+        assert!(warning.contains("contains inline secrets"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executable_inline_secret_config_warns() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.yml");
+        write(
+            &path,
+            "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: https://es.example:9200\n      auth:\n        api_key: inline-key\n",
+        );
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).expect("set permissions");
+        let config = ConfigFile::load(&path).expect("load config");
+
+        let warning = inline_secret_permission_warning(&path, &config).expect("warning");
+
+        assert!(warning.contains("broader than 0600/0400"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restrictive_inline_secret_config_does_not_warn() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.yml");
+        write(
+            &path,
+            "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: https://es.example:9200\n      auth:\n        api_key: inline-key\n",
+        );
+        let config = ConfigFile::load(&path).expect("load config");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).expect("set permissions");
+
+        assert_eq!(inline_secret_permission_warning(&path, &config), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolver_backed_secret_config_does_not_warn() {
+        let _guard = env_lock().lock().expect("env lock");
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join(".elasticrc.yml");
+        unsafe {
+            std::env::set_var("ELASTICRC_TEST_API_KEY", "env-key");
+        }
+        write(
+            &path,
+            "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: https://es.example:9200\n      auth:\n        api_key: $(env:ELASTICRC_TEST_API_KEY)\n",
+        );
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).expect("set permissions");
+        let config: ConfigFile =
+            yaml_serde::from_str(&fs::read_to_string(&path).expect("read config")).expect("parse config");
+
+        assert_eq!(inline_secret_permission_warning(&path, &config), None);
+        unsafe {
+            std::env::remove_var("ELASTICRC_TEST_API_KEY");
+        }
+    }
+}

--- a/crates/elasticrc/src/lib.rs
+++ b/crates/elasticrc/src/lib.rs
@@ -930,12 +930,20 @@ fn run_command_with_timeout(
 
     let start = Instant::now();
     let status = loop {
-        if let Some(status) = child.try_wait().map_err(|source| Error::ResolverFailed {
-            resolver: resolver.to_string(),
-            field: field.to_string(),
-            message: source.to_string(),
-        })? {
-            break status;
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {}
+            Err(source) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = stdout_reader.join();
+                let _ = stderr_reader.join();
+                return Err(Error::ResolverFailed {
+                    resolver: resolver.to_string(),
+                    field: field.to_string(),
+                    message: source.to_string(),
+                });
+            }
         }
         if start.elapsed() >= timeout {
             let _ = child.kill();
@@ -951,8 +959,9 @@ fn run_command_with_timeout(
         thread::sleep(Duration::from_millis(10));
     };
 
-    let stdout = stdout_reader
-        .join()
+    let stdout_result = stdout_reader.join();
+    let stderr_result = stderr_reader.join();
+    let stdout = stdout_result
         .map_err(|_| Error::ResolverFailed {
             resolver: resolver.to_string(),
             field: field.to_string(),
@@ -963,8 +972,7 @@ fn run_command_with_timeout(
             field: field.to_string(),
             message: source.to_string(),
         })?;
-    let _stderr = stderr_reader
-        .join()
+    let _stderr = stderr_result
         .map_err(|_| Error::ResolverFailed {
             resolver: resolver.to_string(),
             field: field.to_string(),

--- a/crates/elasticrc/tests/external-consumer/.gitignore
+++ b/crates/elasticrc/tests/external-consumer/.gitignore
@@ -1,0 +1,2 @@
+/Cargo.lock
+/target/

--- a/crates/elasticrc/tests/external-consumer/Cargo.toml
+++ b/crates/elasticrc/tests/external-consumer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "elasticrc-external-consumer"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[workspace]
+
+[dependencies]
+elasticrc = { path = "../../../../target/package/elasticrc-0.1.0" }

--- a/crates/elasticrc/tests/external-consumer/src/main.rs
+++ b/crates/elasticrc/tests/external-consumer/src/main.rs
@@ -20,9 +20,18 @@
 use elasticrc::{ConfigFile, ContextServiceReference, ResolvedAuth};
 use std::{fs, process};
 
+struct RemoveFileOnDrop(std::path::PathBuf);
+
+impl Drop for RemoveFileOnDrop {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
 fn main() {
     let reference = ContextServiceReference::parse(".production.es").expect("context reference");
     let path = std::env::temp_dir().join(format!("elasticrc-external-consumer-{}.yml", process::id()));
+    let _cleanup = RemoveFileOnDrop(path.clone());
     fs::write(
         &path,
         "current_context: production\ncontexts:\n  production:\n    elasticsearch:\n      url: https://example.invalid:9200\n      auth:\n        api_key: package-secret\n",
@@ -41,5 +50,4 @@ fn main() {
         service.auth,
         ResolvedAuth::ApiKey(ref key) if key.expose_secret() == "package-secret"
     ));
-    fs::remove_file(path).expect("remove config");
 }

--- a/crates/elasticrc/tests/external-consumer/src/main.rs
+++ b/crates/elasticrc/tests/external-consumer/src/main.rs
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use elasticrc::{ConfigFile, ContextServiceReference, ResolvedAuth};
+use std::{fs, process};
+
+fn main() {
+    let reference = ContextServiceReference::parse(".production.es").expect("context reference");
+    let path = std::env::temp_dir().join(format!("elasticrc-external-consumer-{}.yml", process::id()));
+    fs::write(
+        &path,
+        "current_context: production\ncontexts:\n  production:\n    elasticsearch:\n      url: https://example.invalid:9200\n      auth:\n        api_key: package-secret\n",
+    )
+    .expect("write config");
+    let config = ConfigFile::load(&path).expect("load packaged config");
+    let service = config
+        .resolve_service(
+            reference.context.as_deref().expect("named context"),
+            reference.service,
+        )
+        .expect("resolve packaged service");
+
+    assert_eq!(service.url.as_str(), "https://example.invalid:9200/");
+    assert!(matches!(
+        service.auth,
+        ResolvedAuth::ApiKey(ref key) if key.expose_secret() == "package-secret"
+    ));
+    fs::remove_file(path).expect("remove config");
+}

--- a/crates/elasticrc/tests/external_consumer.rs
+++ b/crates/elasticrc/tests/external_consumer.rs
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use elasticrc::{ConfigFile, ContextServiceReference, ResolvedAuth, ServiceKind};
+
+#[test]
+fn public_api_resolves_context_without_esdiag_types() {
+    let fixture = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/elastic-cli-basic.yml");
+    let reference = ContextServiceReference::parse(".local.es").expect("context reference");
+    let config = ConfigFile::load(fixture).expect("load config");
+    let service = config
+        .resolve_service(
+            reference.context.as_deref().expect("named context"),
+            ServiceKind::Elasticsearch,
+        )
+        .expect("resolve service");
+
+    assert_eq!(service.url.as_str(), "https://local-es.example:9200/");
+    assert!(matches!(service.auth, ResolvedAuth::ApiKey(_)));
+}

--- a/crates/elasticrc/tests/fixtures/elastic-cli-basic.yml
+++ b/crates/elasticrc/tests/fixtures/elastic-cli-basic.yml
@@ -1,0 +1,14 @@
+current_context: local
+contexts:
+  local:
+    elasticsearch:
+      url: https://local-es.example:9200
+      auth:
+        api_key: local-api-key
+    kibana:
+      url: https://local-kb.example:5601
+  diag:
+    cloud:
+      url: https://cloud.elastic.co/deployments/deployment-123
+      auth:
+        api_key: cloud-api-key

--- a/crates/elasticrc/tests/schema_drift.rs
+++ b/crates/elasticrc/tests/schema_drift.rs
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use elasticrc::{ConfigFile, Error, ResolvedAuth, ServiceKind};
+use std::fs;
+
+#[test]
+fn supported_elastic_cli_fixture_resolves_expected_services() {
+    let fixture = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/elastic-cli-basic.yml");
+    let config = ConfigFile::load(fixture).expect("fixture should load");
+
+    let es = config
+        .resolve_current_service(ServiceKind::Elasticsearch)
+        .expect("current es service");
+    let kb = config
+        .resolve_current_service(ServiceKind::Kibana)
+        .expect("current kb service");
+    let cloud = config
+        .resolve_service("diag", ServiceKind::Cloud)
+        .expect("diag cloud service");
+
+    assert_eq!(es.url.as_str(), "https://local-es.example:9200/");
+    assert!(matches!(es.auth, ResolvedAuth::ApiKey(ref key) if key.expose_secret() == "local-api-key"));
+    assert_eq!(kb.url.as_str(), "https://local-kb.example:5601/");
+    assert_eq!(
+        cloud.url.as_str(),
+        "https://cloud.elastic.co/deployments/deployment-123"
+    );
+}
+
+#[test]
+fn platform_specific_keyring_resolver_rejects_unsupported_platform() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let path = tmp.path().join(".elasticrc.yml");
+    let resolver = unsupported_platform_resolver();
+    fs::write(
+        &path,
+        format!(
+            "current_context: prod\ncontexts:\n  prod:\n    elasticsearch:\n      url: https://es.example:9200\n      auth:\n        api_key: $({resolver}:elastic-cli/prod-api-key)\n"
+        ),
+    )
+    .expect("write config");
+
+    let config = ConfigFile::load(&path).expect("load config");
+    let err = config
+        .resolve_current_service(ServiceKind::Elasticsearch)
+        .expect_err("unsupported resolver should fail");
+
+    assert!(matches!(err, Error::ResolverFailed { resolver: actual, .. } if actual == resolver));
+}
+
+#[cfg(target_os = "macos")]
+fn unsupported_platform_resolver() -> &'static str {
+    "secret_service"
+}
+
+#[cfg(target_os = "linux")]
+fn unsupported_platform_resolver() -> &'static str {
+    "credential_manager"
+}
+
+#[cfg(target_os = "windows")]
+fn unsupported_platform_resolver() -> &'static str {
+    "keychain"
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+fn unsupported_platform_resolver() -> &'static str {
+    "keychain"
+}


### PR DESCRIPTION
## Summary
- Add the independently publishable `elasticrc` Rust library for reading and securely resolving Elastic CLI context configuration.
- Include lazy, service-scoped resolver execution, redacted authentication, platform keyring integrations, and read-only config discovery.
- Add package metadata, Apache-2.0 licensing, cross-platform/MSRV CI, documentation, and an external consumer check.
- Keep ESDiag integration out of this PR; it remains part of [#344](https://github.com/elastic/esdiag/pull/344).

## Test plan
- [x] `cargo test -p elasticrc`
- [x] `cargo test -p elasticrc --doc`
- [x] `cargo doc -p elasticrc --no-deps`
- [x] `cargo package -p elasticrc --allow-dirty`
- [x] External packaged-crate consumer check
- [x] `cargo publish --dry-run -p elasticrc --allow-dirty`

Made with [Cursor](https://cursor.com)