### PR TITLE
Type elasticrc service configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ published release notes, maintenance branches, and tagged history.
 
 ### Changed
 
+- Changed `elasticrc` to parse schema-keyed `ServiceConfig<T>` values that resolve into typed runtime `Service<T>` values.
 - Replaced `min-diag.sh` with the collection-only, version-aware `esdiag-lite.sh`, using environment-based Elasticsearch authentication, optional ZIP output, and no `jq` runtime dependency.
 
 ### Added

--- a/crates/elasticrc/README.md
+++ b/crates/elasticrc/README.md
@@ -14,20 +14,25 @@ It reads `.elasticrc`, `.elasticrc.json`, `.elasticrc.yaml`, and
 ## Usage
 
 ```rust
-use elasticrc::{ConfigFile, ServiceKind};
+use elasticrc::ConfigFile;
 
 let config = ConfigFile::load_with_options(None, None)?;
-let elasticsearch =
-    config.resolve_current_service(ServiceKind::Elasticsearch)?;
+let elasticsearch = config
+    .current()?
+    .elasticsearch
+    .as_ref()
+    .expect("current context has no Elasticsearch service")
+    .resolve()?;
 
 println!("Connecting to {}", elasticsearch.url);
 
 # Ok::<(), elasticrc::Error>(())
 ```
 
-Loading a config parses and validates its structure without executing resolver
-expressions. `resolve_service` and `resolve_current_service` evaluate only the
-requested service.
+Loading a config parses its typed `ServiceConfig<Elasticsearch>`,
+`ServiceConfig<Kibana>`, and `ServiceConfig<Cloud>` fields without executing
+resolver expressions. `ServiceConfig::resolve` evaluates only the selected
+configuration and returns a runtime `Service<T>`.
 
 Supported resolvers:
 

--- a/crates/elasticrc/examples/inspect.rs
+++ b/crates/elasticrc/examples/inspect.rs
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-use elasticrc::{ConfigFile, ResolvedAuth, ServiceKind};
+use elasticrc::{Auth, ConfigFile};
 use std::{env, path::PathBuf, process::ExitCode};
 
 fn main() -> ExitCode {
@@ -33,17 +33,25 @@ fn main() -> ExitCode {
 fn run() -> Result<(), elasticrc::Error> {
     let explicit_path = env::args_os().nth(1).map(PathBuf::from);
     let config = ConfigFile::load_with_options(explicit_path.as_deref(), None)?;
-    let service = config.resolve_current_service(ServiceKind::Elasticsearch)?;
+    let service = config
+        .current()?
+        .elasticsearch
+        .as_ref()
+        .ok_or_else(|| elasticrc::Error::MissingService {
+            context: config.current_context.clone(),
+            service: "elasticsearch",
+        })?
+        .resolve()?;
 
     println!("context: {}", config.current_context);
-    println!("service: {}", service.kind);
+    println!("service: elasticsearch");
     println!("url: {}", service.url);
     println!(
         "authentication: {}",
         match service.auth {
-            ResolvedAuth::ApiKey(_) => "api_key",
-            ResolvedAuth::Basic { .. } => "basic",
-            ResolvedAuth::None => "none",
+            Auth::ApiKey(_) => "api_key",
+            Auth::Basic { .. } => "basic",
+            Auth::None => "none",
         }
     );
     Ok(())

--- a/crates/elasticrc/examples/inspect.rs
+++ b/crates/elasticrc/examples/inspect.rs
@@ -38,12 +38,12 @@ fn run() -> Result<(), elasticrc::Error> {
         .elasticsearch
         .as_ref()
         .ok_or_else(|| elasticrc::Error::MissingService {
-            context: config.current_context.clone(),
+            context: config.current_context_name().to_string(),
             service: Elasticsearch::NAME,
         })?
         .resolve()?;
 
-    println!("context: {}", config.current_context);
+    println!("context: {}", config.current_context_name());
     println!("service: {}", Elasticsearch::NAME);
     println!("url: {}", service.url);
     println!(

--- a/crates/elasticrc/examples/inspect.rs
+++ b/crates/elasticrc/examples/inspect.rs
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-use elasticrc::{Auth, ConfigFile};
+use elasticrc::{Auth, ConfigFile, Elasticsearch, ServiceType};
 use std::{env, path::PathBuf, process::ExitCode};
 
 fn main() -> ExitCode {
@@ -39,12 +39,12 @@ fn run() -> Result<(), elasticrc::Error> {
         .as_ref()
         .ok_or_else(|| elasticrc::Error::MissingService {
             context: config.current_context.clone(),
-            service: "elasticsearch",
+            service: Elasticsearch::NAME,
         })?
         .resolve()?;
 
     println!("context: {}", config.current_context);
-    println!("service: elasticsearch");
+    println!("service: {}", Elasticsearch::NAME);
     println!("url: {}", service.url);
     println!(
         "authentication: {}",

--- a/crates/elasticrc/src/lib.rs
+++ b/crates/elasticrc/src/lib.rs
@@ -119,8 +119,8 @@ impl ConfigFile {
     /// Validate all raw service blocks without evaluating resolver expressions.
     pub fn validate(&self) -> Result<(), Error> {
         self.validate_shape()?;
-        for context in self.contexts.values() {
-            context.validate()?;
+        for (context_name, context) in &self.contexts {
+            context.validate(context_name)?;
         }
         Ok(())
     }
@@ -204,15 +204,15 @@ pub struct Context {
 }
 
 impl Context {
-    fn validate(&self) -> Result<(), Error> {
+    fn validate(&self, context_name: &str) -> Result<(), Error> {
         if let Some(service) = &self.elasticsearch {
-            service.validate()?;
+            service.validate(Some(context_name))?;
         }
         if let Some(service) = &self.kibana {
-            service.validate()?;
+            service.validate(Some(context_name))?;
         }
         if let Some(service) = &self.cloud {
-            service.validate()?;
+            service.validate(Some(context_name))?;
         }
         Ok(())
     }
@@ -239,20 +239,22 @@ impl<T: ServiceType> ServiceConfig<T> {
         }
     }
 
-    fn validate(&self) -> Result<(), Error> {
+    fn validate(&self, context_name: Option<&str>) -> Result<(), Error> {
         let url = Url::parse(&self.url).map_err(|source| Error::InvalidServiceUrl {
+            context: context_name.map(str::to_string),
             service: T::NAME,
             value: self.url.clone(),
             source,
         })?;
         if !matches!(url.scheme(), "http" | "https") {
             return Err(Error::InvalidServiceUrlScheme {
+                context: context_name.map(str::to_string),
                 service: T::NAME,
                 value: self.url.clone(),
             });
         }
         if let Some(auth) = &self.auth {
-            auth.validate(T::NAME)?;
+            auth.validate(context_name, T::NAME)?;
         }
         Ok(())
     }
@@ -262,18 +264,20 @@ impl<T: ServiceType> ServiceConfig<T> {
         let field = |name: &str| format!("{}.{name}", T::NAME);
         let url_value = resolve_string_expressions(&self.url, &field("url"))?;
         let url = Url::parse(&url_value).map_err(|source| Error::InvalidServiceUrl {
+            context: None,
             service: T::NAME,
             value: url_value.clone(),
             source,
         })?;
         if !matches!(url.scheme(), "http" | "https") {
             return Err(Error::InvalidServiceUrlScheme {
+                context: None,
                 service: T::NAME,
                 value: url_value,
             });
         }
         let auth = if let Some(auth) = &self.auth {
-            auth.validate(T::NAME)?;
+            auth.validate(None, T::NAME)?;
             auth.resolve(T::NAME)?
         } else {
             Auth::None
@@ -312,14 +316,16 @@ impl std::fmt::Debug for AuthConfig {
 }
 
 impl AuthConfig {
-    fn validate(&self, service: &'static str) -> Result<(), Error> {
+    fn validate(&self, context_name: Option<&str>, service: &'static str) -> Result<(), Error> {
         match (&self.api_key, &self.username, &self.password) {
             (Some(_), None, None) | (None, None, None) | (None, Some(_), Some(_)) => Ok(()),
             (Some(_), _, _) => Err(Error::InvalidAuth {
+                context: context_name.map(str::to_string),
                 service,
                 message: "api_key cannot be combined with username or password".to_string(),
             }),
             (None, Some(_), None) | (None, None, Some(_)) => Err(Error::InvalidAuth {
+                context: context_name.map(str::to_string),
                 service,
                 message: "basic authentication requires both username and password".to_string(),
             }),
@@ -440,15 +446,18 @@ pub enum Error {
         service: &'static str,
     },
     InvalidServiceUrl {
+        context: Option<String>,
         service: &'static str,
         value: String,
         source: url::ParseError,
     },
     InvalidServiceUrlScheme {
+        context: Option<String>,
         service: &'static str,
         value: String,
     },
     InvalidAuth {
+        context: Option<String>,
         service: &'static str,
         message: String,
     },
@@ -499,15 +508,51 @@ impl Display for Error {
             Self::MissingService { context, service } => {
                 write!(f, "Elastic CLI context '{context}' does not define service '{service}'")
             }
-            Self::InvalidServiceUrl { service, value, source } => {
-                write!(f, "invalid URL for Elastic CLI service '{service}' ({value}): {source}")
+            Self::InvalidServiceUrl {
+                context,
+                service,
+                value,
+                source,
+            } => {
+                if let Some(context) = context {
+                    write!(
+                        f,
+                        "invalid URL for Elastic CLI context '{context}' service '{service}' ({value}): {source}"
+                    )
+                } else {
+                    write!(f, "invalid URL for Elastic CLI service '{service}' ({value}): {source}")
+                }
             }
-            Self::InvalidServiceUrlScheme { service, value } => write!(
-                f,
-                "invalid URL scheme for Elastic CLI service '{service}' ({value}); expected http or https"
-            ),
-            Self::InvalidAuth { service, message } => {
-                write!(f, "invalid auth for Elastic CLI service '{service}': {message}")
+            Self::InvalidServiceUrlScheme {
+                context,
+                service,
+                value,
+            } => {
+                if let Some(context) = context {
+                    write!(
+                        f,
+                        "invalid URL scheme for Elastic CLI context '{context}' service '{service}' ({value}); expected http or https"
+                    )
+                } else {
+                    write!(
+                        f,
+                        "invalid URL scheme for Elastic CLI service '{service}' ({value}); expected http or https"
+                    )
+                }
+            }
+            Self::InvalidAuth {
+                context,
+                service,
+                message,
+            } => {
+                if let Some(context) = context {
+                    write!(
+                        f,
+                        "invalid auth for Elastic CLI context '{context}' service '{service}': {message}"
+                    )
+                } else {
+                    write!(f, "invalid auth for Elastic CLI service '{service}': {message}")
+                }
             }
             Self::InvalidResolverExpression { field, value } => {
                 write!(f, "invalid resolver expression in field '{field}': {value}")
@@ -1406,21 +1451,15 @@ contexts:
         );
 
         let config = ConfigFile::load(&path).expect("load config");
-        let err = config
-            .current()
-            .expect("current context")
-            .elasticsearch
-            .as_ref()
-            .expect("Elasticsearch config")
-            .resolve()
-            .expect_err("invalid url should fail");
+        let err = config.validate().expect_err("invalid url should fail");
 
         assert!(matches!(
             err,
             Error::InvalidServiceUrlScheme {
+                context: Some(ref context),
                 service: "elasticsearch",
                 ..
-            }
+            } if context == "prod"
         ));
     }
 
@@ -1434,21 +1473,15 @@ contexts:
         );
 
         let config = ConfigFile::load(&path).expect("load config");
-        let err = config
-            .current()
-            .expect("current context")
-            .elasticsearch
-            .as_ref()
-            .expect("Elasticsearch config")
-            .resolve()
-            .expect_err("invalid auth should fail");
+        let err = config.validate().expect_err("invalid auth should fail");
 
         assert!(matches!(
             err,
             Error::InvalidAuth {
+                context: Some(ref context),
                 service: "elasticsearch",
                 ..
-            }
+            } if context == "prod"
         ));
     }
 

--- a/crates/elasticrc/src/lib.rs
+++ b/crates/elasticrc/src/lib.rs
@@ -77,7 +77,7 @@ const ELASTIC_CREDENTIAL_ENV_VARS: [&str; 9] = [
     "ELASTIC_CLOUD_PASSWORD",
 ];
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 /// Raw Elastic CLI configuration.
 ///
 /// Secret fields may contain inline values or unresolved expressions. Resolver
@@ -87,7 +87,34 @@ pub struct ConfigFile {
     pub contexts: BTreeMap<String, Context>,
 }
 
+impl<'de> Deserialize<'de> for ConfigFile {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct ConfigFileData {
+            current_context: String,
+            contexts: BTreeMap<String, Context>,
+        }
+
+        let data = ConfigFileData::deserialize(deserializer)?;
+        let mut config = Self {
+            current_context: data.current_context,
+            contexts: data.contexts,
+        };
+        config.attach_context_names();
+        Ok(config)
+    }
+}
+
 impl ConfigFile {
+    fn attach_context_names(&mut self) {
+        for (context_name, context) in &mut self.contexts {
+            context.attach_name(context_name);
+        }
+    }
+
     /// Load a JSON or YAML Elastic CLI config from an explicit path.
     pub fn load(path: impl AsRef<Path>) -> Result<Self, Error> {
         load_config_file(path)
@@ -119,8 +146,8 @@ impl ConfigFile {
     /// Validate all raw service blocks without evaluating resolver expressions.
     pub fn validate(&self) -> Result<(), Error> {
         self.validate_shape()?;
-        for (context_name, context) in &self.contexts {
-            context.validate(context_name)?;
+        for context in self.contexts.values() {
+            context.validate()?;
         }
         Ok(())
     }
@@ -204,15 +231,27 @@ pub struct Context {
 }
 
 impl Context {
-    fn validate(&self, context_name: &str) -> Result<(), Error> {
+    fn attach_name(&mut self, context_name: &str) {
+        if let Some(service) = &mut self.elasticsearch {
+            service.context = Some(context_name.to_string());
+        }
+        if let Some(service) = &mut self.kibana {
+            service.context = Some(context_name.to_string());
+        }
+        if let Some(service) = &mut self.cloud {
+            service.context = Some(context_name.to_string());
+        }
+    }
+
+    fn validate(&self) -> Result<(), Error> {
         if let Some(service) = &self.elasticsearch {
-            service.validate(Some(context_name))?;
+            service.validate()?;
         }
         if let Some(service) = &self.kibana {
-            service.validate(Some(context_name))?;
+            service.validate()?;
         }
         if let Some(service) = &self.cloud {
-            service.validate(Some(context_name))?;
+            service.validate()?;
         }
         Ok(())
     }
@@ -226,6 +265,8 @@ pub struct ServiceConfig<T> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth: Option<AuthConfig>,
     #[serde(skip)]
+    context: Option<String>,
+    #[serde(skip)]
     service_type: PhantomData<T>,
 }
 
@@ -235,50 +276,54 @@ impl<T: ServiceType> ServiceConfig<T> {
         Self {
             url: url.into(),
             auth,
+            context: None,
             service_type: PhantomData,
         }
     }
 
-    fn validate(&self, context_name: Option<&str>) -> Result<(), Error> {
+    fn validate(&self) -> Result<(), Error> {
         let url = Url::parse(&self.url).map_err(|source| Error::InvalidServiceUrl {
-            context: context_name.map(str::to_string),
+            context: self.context.clone(),
             service: T::NAME,
             value: self.url.clone(),
             source,
         })?;
         if !matches!(url.scheme(), "http" | "https") {
             return Err(Error::InvalidServiceUrlScheme {
-                context: context_name.map(str::to_string),
+                context: self.context.clone(),
                 service: T::NAME,
                 value: self.url.clone(),
             });
         }
         if let Some(auth) = &self.auth {
-            auth.validate(context_name, T::NAME)?;
+            auth.validate(self.context.as_deref(), T::NAME)?;
         }
         Ok(())
     }
 
     /// Resolve expressions and produce a validated runtime service.
     pub fn resolve(&self) -> Result<Service<T>, Error> {
-        let field = |name: &str| format!("{}.{name}", T::NAME);
+        let field = |name: &str| match &self.context {
+            Some(context) => format!("{context}.{}.{name}", T::NAME),
+            None => format!("{}.{name}", T::NAME),
+        };
         let url_value = resolve_string_expressions(&self.url, &field("url"))?;
         let url = Url::parse(&url_value).map_err(|source| Error::InvalidServiceUrl {
-            context: None,
+            context: self.context.clone(),
             service: T::NAME,
             value: url_value.clone(),
             source,
         })?;
         if !matches!(url.scheme(), "http" | "https") {
             return Err(Error::InvalidServiceUrlScheme {
-                context: None,
+                context: self.context.clone(),
                 service: T::NAME,
                 value: url_value,
             });
         }
         let auth = if let Some(auth) = &self.auth {
-            auth.validate(None, T::NAME)?;
-            auth.resolve(T::NAME)?
+            auth.validate(self.context.as_deref(), T::NAME)?;
+            auth.resolve(self.context.as_deref(), T::NAME)?
         } else {
             Auth::None
         };
@@ -332,8 +377,14 @@ impl AuthConfig {
         }
     }
 
-    fn resolve(&self, service: &'static str) -> Result<Auth, Error> {
-        let resolve = |value: &str, name: &str| resolve_string_expressions(value, &format!("{service}.auth.{name}"));
+    fn resolve(&self, context_name: Option<&str>, service: &'static str) -> Result<Auth, Error> {
+        let resolve = |value: &str, name: &str| {
+            let field = match context_name {
+                Some(context) => format!("{context}.{service}.auth.{name}"),
+                None => format!("{service}.auth.{name}"),
+            };
+            resolve_string_expressions(value, &field)
+        };
         match (&self.api_key, &self.username, &self.password) {
             (Some(api_key), None, None) => Ok(Auth::api_key(resolve(api_key, "api_key")?)),
             (None, Some(username), Some(password)) => Ok(Auth::basic(
@@ -1461,6 +1512,18 @@ contexts:
                 ..
             } if context == "prod"
         ));
+
+        let err = current_elasticsearch(&config)
+            .resolve()
+            .expect_err("resolved URL should retain context");
+        assert!(matches!(
+            err,
+            Error::InvalidServiceUrlScheme {
+                context: Some(ref context),
+                service: "elasticsearch",
+                ..
+            } if context == "prod"
+        ));
     }
 
     #[test]
@@ -1678,7 +1741,11 @@ contexts:
             .resolve()
             .expect_err("unknown resolver should fail");
 
-        assert!(matches!(err, Error::UnknownResolver { resolver, .. } if resolver == "unknown"));
+        assert!(matches!(
+            err,
+            Error::UnknownResolver { resolver, field }
+                if resolver == "unknown" && field == "prod.elasticsearch.auth.api_key"
+        ));
     }
 
     #[cfg(unix)]

--- a/crates/elasticrc/src/lib.rs
+++ b/crates/elasticrc/src/lib.rs
@@ -20,18 +20,23 @@
 //! Read-only discovery, parsing, and lazy resolution of Elastic CLI contexts.
 //!
 //! Loading a [`ConfigFile`] validates only its top-level shape and never executes
-//! resolver expressions. Call [`ConfigFile::resolve_service`] or
-//! [`ConfigFile::resolve_current_service`] to resolve one selected service.
+//! resolver expressions. Call [`ServiceConfig::resolve`] on one selected service
+//! configuration to produce a runtime [`Service`].
 //!
-//! Resolved credentials use [`SecretString`] so common debug formatting does not
+//! Runtime credentials use [`SecretString`] so common debug formatting does not
 //! reveal secret values. Callers should keep those values runtime-only.
 //!
 //! ```
-//! use elasticrc::{ConfigFile, ServiceKind};
+//! use elasticrc::ConfigFile;
 //!
 //! # fn example() -> Result<(), elasticrc::Error> {
 //! let config = ConfigFile::load_with_options(None, None)?;
-//! let elasticsearch = config.resolve_current_service(ServiceKind::Elasticsearch)?;
+//! let elasticsearch = config
+//!     .current()?
+//!     .elasticsearch
+//!     .as_ref()
+//!     .expect("current context has no Elasticsearch service")
+//!     .resolve()?;
 //! println!("Elasticsearch URL: {}", elasticsearch.url);
 //! # Ok(())
 //! # }
@@ -48,9 +53,9 @@ use std::{
     fmt::Display,
     fs,
     io::{self, Read},
+    marker::PhantomData,
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    str::FromStr,
     thread,
     time::{Duration, Instant},
 };
@@ -114,8 +119,8 @@ impl ConfigFile {
     /// Validate all raw service blocks without evaluating resolver expressions.
     pub fn validate(&self) -> Result<(), Error> {
         self.validate_shape()?;
-        for (context_name, context) in &self.contexts {
-            context.validate(context_name)?;
+        for context in self.contexts.values() {
+            context.validate()?;
         }
         Ok(())
     }
@@ -130,58 +135,84 @@ impl ConfigFile {
         Ok(())
     }
 
-    /// Resolve and validate one service from a named context.
-    pub fn resolve_service(&self, context_name: &str, kind: ServiceKind) -> Result<ResolvedService, Error> {
-        let context = self.contexts.get(context_name).ok_or_else(|| Error::MissingContext {
-            name: context_name.to_string(),
+    /// Return a named context.
+    pub fn context(&self, name: &str) -> Result<&Context, Error> {
+        self.contexts.get(name).ok_or_else(|| Error::MissingContext {
+            name: name.to_string(),
             available: self.contexts.keys().cloned().collect(),
-        })?;
-        let service = context.service(kind).ok_or_else(|| Error::MissingService {
-            context: context_name.to_string(),
-            service: kind,
-        })?;
-        let mut service = service.clone();
-        service.resolve_expressions(context_name, kind)?;
-        service.validate(context_name, kind)?;
-        service.resolve(kind)
+        })
     }
 
-    /// Resolve and validate one service from `current_context`.
-    pub fn resolve_current_service(&self, kind: ServiceKind) -> Result<ResolvedService, Error> {
-        self.resolve_service(&self.current_context, kind)
+    /// Return the current context.
+    pub fn current(&self) -> Result<&Context, Error> {
+        self.contexts
+            .get(&self.current_context)
+            .ok_or_else(|| Error::MissingContext {
+                name: self.current_context.clone(),
+                available: self.contexts.keys().cloned().collect(),
+            })
     }
+}
+
+/// Marker for an Elasticsearch service.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Elasticsearch;
+
+/// Marker for a Kibana service.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Kibana;
+
+/// Marker for an Elastic Cloud service.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Cloud;
+
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for super::Elasticsearch {}
+    impl Sealed for super::Kibana {}
+    impl Sealed for super::Cloud {}
+}
+
+/// A service type supported by the Elastic CLI configuration schema.
+pub trait ServiceType: private::Sealed {
+    /// Canonical name used by the Elastic CLI configuration schema.
+    const NAME: &'static str;
+}
+
+impl ServiceType for Elasticsearch {
+    const NAME: &'static str = "elasticsearch";
+}
+
+impl ServiceType for Kibana {
+    const NAME: &'static str = "kibana";
+}
+
+impl ServiceType for Cloud {
+    const NAME: &'static str = "cloud";
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 /// Services configured for one Elastic CLI context.
 pub struct Context {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub elasticsearch: Option<ServiceBlock>,
+    pub elasticsearch: Option<ServiceConfig<Elasticsearch>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub kibana: Option<ServiceBlock>,
+    pub kibana: Option<ServiceConfig<Kibana>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cloud: Option<ServiceBlock>,
+    pub cloud: Option<ServiceConfig<Cloud>>,
 }
 
 impl Context {
-    /// Return a raw service block without evaluating its resolver expressions.
-    pub fn service(&self, kind: ServiceKind) -> Option<&ServiceBlock> {
-        match kind {
-            ServiceKind::Elasticsearch => self.elasticsearch.as_ref(),
-            ServiceKind::Kibana => self.kibana.as_ref(),
-            ServiceKind::Cloud => self.cloud.as_ref(),
+    fn validate(&self) -> Result<(), Error> {
+        if let Some(service) = &self.elasticsearch {
+            service.validate()?;
         }
-    }
-
-    fn validate(&self, context_name: &str) -> Result<(), Error> {
-        for (kind, service) in [
-            (ServiceKind::Elasticsearch, self.elasticsearch.as_ref()),
-            (ServiceKind::Kibana, self.kibana.as_ref()),
-            (ServiceKind::Cloud, self.cloud.as_ref()),
-        ] {
-            if let Some(service) = service {
-                service.validate(context_name, kind)?;
-            }
+        if let Some(service) = &self.kibana {
+            service.validate()?;
+        }
+        if let Some(service) = &self.cloud {
+            service.validate()?;
         }
         Ok(())
     }
@@ -189,57 +220,70 @@ impl Context {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 /// Raw URL and optional authentication for one context service.
-pub struct ServiceBlock {
+#[serde(bound = "")]
+pub struct ServiceConfig<T> {
     pub url: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub auth: Option<AuthBlock>,
+    pub auth: Option<AuthConfig>,
+    #[serde(skip)]
+    service_type: PhantomData<T>,
 }
 
-impl ServiceBlock {
-    fn validate(&self, context_name: &str, kind: ServiceKind) -> Result<(), Error> {
+impl<T: ServiceType> ServiceConfig<T> {
+    /// Construct a raw service configuration.
+    pub fn new(url: impl Into<String>, auth: Option<AuthConfig>) -> Self {
+        Self {
+            url: url.into(),
+            auth,
+            service_type: PhantomData,
+        }
+    }
+
+    fn validate(&self) -> Result<(), Error> {
         let url = Url::parse(&self.url).map_err(|source| Error::InvalidServiceUrl {
-            context: context_name.to_string(),
-            service: kind,
+            service: T::NAME,
             value: self.url.clone(),
             source,
         })?;
         if !matches!(url.scheme(), "http" | "https") {
             return Err(Error::InvalidServiceUrlScheme {
-                context: context_name.to_string(),
-                service: kind,
+                service: T::NAME,
                 value: self.url.clone(),
             });
         }
         if let Some(auth) = &self.auth {
-            auth.validate(context_name, kind)?;
+            auth.validate(T::NAME)?;
         }
         Ok(())
     }
 
-    fn resolve(&self, kind: ServiceKind) -> Result<ResolvedService, Error> {
-        Ok(ResolvedService {
-            kind,
-            url: Url::parse(&self.url).map_err(|source| Error::InvalidServiceUrl {
-                context: "<resolved>".to_string(),
-                service: kind,
-                value: self.url.clone(),
-                source,
-            })?,
-            auth: self
-                .auth
-                .as_ref()
-                .map(AuthBlock::resolve)
-                .transpose()?
-                .unwrap_or_default(),
+    /// Resolve expressions and produce a validated runtime service.
+    pub fn resolve(&self) -> Result<Service<T>, Error> {
+        let field = |name: &str| format!("{}.{name}", T::NAME);
+        let url_value = resolve_string_expressions(&self.url, &field("url"))?;
+        let url = Url::parse(&url_value).map_err(|source| Error::InvalidServiceUrl {
+            service: T::NAME,
+            value: url_value.clone(),
+            source,
+        })?;
+        if !matches!(url.scheme(), "http" | "https") {
+            return Err(Error::InvalidServiceUrlScheme {
+                service: T::NAME,
+                value: url_value,
+            });
+        }
+        let auth = if let Some(auth) = &self.auth {
+            auth.validate(T::NAME)?;
+            auth.resolve(T::NAME)?
+        } else {
+            Auth::None
+        };
+
+        Ok(Service {
+            url,
+            auth,
+            service_type: PhantomData,
         })
-    }
-
-    fn resolve_expressions(&mut self, context_name: &str, kind: ServiceKind) -> Result<(), Error> {
-        self.url = resolve_string_expressions(&self.url, &format!("{context_name}.{kind}.url"))?;
-        if let Some(auth) = &mut self.auth {
-            auth.resolve_expressions(context_name, kind)?;
-        }
-        Ok(())
     }
 }
 
@@ -247,7 +291,7 @@ impl ServiceBlock {
 /// Raw authentication configuration.
 ///
 /// Debug output redacts API keys and passwords, including inline values.
-pub struct AuthBlock {
+pub struct AuthConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -256,10 +300,10 @@ pub struct AuthBlock {
     pub password: Option<String>,
 }
 
-impl std::fmt::Debug for AuthBlock {
+impl std::fmt::Debug for AuthConfig {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
-            .debug_struct("AuthBlock")
+            .debug_struct("AuthConfig")
             .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
             .field("username", &self.username)
             .field("password", &self.password.as_ref().map(|_| "[REDACTED]"))
@@ -267,107 +311,41 @@ impl std::fmt::Debug for AuthBlock {
     }
 }
 
-impl AuthBlock {
-    fn validate(&self, context_name: &str, kind: ServiceKind) -> Result<(), Error> {
+impl AuthConfig {
+    fn validate(&self, service: &'static str) -> Result<(), Error> {
         match (&self.api_key, &self.username, &self.password) {
             (Some(_), None, None) | (None, None, None) | (None, Some(_), Some(_)) => Ok(()),
             (Some(_), _, _) => Err(Error::InvalidAuth {
-                context: context_name.to_string(),
-                service: kind,
+                service,
                 message: "api_key cannot be combined with username or password".to_string(),
             }),
             (None, Some(_), None) | (None, None, Some(_)) => Err(Error::InvalidAuth {
-                context: context_name.to_string(),
-                service: kind,
+                service,
                 message: "basic authentication requires both username and password".to_string(),
             }),
         }
     }
 
-    fn resolve(&self) -> Result<ResolvedAuth, Error> {
+    fn resolve(&self, service: &'static str) -> Result<Auth, Error> {
+        let resolve = |value: &str, name: &str| resolve_string_expressions(value, &format!("{service}.auth.{name}"));
         match (&self.api_key, &self.username, &self.password) {
-            (Some(api_key), None, None) => Ok(ResolvedAuth::api_key(api_key.clone())),
-            (None, Some(username), Some(password)) => Ok(ResolvedAuth::basic(username.clone(), password.clone())),
-            (None, None, None) => Ok(ResolvedAuth::None),
+            (Some(api_key), None, None) => Ok(Auth::api_key(resolve(api_key, "api_key")?)),
+            (None, Some(username), Some(password)) => Ok(Auth::basic(
+                resolve(username, "username")?,
+                resolve(password, "password")?,
+            )),
+            (None, None, None) => Ok(Auth::None),
             _ => Err(Error::InvalidShape("invalid auth block".to_string())),
         }
     }
-
-    fn resolve_expressions(&mut self, context_name: &str, kind: ServiceKind) -> Result<(), Error> {
-        if let Some(api_key) = &mut self.api_key {
-            *api_key = resolve_string_expressions(api_key, &format!("{context_name}.{kind}.auth.api_key"))?;
-        }
-        if let Some(username) = &mut self.username {
-            *username = resolve_string_expressions(username, &format!("{context_name}.{kind}.auth.username"))?;
-        }
-        if let Some(password) = &mut self.password {
-            *password = resolve_string_expressions(password, &format!("{context_name}.{kind}.auth.password"))?;
-        }
-        Ok(())
-    }
 }
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-/// Service blocks supported by the Elastic CLI configuration schema.
-pub enum ServiceKind {
-    Elasticsearch,
-    Kibana,
-    Cloud,
-}
-
-impl ServiceKind {
-    /// Parse a canonical service name or supported short alias.
-    pub fn parse_alias(value: &str) -> Option<Self> {
-        match value {
-            "elasticsearch" | "es" => Some(Self::Elasticsearch),
-            "kibana" | "kb" => Some(Self::Kibana),
-            "cloud" => Some(Self::Cloud),
-            _ => None,
-        }
-    }
-
-    /// Return the canonical Elastic CLI service name.
-    pub fn canonical_name(self) -> &'static str {
-        match self {
-            Self::Elasticsearch => "elasticsearch",
-            Self::Kibana => "kibana",
-            Self::Cloud => "cloud",
-        }
-    }
-}
-
-impl Display for ServiceKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.canonical_name())
-    }
-}
-
-impl FromStr for ServiceKind {
-    type Err = UnknownService;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Self::parse_alias(value).ok_or_else(|| UnknownService(value.to_string()))
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-/// Error returned when parsing an unsupported service name.
-pub struct UnknownService(String);
-
-impl Display for UnknownService {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "unknown Elastic CLI service '{}'", self.0)
-    }
-}
-
-impl std::error::Error for UnknownService {}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// Parsed `.service` or `.context.service` reference.
-pub struct ContextServiceReference {
-    pub context: Option<String>,
-    pub service: ServiceKind,
+pub enum ContextServiceReference {
+    Elasticsearch { context: Option<String> },
+    Kibana { context: Option<String> },
+    Cloud { context: Option<String> },
 }
 
 impl ContextServiceReference {
@@ -386,24 +364,26 @@ impl ContextServiceReference {
             }
             None => (None, value),
         };
-        Some(Self {
-            context,
-            service: ServiceKind::parse_alias(service)?,
-        })
+        match service {
+            "elasticsearch" | "es" => Some(Self::Elasticsearch { context }),
+            "kibana" | "kb" => Some(Self::Kibana { context }),
+            "cloud" => Some(Self::Cloud { context }),
+            _ => None,
+        }
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-/// A validated service with lazily resolved authentication.
-pub struct ResolvedService {
-    pub kind: ServiceKind,
+/// A runtime service with a validated URL and resolved authentication.
+pub struct Service<T> {
     pub url: Url,
-    pub auth: ResolvedAuth,
+    pub auth: Auth,
+    service_type: PhantomData<T>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-/// Authentication resolved for a selected service.
-pub enum ResolvedAuth {
+/// Runtime authentication for a selected service.
+pub enum Auth {
     ApiKey(SecretString),
     Basic {
         username: String,
@@ -413,7 +393,7 @@ pub enum ResolvedAuth {
     None,
 }
 
-impl ResolvedAuth {
+impl Auth {
     /// Construct redacted API key authentication.
     pub fn api_key(api_key: impl Into<String>) -> Self {
         Self::ApiKey(SecretString::new(api_key.into()))
@@ -457,22 +437,19 @@ pub enum Error {
     },
     MissingService {
         context: String,
-        service: ServiceKind,
+        service: &'static str,
     },
     InvalidServiceUrl {
-        context: String,
-        service: ServiceKind,
+        service: &'static str,
         value: String,
         source: url::ParseError,
     },
     InvalidServiceUrlScheme {
-        context: String,
-        service: ServiceKind,
+        service: &'static str,
         value: String,
     },
     InvalidAuth {
-        context: String,
-        service: ServiceKind,
+        service: &'static str,
         message: String,
     },
     InvalidResolverExpression {
@@ -522,31 +499,16 @@ impl Display for Error {
             Self::MissingService { context, service } => {
                 write!(f, "Elastic CLI context '{context}' does not define service '{service}'")
             }
-            Self::InvalidServiceUrl {
-                context,
-                service,
-                value,
-                source,
-            } => write!(
+            Self::InvalidServiceUrl { service, value, source } => {
+                write!(f, "invalid URL for Elastic CLI service '{service}' ({value}): {source}")
+            }
+            Self::InvalidServiceUrlScheme { service, value } => write!(
                 f,
-                "invalid URL for Elastic CLI context '{context}' service '{service}' ({value}): {source}"
+                "invalid URL scheme for Elastic CLI service '{service}' ({value}); expected http or https"
             ),
-            Self::InvalidServiceUrlScheme {
-                context,
-                service,
-                value,
-            } => write!(
-                f,
-                "invalid URL scheme for Elastic CLI context '{context}' service '{service}' ({value}); expected http or https"
-            ),
-            Self::InvalidAuth {
-                context,
-                service,
-                message,
-            } => write!(
-                f,
-                "invalid auth for Elastic CLI context '{context}' service '{service}': {message}"
-            ),
+            Self::InvalidAuth { service, message } => {
+                write!(f, "invalid auth for Elastic CLI service '{service}': {message}")
+            }
             Self::InvalidResolverExpression { field, value } => {
                 write!(f, "invalid resolver expression in field '{field}': {value}")
             }
@@ -644,20 +606,21 @@ impl ConfigFile {
 
 impl Context {
     fn contains_inline_secret(&self) -> bool {
-        [&self.elasticsearch, &self.kibana, &self.cloud]
-            .into_iter()
-            .flatten()
-            .any(ServiceBlock::contains_inline_secret)
+        self.elasticsearch
+            .as_ref()
+            .is_some_and(ServiceConfig::contains_inline_secret)
+            || self.kibana.as_ref().is_some_and(ServiceConfig::contains_inline_secret)
+            || self.cloud.as_ref().is_some_and(ServiceConfig::contains_inline_secret)
     }
 }
 
-impl ServiceBlock {
+impl<T> ServiceConfig<T> {
     fn contains_inline_secret(&self) -> bool {
-        self.auth.as_ref().is_some_and(AuthBlock::contains_inline_secret)
+        self.auth.as_ref().is_some_and(AuthConfig::contains_inline_secret)
     }
 }
 
-impl AuthBlock {
+impl AuthConfig {
     fn contains_inline_secret(&self) -> bool {
         [&self.api_key, &self.password]
             .into_iter()
@@ -1073,8 +1036,8 @@ fn resolve_platform_keyring_secret(resolver: &str, _service: &str, _account: &st
 #[cfg(test)]
 mod tests {
     use super::{
-        ConfigFile, ContextServiceReference, ELASTIC_CREDENTIAL_ENV_VARS, Error, FILE_RESOLVER_MAX_BYTES, ResolvedAuth,
-        ServiceKind, discover_config_path, inline_secret_permission_warning, parse_command_argv, read_command_output,
+        Auth, ConfigFile, ContextServiceReference, ELASTIC_CREDENTIAL_ENV_VARS, Error, FILE_RESOLVER_MAX_BYTES,
+        discover_config_path, inline_secret_permission_warning, parse_command_argv, read_command_output,
         read_file_resolver_value, read_keyring_store,
     };
     #[cfg(unix)]
@@ -1085,7 +1048,6 @@ mod tests {
         fs,
         io::ErrorKind,
         path::Path,
-        str::FromStr,
         sync::{Mutex, OnceLock},
         time::{Duration, Instant},
     };
@@ -1095,34 +1057,25 @@ mod tests {
         fs::write(path, contents).expect("write config");
     }
 
+    fn current_elasticsearch(config: &ConfigFile) -> &super::ServiceConfig<super::Elasticsearch> {
+        config
+            .current()
+            .expect("current context")
+            .elasticsearch
+            .as_ref()
+            .expect("Elasticsearch config")
+    }
+
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
     }
 
     #[test]
-    fn service_kind_parses_supported_aliases() {
-        assert_eq!(ServiceKind::from_str("elasticsearch"), Ok(ServiceKind::Elasticsearch));
-        assert_eq!(ServiceKind::from_str("es"), Ok(ServiceKind::Elasticsearch));
-        assert_eq!(ServiceKind::from_str("kibana"), Ok(ServiceKind::Kibana));
-        assert_eq!(ServiceKind::from_str("kb"), Ok(ServiceKind::Kibana));
-        assert_eq!(ServiceKind::from_str("cloud"), Ok(ServiceKind::Cloud));
-    }
-
-    #[test]
-    fn service_kind_rejects_unsupported_aliases() {
-        assert!(ServiceKind::from_str("ls").is_err());
-        assert!(ServiceKind::from_str("logstash").is_err());
-    }
-
-    #[test]
     fn context_service_reference_parses_active_context_service() {
         assert_eq!(
             ContextServiceReference::parse(".es"),
-            Some(ContextServiceReference {
-                context: None,
-                service: ServiceKind::Elasticsearch,
-            })
+            Some(ContextServiceReference::Elasticsearch { context: None })
         );
     }
 
@@ -1130,10 +1083,25 @@ mod tests {
     fn context_service_reference_parses_named_context_from_rightmost_segment() {
         assert_eq!(
             ContextServiceReference::parse(".prod.us-west.es"),
-            Some(ContextServiceReference {
+            Some(ContextServiceReference::Elasticsearch {
                 context: Some("prod.us-west".to_string()),
-                service: ServiceKind::Elasticsearch,
             })
+        );
+    }
+
+    #[test]
+    fn context_service_reference_parses_all_service_keys_and_aliases() {
+        assert_eq!(
+            ContextServiceReference::parse(".elasticsearch"),
+            Some(ContextServiceReference::Elasticsearch { context: None })
+        );
+        assert_eq!(
+            ContextServiceReference::parse(".kb"),
+            Some(ContextServiceReference::Kibana { context: None })
+        );
+        assert_eq!(
+            ContextServiceReference::parse(".cloud"),
+            Some(ContextServiceReference::Cloud { context: None })
         );
     }
 
@@ -1145,8 +1113,8 @@ mod tests {
     }
 
     #[test]
-    fn resolved_auth_debug_redacts_api_key() {
-        let auth = super::ResolvedAuth::api_key("super-secret");
+    fn auth_debug_redacts_api_key() {
+        let auth = Auth::api_key("super-secret");
         let rendered = format!("{auth:?}");
 
         assert!(rendered.contains("[REDACTED"));
@@ -1154,8 +1122,8 @@ mod tests {
     }
 
     #[test]
-    fn resolved_auth_debug_redacts_basic_password() {
-        let auth = super::ResolvedAuth::basic("elastic", "super-secret");
+    fn auth_debug_redacts_basic_password() {
+        let auth = Auth::basic("elastic", "super-secret");
         let rendered = format!("{auth:?}");
 
         assert!(rendered.contains("elastic"));
@@ -1216,7 +1184,7 @@ mod tests {
 
     #[test]
     fn raw_auth_debug_redacts_inline_secrets() {
-        let auth = super::AuthBlock {
+        let auth = super::AuthConfig {
             api_key: Some("inline-api-key".to_string()),
             username: Some("elastic".to_string()),
             password: Some("inline-password".to_string()),
@@ -1276,11 +1244,16 @@ contexts:
 
         let config = ConfigFile::load(&path).expect("load config");
         let service = config
-            .resolve_service("prod", ServiceKind::Elasticsearch)
+            .context("prod")
+            .expect("prod context")
+            .elasticsearch
+            .as_ref()
+            .expect("Elasticsearch config")
+            .resolve()
             .expect("resolve service");
 
         assert_eq!(service.url.as_str(), "https://es.example:9200/");
-        assert!(matches!(service.auth, ResolvedAuth::ApiKey(ref key) if key.expose_secret() == "es-key"));
+        assert!(matches!(service.auth, Auth::ApiKey(ref key) if key.expose_secret() == "es-key"));
     }
 
     #[test]
@@ -1307,12 +1280,17 @@ contexts:
 
         let config = ConfigFile::load(&path).expect("load config");
         let service = config
-            .resolve_current_service(ServiceKind::Elasticsearch)
+            .current()
+            .expect("current context")
+            .elasticsearch
+            .as_ref()
+            .expect("Elasticsearch config")
+            .resolve()
             .expect("resolve service");
 
         assert!(matches!(
             service.auth,
-            ResolvedAuth::Basic { ref username, ref password }
+            Auth::Basic { ref username, ref password }
                 if username == "elastic" && password.expose_secret() == "changeme"
         ));
     }
@@ -1400,9 +1378,7 @@ contexts:
         );
         let config = ConfigFile::load(&path).expect("load config");
 
-        let err = config
-            .resolve_service("diag", ServiceKind::Elasticsearch)
-            .expect_err("missing context should fail");
+        let err = config.context("diag").expect_err("missing context should fail");
 
         assert!(matches!(err, Error::MissingContext { name, .. } if name == "diag"));
     }
@@ -1417,17 +1393,7 @@ contexts:
         );
         let config = ConfigFile::load(&path).expect("load config");
 
-        let err = config
-            .resolve_service("prod", ServiceKind::Kibana)
-            .expect_err("missing service should fail");
-
-        assert!(matches!(
-            err,
-            Error::MissingService {
-                service: ServiceKind::Kibana,
-                ..
-            }
-        ));
+        assert!(config.context("prod").expect("prod context").kibana.is_none());
     }
 
     #[test]
@@ -1441,13 +1407,18 @@ contexts:
 
         let config = ConfigFile::load(&path).expect("load config");
         let err = config
-            .resolve_current_service(ServiceKind::Elasticsearch)
+            .current()
+            .expect("current context")
+            .elasticsearch
+            .as_ref()
+            .expect("Elasticsearch config")
+            .resolve()
             .expect_err("invalid url should fail");
 
         assert!(matches!(
             err,
             Error::InvalidServiceUrlScheme {
-                service: ServiceKind::Elasticsearch,
+                service: "elasticsearch",
                 ..
             }
         ));
@@ -1464,13 +1435,18 @@ contexts:
 
         let config = ConfigFile::load(&path).expect("load config");
         let err = config
-            .resolve_current_service(ServiceKind::Elasticsearch)
+            .current()
+            .expect("current context")
+            .elasticsearch
+            .as_ref()
+            .expect("Elasticsearch config")
+            .resolve()
             .expect_err("invalid auth should fail");
 
         assert!(matches!(
             err,
             Error::InvalidAuth {
-                service: ServiceKind::Elasticsearch,
+                service: "elasticsearch",
                 ..
             }
         ));
@@ -1491,10 +1467,15 @@ contexts:
 
         let config = ConfigFile::load(&path).expect("load config");
         let service = config
-            .resolve_current_service(ServiceKind::Elasticsearch)
+            .current()
+            .expect("current context")
+            .elasticsearch
+            .as_ref()
+            .expect("Elasticsearch config")
+            .resolve()
             .expect("resolve service");
 
-        assert!(matches!(service.auth, ResolvedAuth::ApiKey(ref key) if key.expose_secret() == "env-key"));
+        assert!(matches!(service.auth, Auth::ApiKey(ref key) if key.expose_secret() == "env-key"));
         unsafe {
             std::env::remove_var("ELASTICRC_TEST_API_KEY");
         }
@@ -1543,9 +1524,7 @@ contexts:
         );
 
         let config = ConfigFile::load(&config_path).expect("load config");
-        config
-            .resolve_current_service(ServiceKind::Elasticsearch)
-            .expect("resolve Elasticsearch");
+        current_elasticsearch(&config).resolve().expect("resolve Elasticsearch");
 
         assert!(!marker.exists(), "unselected Kibana resolver must remain lazy");
     }
@@ -1565,11 +1544,9 @@ contexts:
         );
 
         let config = ConfigFile::load(&config).expect("load config");
-        let service = config
-            .resolve_current_service(ServiceKind::Elasticsearch)
-            .expect("resolve service");
+        let service = current_elasticsearch(&config).resolve().expect("resolve service");
 
-        assert!(matches!(service.auth, ResolvedAuth::ApiKey(ref key) if key.expose_secret() == "file-key"));
+        assert!(matches!(service.auth, Auth::ApiKey(ref key) if key.expose_secret() == "file-key"));
     }
 
     #[test]
@@ -1582,11 +1559,9 @@ contexts:
         );
 
         let config = ConfigFile::load(&path).expect("load config");
-        let service = config
-            .resolve_current_service(ServiceKind::Elasticsearch)
-            .expect("resolve service");
+        let service = current_elasticsearch(&config).resolve().expect("resolve service");
 
-        assert!(matches!(service.auth, ResolvedAuth::ApiKey(ref key) if key.expose_secret() == "cmd-key"));
+        assert!(matches!(service.auth, Auth::ApiKey(ref key) if key.expose_secret() == "cmd-key"));
     }
 
     #[test]
@@ -1649,8 +1624,8 @@ contexts:
         );
 
         let config = ConfigFile::load(&path).expect("load config");
-        let err = config
-            .resolve_current_service(ServiceKind::Elasticsearch)
+        let err = current_elasticsearch(&config)
+            .resolve()
             .expect_err("shell syntax should fail");
 
         assert!(matches!(err, Error::ShellSyntaxUnsupported { .. }));
@@ -1666,8 +1641,8 @@ contexts:
         );
 
         let config = ConfigFile::load(&path).expect("load config");
-        let err = config
-            .resolve_current_service(ServiceKind::Elasticsearch)
+        let err = current_elasticsearch(&config)
+            .resolve()
             .expect_err("unknown resolver should fail");
 
         assert!(matches!(err, Error::UnknownResolver { resolver, .. } if resolver == "unknown"));

--- a/crates/elasticrc/src/lib.rs
+++ b/crates/elasticrc/src/lib.rs
@@ -83,8 +83,8 @@ const ELASTIC_CREDENTIAL_ENV_VARS: [&str; 9] = [
 /// Secret fields may contain inline values or unresolved expressions. Resolver
 /// expressions are evaluated only when a service is explicitly resolved.
 pub struct ConfigFile {
-    pub current_context: String,
-    pub contexts: BTreeMap<String, Context>,
+    current_context: String,
+    contexts: BTreeMap<String, Context>,
 }
 
 impl<'de> Deserialize<'de> for ConfigFile {
@@ -168,6 +168,16 @@ impl ConfigFile {
             name: name.to_string(),
             available: self.contexts.keys().cloned().collect(),
         })
+    }
+
+    /// Return the configured current context name.
+    pub fn current_context_name(&self) -> &str {
+        &self.current_context
+    }
+
+    /// Return all configured contexts.
+    pub fn contexts(&self) -> &BTreeMap<String, Context> {
+        &self.contexts
     }
 
     /// Return the current context.
@@ -1410,7 +1420,7 @@ contexts:
 
         let config = ConfigFile::load_with_options(Some(&explicit), None).expect("load config");
 
-        assert_eq!(config.current_context, "explicit");
+        assert_eq!(config.current_context_name(), "explicit");
         unsafe {
             std::env::remove_var("ELASTIC_CLI_CONFIG_FILE");
         }
@@ -1436,7 +1446,7 @@ contexts:
 
         let config = ConfigFile::load_with_options(None, Some(&home)).expect("load config");
 
-        assert_eq!(config.current_context, "env");
+        assert_eq!(config.current_context_name(), "env");
         unsafe {
             std::env::remove_var("ELASTIC_CLI_CONFIG_FILE");
         }
@@ -1592,7 +1602,7 @@ contexts:
 
         let config = ConfigFile::load(&path).expect("load config");
         let api_key = config
-            .contexts
+            .contexts()
             .get("prod")
             .and_then(|context| context.elasticsearch.as_ref())
             .and_then(|service| service.auth.as_ref())

--- a/crates/elasticrc/tests/external-consumer/src/main.rs
+++ b/crates/elasticrc/tests/external-consumer/src/main.rs
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-use elasticrc::{ConfigFile, ContextServiceReference, ResolvedAuth};
+use elasticrc::{Auth, ConfigFile, ContextServiceReference};
 use std::{fs, process};
 
 struct RemoveFileOnDrop(std::path::PathBuf);
@@ -38,16 +38,21 @@ fn main() {
     )
     .expect("write config");
     let config = ConfigFile::load(&path).expect("load packaged config");
+    let ContextServiceReference::Elasticsearch { context } = reference else {
+        panic!("expected Elasticsearch reference");
+    };
     let service = config
-        .resolve_service(
-            reference.context.as_deref().expect("named context"),
-            reference.service,
-        )
+        .context(context.as_deref().expect("named context"))
+        .expect("context")
+        .elasticsearch
+        .as_ref()
+        .expect("Elasticsearch config")
+        .resolve()
         .expect("resolve packaged service");
 
     assert_eq!(service.url.as_str(), "https://example.invalid:9200/");
     assert!(matches!(
         service.auth,
-        ResolvedAuth::ApiKey(ref key) if key.expose_secret() == "package-secret"
+        Auth::ApiKey(ref key) if key.expose_secret() == "package-secret"
     ));
 }

--- a/crates/elasticrc/tests/external_consumer.rs
+++ b/crates/elasticrc/tests/external_consumer.rs
@@ -17,20 +17,28 @@
  * under the License.
  */
 
-use elasticrc::{ConfigFile, ContextServiceReference, ResolvedAuth, ServiceKind};
+use elasticrc::{Auth, ConfigFile, ContextServiceReference, Elasticsearch, Service};
+
+fn accepts_elasticsearch_service(_service: &Service<Elasticsearch>) {}
 
 #[test]
 fn public_api_resolves_context_without_esdiag_types() {
     let fixture = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/elastic-cli-basic.yml");
     let reference = ContextServiceReference::parse(".local.es").expect("context reference");
     let config = ConfigFile::load(fixture).expect("load config");
+    let ContextServiceReference::Elasticsearch { context } = reference else {
+        panic!("expected Elasticsearch reference");
+    };
     let service = config
-        .resolve_service(
-            reference.context.as_deref().expect("named context"),
-            ServiceKind::Elasticsearch,
-        )
+        .context(context.as_deref().expect("named context"))
+        .expect("context")
+        .elasticsearch
+        .as_ref()
+        .expect("Elasticsearch config")
+        .resolve()
         .expect("resolve service");
 
+    accepts_elasticsearch_service(&service);
     assert_eq!(service.url.as_str(), "https://local-es.example:9200/");
-    assert!(matches!(service.auth, ResolvedAuth::ApiKey(_)));
+    assert!(matches!(service.auth, Auth::ApiKey(_)));
 }

--- a/crates/elasticrc/tests/schema_drift.rs
+++ b/crates/elasticrc/tests/schema_drift.rs
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-use elasticrc::{ConfigFile, Error, ResolvedAuth, ServiceKind};
+use elasticrc::{Auth, ConfigFile, Error};
 use std::fs;
 
 #[test]
@@ -25,18 +25,30 @@ fn supported_elastic_cli_fixture_resolves_expected_services() {
     let fixture = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/elastic-cli-basic.yml");
     let config = ConfigFile::load(fixture).expect("fixture should load");
 
-    let es = config
-        .resolve_current_service(ServiceKind::Elasticsearch)
+    let current = config.current().expect("current context");
+    let es = current
+        .elasticsearch
+        .as_ref()
+        .expect("current es config")
+        .resolve()
         .expect("current es service");
-    let kb = config
-        .resolve_current_service(ServiceKind::Kibana)
+    let kb = current
+        .kibana
+        .as_ref()
+        .expect("current kb config")
+        .resolve()
         .expect("current kb service");
     let cloud = config
-        .resolve_service("diag", ServiceKind::Cloud)
+        .context("diag")
+        .expect("diag context")
+        .cloud
+        .as_ref()
+        .expect("diag cloud config")
+        .resolve()
         .expect("diag cloud service");
 
     assert_eq!(es.url.as_str(), "https://local-es.example:9200/");
-    assert!(matches!(es.auth, ResolvedAuth::ApiKey(ref key) if key.expose_secret() == "local-api-key"));
+    assert!(matches!(es.auth, Auth::ApiKey(ref key) if key.expose_secret() == "local-api-key"));
     assert_eq!(kb.url.as_str(), "https://local-kb.example:5601/");
     assert_eq!(
         cloud.url.as_str(),
@@ -59,7 +71,12 @@ fn platform_specific_keyring_resolver_rejects_unsupported_platform() {
 
     let config = ConfigFile::load(&path).expect("load config");
     let err = config
-        .resolve_current_service(ServiceKind::Elasticsearch)
+        .current()
+        .expect("current context")
+        .elasticsearch
+        .as_ref()
+        .expect("Elasticsearch config")
+        .resolve()
         .expect_err("unsupported resolver should fail");
 
     assert!(matches!(err, Error::ResolverFailed { resolver: actual, .. } if actual == resolver));


### PR DESCRIPTION
## Summary

- parse schema-keyed services as `ServiceConfig<Elasticsearch>`, `ServiceConfig<Kibana>`, or `ServiceConfig<Cloud>`
- preserve the service type when resolving configuration into runtime `Service<T>` values
- update public examples, package-consumer coverage, and release notes for the typed API

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --locked --package elasticrc --all-targets`
- [x] `cargo test --locked --package elasticrc`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --locked --package elasticrc --no-deps`
- [x] `cargo package --allow-dirty --locked --package elasticrc`
- [x] external consumer package run
- [x] `cargo publish --dry-run --allow-dirty --locked --package elasticrc`

Made with [Cursor](https://cursor.com)