### PR TITLE
fix: map searchable snapshot stats correctly

### DIFF
--- a/.agents/skills/changelog/SKILL.md
+++ b/.agents/skills/changelog/SKILL.md
@@ -18,10 +18,14 @@ update changelog content.
 
 ## Project Rules
 
-- Prefer issue numbers over PR numbers on bullets.
-- Use a PR number only when there is no explicit issue reference to cite.
-- Add `#123` references inline at the end of the bullet whenever they can be
-  verified from GitHub history or release notes.
+- Changelog issue references must point only to the public `elastic/esdiag`
+  repository, using `https://github.com/elastic/esdiag/issues/<number>` or a
+  verified public issue number such as `#123`.
+- `elastic/esdiag-dev` is private. Never include its issue links, qualified
+  references, or bare issue numbers in the changelog. Do not transfer a private
+  issue number to a public URL; the repositories have separate issue numbering.
+- If no corresponding public `elastic/esdiag` issue is verified, keep the
+  changelog bullet without a reference. Do not substitute a PR link or number.
 - Only include a `Fixed` bullet if the change clearly closed or resolved a GitHub
   issue, or if release notes explicitly frame it as a bug fix.
 
@@ -54,19 +58,18 @@ When updating changelog content:
 4. For each candidate bullet:
    - choose the correct section (`Added`, `Changed`, `Fixed`, etc.)
    - reduce it to a single user-facing item
-   - attach an issue number if verified
-   - otherwise attach a PR number if verified
+   - attach a reference only if the corresponding public `elastic/esdiag` issue is verified
+   - otherwise omit the reference
 5. Remove or rewrite bullets that cannot be supported by the sources.
 
 ## GitHub Verification Guidance
 
-- Use release notes to recover issue and PR references that are not obvious from
-  commit messages.
-- If a commit maps to a PR and that PR says `Resolves #123`, cite `#123` instead
-  of the PR number.
-- If a PR is the only clean reference, cite the PR number.
-- If neither issue nor PR can be verified confidently, omit the reference instead
-  of guessing.
+- Use release notes, PRs, and commit history to find the corresponding public
+  `elastic/esdiag` issue. Verify the repository as well as the issue number.
+- A PR's `Resolves #123` refers to its own repository unless explicitly qualified;
+  it does not establish that public `elastic/esdiag#123` is the same issue.
+- Private issues may substantiate a fix internally, but must not appear as
+  changelog references. A verified private fix can have an unreferenced `Fixed` bullet.
 
 ## PR Review Use
 
@@ -74,7 +77,7 @@ During PR review workflows, check changelog updates for:
 
 - correct Keep a Changelog structure
 - one feature per `Added` bullet
-- issue-first reference policy
+- references restricted to verified public `elastic/esdiag` issues, with no private references
 - `Fixed` bullets limited to verified fixes
 - no invented versions or unsupported claims
 - accurate `Unreleased` scope for the branch being reviewed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ published release notes, maintenance branches, and tagged history.
 
 ### Fixed
 
+- Fixed searchable-snapshot documents being rejected by Elasticsearch and placed their stats mappings under `searchable_snapshot`.
 - Fixed `esdiag local` launcher execution and structured outcomes for help output and forwarded state directories (#382).
 - Fixed compilation of every `server`, `setup`, and `keystore` feature combination, including `--no-default-features` (#347).
 - Fixed the file, stream, and directory exporters reporting a fabricated HTTP `200` request status; they now report the reserved `0` that means "no HTTP transport", so a real Elasticsearch response is distinguishable from a local write (#350).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ published release notes, maintenance branches, and tagged history.
 
 ### Fixed
 
-- Fixed searchable-snapshot documents being rejected by Elasticsearch and placed their stats mappings under `searchable_snapshot`.
+- Fixed searchable-snapshot documents being rejected by Elasticsearch by placing their stats mappings under `searchable_snapshot`.
 - Fixed `esdiag local` launcher execution and structured outcomes for help output and forwarded state directories (#382).
 - Fixed compilation of every `server`, `setup`, and `keystore` feature combination, including `--no-default-features` (#347).
 - Fixed the file, stream, and directory exporters reporting a fabricated HTTP `200` request status; they now report the reserved `0` that means "no HTTP transport", so a real Elasticsearch response is distinguishable from a local write (#350).

--- a/assets/elasticsearch/index_templates/metrics-searchable_snapshot.json
+++ b/assets/elasticsearch/index_templates/metrics-searchable_snapshot.json
@@ -36,74 +36,84 @@
           }
         },
         "index": {
-          "type": "keyword"
-        },
-        "file_ext": {
-          "type": "keyword"
-        },
-        "num_files": {
-          "type": "long"
-        },
-        "open_count": {
-          "type": "long"
-        },
-        "close_count": {
-          "type": "long"
-        },
-        "size": {
-          "type": "object"
-        },
-        "contiguous_bytes_read": {
-          "type": "object"
-        },
-        "non_contiguous_bytes_read": {
-          "type": "object"
-        },
-        "cached_bytes_read": {
-          "type": "object"
-        },
-        "index_cache_bytes_read": {
-          "type": "object"
-        },
-        "cached_bytes_written": {
-          "type": "object"
-        },
-        "direct_bytes_read": {
-          "type": "object"
-        },
-        "optimized_bytes_read": {
-          "type": "object"
-        },
-        "forward_seeks": {
           "type": "object",
           "properties": {
-            "small": {
-              "type": "object"
-            },
-            "large": {
-              "type": "object"
+            "name": {
+              "type": "keyword"
             }
           }
         },
-        "backward_seeks": {
+        "searchable_snapshot": {
           "type": "object",
           "properties": {
-            "small": {
+            "file_ext": {
+              "type": "keyword"
+            },
+            "num_files": {
+              "type": "long"
+            },
+            "open_count": {
+              "type": "long"
+            },
+            "close_count": {
+              "type": "long"
+            },
+            "size": {
               "type": "object"
             },
-            "large": {
+            "contiguous_bytes_read": {
               "type": "object"
+            },
+            "non_contiguous_bytes_read": {
+              "type": "object"
+            },
+            "cached_bytes_read": {
+              "type": "object"
+            },
+            "index_cache_bytes_read": {
+              "type": "object"
+            },
+            "cached_bytes_written": {
+              "type": "object"
+            },
+            "direct_bytes_read": {
+              "type": "object"
+            },
+            "optimized_bytes_read": {
+              "type": "object"
+            },
+            "forward_seeks": {
+              "type": "object",
+              "properties": {
+                "small": {
+                  "type": "object"
+                },
+                "large": {
+                  "type": "object"
+                }
+              }
+            },
+            "backward_seeks": {
+              "type": "object",
+              "properties": {
+                "small": {
+                  "type": "object"
+                },
+                "large": {
+                  "type": "object"
+                }
+              }
+            },
+            "blob_store_bytes_requested": {
+              "type": "object"
+            },
+            "lucene_bytes_read": {
+              "type": "object"
+            },
+            "current_index_cache_fills": {
+              "type": "long"
             }
           }
-        },
-        "blob_store_bytes_requested": {
-          "type": "object"
-        },
-        "lucene_bytes_read": {
-          "type": "object"
-        },
-        "current_index_cache_fills": {
-          "type": "long"
         }
       }
     }

--- a/tests/archive_lookup_enriched_processors_tests.rs
+++ b/tests/archive_lookup_enriched_processors_tests.rs
@@ -5,6 +5,68 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::{TempDir, tempdir};
 
+#[test]
+fn searchable_snapshot_template_matches_processed_documents() {
+    use std::io::Write;
+
+    let input = tempdir().expect("temporary archive directory");
+    let archive = input.path().join("searchable-snapshots.zip");
+    fs::copy("tests/archives/elasticsearch-api-diagnostics-9.3.3.zip", &archive).expect("copy fixture");
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&archive)
+        .expect("open archive");
+    let mut zip = zip::ZipWriter::new_append(file).expect("append archive");
+    zip.start_file(
+        "commercial/searchable_snapshots_stats.json",
+        zip::write::SimpleFileOptions::default(),
+    )
+    .expect("start stats file");
+    zip.write_all(include_bytes!("fixtures/searchable_snapshots_stats.json"))
+        .expect("write stats fixture");
+    zip.finish().expect("finish archive");
+
+    let output = process_archive(&archive);
+    let docs = read_docs(&output, "metrics-searchable_snapshot-esdiag.ndjson");
+    assert_eq!(docs.len(), 1);
+    let doc = &docs[0];
+    assert_eq!(doc["index"]["name"], "partial-snapshot-index");
+    assert_eq!(doc["data_stream"]["dataset"], "searchable_snapshot");
+
+    let template: Value = serde_json::from_str(include_str!(
+        "../assets/elasticsearch/index_templates/metrics-searchable_snapshot.json"
+    ))
+    .expect("parse template");
+    let properties = &template["template"]["mappings"]["properties"];
+    assert_eq!(properties["index"]["type"], "object");
+    assert_eq!(properties["index"]["properties"]["name"]["type"], "keyword");
+    assert_eq!(properties["searchable_snapshot"]["type"], "object");
+    let mappings = properties["searchable_snapshot"]["properties"]
+        .as_object()
+        .expect("stats mappings");
+    let stats = doc["searchable_snapshot"].as_object().expect("stats object");
+    assert_eq!(
+        mappings.len(),
+        stats.len(),
+        "every declared stats field must be exercised"
+    );
+    for (field, value) in stats {
+        assert!(
+            properties.get(field).is_none(),
+            "{field} must not be mapped at the root"
+        );
+        let expected_type = if value.is_object() {
+            "object"
+        } else if value.is_string() {
+            "keyword"
+        } else {
+            "long"
+        };
+        assert_eq!(mappings[field]["type"], expected_type, "searchable_snapshot.{field}");
+    }
+}
+
 fn archive_fixtures() -> Vec<PathBuf> {
     let archives_dir = Path::new("tests/archives");
     let mut archives = Vec::new();

--- a/tests/fixtures/searchable_snapshots_stats.json
+++ b/tests/fixtures/searchable_snapshots_stats.json
@@ -1,0 +1,29 @@
+{
+  "_shards": {"total": 1, "successful": 1, "failed": 0},
+  "total": [],
+  "indices": {
+    "partial-snapshot-index": {
+      "total": [
+        {
+          "file_ext": "cfe",
+          "num_files": 1,
+          "open_count": 2,
+          "close_count": 1,
+          "size": {"total": "491b", "total_in_bytes": 491, "min_in_bytes": 491, "max_in_bytes": 491, "average_in_bytes": 491},
+          "contiguous_bytes_read": {"count": 13928, "min": 491, "max": 491, "sum": 6838648},
+          "non_contiguous_bytes_read": {"count": 0, "min": 0, "max": 0, "sum": 0},
+          "cached_bytes_read": {"count": 1, "min": 491, "max": 491, "sum": 491},
+          "index_cache_bytes_read": {"count": 0, "min": 0, "max": 0, "sum": 0},
+          "cached_bytes_written": {"count": 1, "min": 491, "max": 491, "sum": 491, "time": "1ms", "time_in_nanos": 1000000},
+          "direct_bytes_read": {"count": 0, "min": 0, "max": 0, "sum": 0, "time": "0s", "time_in_nanos": 0},
+          "optimized_bytes_read": {"count": 0, "min": 0, "max": 0, "sum": 0, "time": "0s", "time_in_nanos": 0},
+          "forward_seeks": {"small": {"count": 0, "min": 0, "max": 0, "sum": 0}, "large": {"count": 0, "min": 0, "max": 0, "sum": 0}},
+          "backward_seeks": {"small": {"count": 0, "min": 0, "max": 0, "sum": 0}, "large": {"count": 0, "min": 0, "max": 0, "sum": 0}},
+          "blob_store_bytes_requested": {"count": 1, "min": 491, "max": 491, "sum": 491},
+          "lucene_bytes_read": {"count": 1, "min": 491, "max": 491, "sum": 491},
+          "current_index_cache_fills": 0
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The searchable-snapshot processor emits `index` as `{ "name": ... }` and puts all statistics under `searchable_snapshot.*`, but the shipped index template mapped `index` as a keyword and declared the statistics at the document root. Elasticsearch rejected every searchable-snapshot document as a result.

This PR updates the template to match the processor output and adds a regression test that processes a real diagnostic archive shape and checks the emitted document against the template. It also documents the public issue reference rule used by the changelog skill.

Validation:

- `cargo test --test archive_lookup_enriched_processors_tests --test elasticsearch_asset_templates_tests`
- `cargo fmt --check`
- `git diff --check`
- Verified original template rejection and fixed-template ingestion on Elasticsearch 9.4.2, including rollover of an existing data stream.
