### PR TITLE
fix: support Serverless setup assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,8 @@ published release notes, maintenance branches, and tagged history.
 
 ### Fixed
 
-- Fixed Serverless setup failures caused by security and license probes, ILM template settings, Kibana space controls, and read-only fields in default-agent updates (#390).
+- Fixed Serverless setup failures caused by security and license probes (#390).
+- Fixed Serverless asset installation failures caused by unsupported ILM template settings, Kibana space controls, and read-only fields in default-agent updates (#390).
 - Fixed searchable-snapshot documents being rejected by Elasticsearch by placing their stats mappings under `searchable_snapshot`.
 - Fixed `esdiag local` launcher execution and structured outcomes for help output and forwarded state directories (#382).
 - Fixed compilation of every `server`, `setup`, and `keystore` feature combination, including `--no-default-features` (#347).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ published release notes, maintenance branches, and tagged history.
 
 ### Fixed
 
+- Fixed Serverless setup failures caused by security and license probes, ILM template settings, Kibana space controls, and read-only fields in default-agent updates (#390).
 - Fixed searchable-snapshot documents being rejected by Elasticsearch by placing their stats mappings under `searchable_snapshot`.
 - Fixed `esdiag local` launcher execution and structured outcomes for help output and forwarded state directories (#382).
 - Fixed compilation of every `server`, `setup`, and `keystore` feature combination, including `--no-default-features` (#347).

--- a/assets/elasticsearch/index_templates/metrics-diagnostic.json
+++ b/assets/elasticsearch/index_templates/metrics-diagnostic.json
@@ -9,6 +9,10 @@
   "data_stream": {},
   "priority": 300,
   "template": {
+    "lifecycle": {
+      "enabled": false,
+      "data_retention": null
+    },
     "mappings": {
       "numeric_detection": false,
       "dynamic": true,
@@ -473,5 +477,5 @@
       }
     }
   },
-  "version": 2
+  "version": 3
 }

--- a/docs/reference/serverless-assets.md
+++ b/docs/reference/serverless-assets.md
@@ -1,0 +1,127 @@
+---
+type: Reference
+title: Serverless asset compatibility
+description: Elasticsearch and Kibana setup asset audit and live verification.
+tags: [setup, serverless, elasticsearch, kibana]
+---
+
+# Serverless asset compatibility
+
+Audited for issue [#390](https://github.com/elastic/esdiag/issues/390) on
+2026-09-04 using the saved `esdiag-less` and `esdiag-less-kb` hosts. Both
+products reported version `9.6.0` and build flavor `serverless`.
+
+Setup reads `version.build_flavor` from Elasticsearch's root response or
+Kibana's `/api/status`. It does not infer deployment type from the hostname.
+An Elasticsearch security usage response of HTTP 410 reports security as
+enabled. Deployment metadata selects the Serverless asset adaptations;
+security status does not determine deployment compatibility.
+
+## Findings and changes
+
+| Item | Finding | Setup behavior |
+| --- | --- | --- |
+| Security usage | `/_xpack/usage` returns HTTP 410; Serverless always has security enabled | Skip the probe on a known Serverless deployment and report security as enabled for HTTP 410. |
+| Bundled role | The stateful role asset is not provisioned on Serverless | Skip security-dependent assets and tell the administrator to configure project roles separately. Authentication remains enabled. |
+| `esdiag@settings` | `index.lifecycle.prefer_ilm` and `index.lifecycle.name` are unsupported ILM settings | Remove these settings from outgoing Serverless templates. Keep stateful assets unchanged. |
+| Retention | Data stream lifecycle is supported | Preserve `template.lifecycle.data_retention: 30d`. |
+| Kibana space | The project rejects `solution` and a nonempty `disabledFeatures` list | Omit both controls for Serverless. Preserve the space ID, name, description, and appearance. |
+| Trial license | Serverless manages feature entitlements | Skip `/_license` and `/_license/start_trial`; Kibana APIs still report missing feature access or privileges. |
+| Default agent | A GET response includes fields that the update API rejects, including `access_control.entries` | Send only the existing configuration with the ESDiag skill added. Preserve existing skill IDs and avoid duplicates. |
+
+The remaining template settings are `index.codec`, `index.mapping.source.mode`,
+`index.mapping.ignore_malformed`, `index.mapping.total_fields.limit`,
+`index.mapping.total_fields.ignore_dynamic_beyond_limit`, and
+`index.query.default_field`. All appear in Elastic's
+[Serverless settings list](https://www.elastic.co/docs/reference/elasticsearch/index-settings/serverless).
+The regression test inventories settings across every component and index
+template and requires a compatibility review when that list grows.
+
+The agent update follows the
+[partial update API](https://www.elastic.co/docs/api/doc/kibana/operation/operation-put-agent-builder-agents-id).
+It does not modify the agent's access controls.
+
+## Retention
+
+The shared `esdiag@settings` component configures
+`template.lifecycle.data_retention: 30d`, including on Serverless. Removing
+unsupported ILM settings preserves this data stream lifecycle configuration.
+
+Diagnostic reports in `metrics-diagnostic-esdiag` are retained indefinitely.
+Their index template disables data stream lifecycle and clears the inherited
+retention. Template changes apply to newly created data streams; existing
+report streams require their lifecycle to be updated separately.
+
+## Asset inventory
+
+| Asset family | Count | Audit scope |
+| --- | ---: | --- |
+| Elasticsearch ingest pipelines | 1 | `set` processors and `reroute`; installation and simulation |
+| Elasticsearch component templates | 7 | Settings, mappings, metadata, and composition |
+| Elasticsearch index templates | 26 | Settings, mappings, data streams, and composition |
+| Elasticsearch roles | 1 | Skipped on Serverless |
+| Kibana spaces | 1 | Creation and update with project-managed controls omitted |
+| Kibana saved objects | 90 | Dashboards, data views, Lens, saved searches, Vega visualizations, links, and tags |
+| Kibana workflows | 1 | Installation and its Elasticsearch authentication and ES|QL request definitions |
+| Agent Builder tools | 1 | Workflow reference and installation |
+| Agent Builder skills | 1 | Installation, referenced diagnostic guides, and attachment to the default agent |
+| Custom Agent Builder agents | 0 | The bundle extends the built-in agent |
+
+ILM, SLM, allocation, node, and shard names inside diagnostic mappings and
+dashboard queries describe imported source data. They do not configure those
+features on the destination. The audit retains them, including the lifecycle
+dashboards and data views. No bundled query uses the unsupported
+`scripted_metric` aggregation, and the templates do not define join fields.
+See Elastic's [Hosted and Serverless comparison](https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings).
+
+The `sources.yml` files define diagnostic **collection** requests, including
+stateful APIs such as ILM and node statistics. Setup does not send these
+requests. This audit covers Serverless as the diagnostic destination and
+viewer; it does not establish Serverless diagnostic collection support.
+
+## Repeat the verification
+
+Both setup commands completed successfully on the audited project. The live
+audit passed after reading all 34 installed Elasticsearch assets, simulating
+all 26 composed index templates and the pipeline, finding all 90 Kibana saved
+objects, verifying their references, and checking the workflow, tool, skill,
+and default-agent attachment. Embedded Vega searches also succeeded.
+
+Kibana may assign new IDs when an imported object already exists in another
+space. The audit matches these objects by `originId` and checks their actual
+references; it does not assume every imported object retains its original ID.
+
+Use an unlocked keystore and saved Elasticsearch and Kibana hosts for a
+Serverless test project. These setup commands install or update ESDiag assets:
+
+```sh
+cargo build --bin esdiag
+target/debug/esdiag setup esdiag-less
+target/debug/esdiag setup esdiag-less-kb
+```
+
+The explicit live test reads installed assets, simulates composed templates
+and the ingest pipeline, checks Kibana objects and default-agent skill
+attachment, and executes embedded Vega searches. It does not create
+diagnostic data or run an agent conversation:
+
+```sh
+ESDIAG_SERVERLESS_TEST_HOST=esdiag-less \
+ESDIAG_SERVERLESS_TEST_KIBANA_HOST=esdiag-less-kb \
+cargo test --lib setup::serverless_tests::live_serverless_asset_audit -- --ignored --nocapture
+```
+
+Offline checks:
+
+```sh
+cargo test --lib setup::
+cargo test --test serverless_setup_tests
+cargo test --test elasticsearch_asset_templates_tests
+```
+
+Live validation covers API acceptance and asset composition. Dashboard
+rendering, every ES|QL query against representative diagnostic data, and
+workflow execution under an interactive user's identity need separate
+functional testing. Agent Builder availability depends on project feature
+tiers and privileges, as described in the
+[Agent Builder setup guide](https://www.elastic.co/docs/explore-analyze/ai-features/agent-builder/get-started).

--- a/docs/setup/existing-cluster.md
+++ b/docs/setup/existing-cluster.md
@@ -69,6 +69,23 @@ The output needs ESDiag templates and ingest pipelines:
 esdiag setup diagnostics-output
 ```
 
+On Elasticsearch Serverless, `setup` detects the deployment, omits unsupported
+ILM settings, and keeps the 30-day data stream retention policy. It installs
+templates and ingest pipelines and skips bundled security-dependent role
+assets. Configure project roles separately. Serverless security is always
+enabled; a `410 Gone` security usage response also reports security as enabled.
+
+Run `esdiag setup <saved-kibana-host>` to install the Kibana assets separately.
+On Serverless, the ESDiag space uses the project's solution and feature
+visibility. Guided setup skips the stateful Elasticsearch trial-license API;
+Agent Builder access depends on the project's feature tier.
+
+ILM, shard, node, and snapshot dashboards remain available for analyzing
+diagnostics collected from stateful clusters. Those fields describe the
+source cluster, not the Serverless destination. See the
+[Serverless asset audit](../reference/serverless-assets.md) for compatibility
+details and repeatable verification.
+
 Run this with a credential that can install assets. If normal ingestion uses a
 less-privileged credential, replace the saved secret after setup:
 

--- a/docs/setup/existing-cluster.md
+++ b/docs/setup/existing-cluster.md
@@ -70,7 +70,8 @@ esdiag setup diagnostics-output
 ```
 
 On Elasticsearch Serverless, `setup` detects the deployment, omits unsupported
-ILM settings, and keeps the 30-day data stream retention policy. It installs
+ILM settings, and keeps the 30-day data stream retention policy for ordinary
+diagnostic data. Diagnostic reports are retained indefinitely. It installs
 templates and ingest pipelines and skips bundled security-dependent role
 assets. Configure project roles separately. Serverless security is always
 enabled; a `410 Gone` security usage response also reports security as enabled.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -28,6 +28,29 @@ pub enum Client {
 }
 
 impl Client {
+    /// Detect the deployment from product metadata, without relying on its hostname.
+    pub async fn is_serverless(&self) -> Result<bool> {
+        let path = match self {
+            Client::Elasticsearch(_) => "/",
+            Client::Kibana(_) => "/api/status",
+            Client::Logstash(_) => return Ok(false),
+        };
+        let response = self.request(Method::GET, &HashMap::new(), path, None).await?;
+        let status = response.status();
+        if matches!(status.as_u16(), 401 | 403 | 404) {
+            tracing::debug!("Deployment metadata is unavailable (HTTP {status}); using endpoint capability probes");
+            return Ok(false);
+        }
+        if !status.is_success() {
+            return Err(eyre!("Failed to detect deployment type: HTTP {status}"));
+        }
+        let metadata: serde_json::Value = response.json().await?;
+        Ok(metadata
+            .pointer("/version/build_flavor")
+            .and_then(serde_json::Value::as_str)
+            == Some("serverless"))
+    }
+
     /// Send an HTTP request to a path on the client's base URL
     pub async fn request(
         &self,
@@ -134,6 +157,8 @@ impl Client {
     /// Check if security is enabled on the cluster.
     ///
     /// For Elasticsearch, this checks the `security.enabled` flag in `/_xpack/usage`.
+    /// An unavailable usage API (HTTP 410 on Serverless) does not mean security is disabled.
+    /// Serverless always has security enabled, including when the probe returns HTTP 410.
     /// For Kibana and Logstash, this currently always returns `true`.
     pub async fn has_security_enabled(&self) -> Result<bool> {
         match self {
@@ -171,6 +196,12 @@ impl Client {
                                 "Security detection returned 404. Assuming security is disabled or not supported."
                             );
                             Ok(false)
+                        }
+                        410 => {
+                            tracing::debug!(
+                                "Serverless security is always enabled; the security usage API is unavailable."
+                            );
+                            Ok(true)
                         }
                         _ => {
                             tracing::warn!("Failed to check security status (HTTP {status}).");

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -38,6 +38,17 @@ impl Client {
         let response = self.request(Method::GET, &HashMap::new(), path, None).await?;
         let status = response.status();
         if matches!(status.as_u16(), 401 | 403 | 404) {
+            if matches!(self, Client::Elasticsearch(_)) {
+                let usage = self
+                    .request(Method::GET, &HashMap::new(), "/_xpack/usage", None)
+                    .await?;
+                if usage.status() == reqwest::StatusCode::GONE {
+                    tracing::debug!(
+                        "Deployment metadata is restricted and the security usage API is gone; identifying the deployment as Serverless"
+                    );
+                    return Ok(true);
+                }
+            }
             tracing::debug!("Deployment metadata is unavailable (HTTP {status}); using endpoint capability probes");
             return Ok(false);
         }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -236,12 +236,44 @@ async fn install_provenance_aliases(client: &Client) -> Result<()> {
     Ok(())
 }
 
-fn should_skip_asset(asset: &Asset, security_enabled: bool) -> bool {
-    asset.requires_security && !security_enabled
+fn should_skip_asset(asset: &Asset, security_assets_supported: bool) -> bool {
+    asset.requires_security && !security_assets_supported
 }
 
 async fn send_asset(client: &Client, asset: &Asset, path: &Path, contents: &[u8], named: bool) -> Result<()> {
     send_asset_with_allowed_statuses(client, asset, path, contents, named, &[]).await
+}
+
+/// Adapt only template settings. ILM fields in diagnostic mappings are source data.
+fn serverless_asset_contents(asset: &Asset, contents: &[u8]) -> Result<Vec<u8>> {
+    if !matches!(
+        asset.endpoint.trim_matches('/'),
+        "_component_template" | "_index_template"
+    ) {
+        return Ok(contents.to_vec());
+    }
+    let mut body: Value = serde_json::from_slice(contents)?;
+    if let Some(settings) = body.pointer_mut("/template/settings") {
+        remove_serverless_ilm_settings(settings, "");
+    }
+    Ok(serde_json::to_vec(&body)?)
+}
+
+fn remove_serverless_ilm_settings(value: &mut Value, prefix: &str) {
+    if let Some(settings) = value.as_object_mut() {
+        settings.retain(|key, value| {
+            let path = if prefix.is_empty() {
+                key.clone()
+            } else {
+                format!("{prefix}.{key}")
+            };
+            if matches!(path.as_str(), "index.lifecycle.name" | "index.lifecycle.prefer_ilm") {
+                return false;
+            }
+            remove_serverless_ilm_settings(value, &path);
+            !value.as_object().is_some_and(|object| object.is_empty())
+        });
+    }
 }
 
 async fn send_asset_with_allowed_statuses(
@@ -301,19 +333,25 @@ pub async fn assets(client: &Client) -> Result<()> {
     let assets = parse_assets_yml(client.into(), &embedded_assets)?;
 
     // Check security status
-    let security_enabled = client
-        .has_security_enabled()
-        .await
-        .wrap_err("Failed to determine security status")?;
-
-    if !security_enabled {
+    let serverless = client.is_serverless().await?;
+    let security_enabled = serverless
+        || client
+            .has_security_enabled()
+            .await
+            .wrap_err("Failed to determine security status")?;
+    if serverless {
+        tracing::info!(
+            "Serverless security is always enabled. Skipping bundled security-dependent assets; configure project roles separately."
+        );
+    } else if !security_enabled {
         tracing::info!("Security is disabled on the cluster. Security-dependent assets will be skipped.");
     }
+    let supports_security_assets = security_enabled && !serverless;
 
     let mut error_count = 0;
 
     for asset in assets {
-        if should_skip_asset(&asset, security_enabled) {
+        if should_skip_asset(&asset, supports_security_assets) {
             tracing::debug!("Skipping security-dependent asset: {}", &asset.name);
             continue;
         }
@@ -326,6 +364,11 @@ pub async fn assets(client: &Client) -> Result<()> {
         if !dir_files.is_empty() {
             // do something with the directory
             for (file_path, contents) in dir_files {
+                let contents = if serverless {
+                    std::borrow::Cow::Owned(serverless_asset_contents(&asset, &contents)?)
+                } else {
+                    contents
+                };
                 tracing::debug!("file.path: {:?}", file_path);
                 match send_asset(client, &asset, &file_path, &contents, true).await {
                     Ok(res) => tracing::debug!("Response: {:?}", res),
@@ -336,6 +379,11 @@ pub async fn assets(client: &Client) -> Result<()> {
                 }
             }
         } else if let Some(contents) = embedded_assets.get_file(&path) {
+            let contents = if serverless {
+                std::borrow::Cow::Owned(serverless_asset_contents(&asset, &contents)?)
+            } else {
+                contents
+            };
             // do something with the file
             tracing::debug!("file.path: {:?}", &path);
             if let Err(e) = send_asset(client, &asset, &path, &contents, false).await {
@@ -372,6 +420,11 @@ pub async fn ensure_agent_builder_license(client: &Client) -> Result<()> {
     let Client::Elasticsearch(_) = client else {
         return Err(eyre!("an Elasticsearch client is required to start the trial license"));
     };
+
+    if client.is_serverless().await? {
+        tracing::info!("Serverless manages feature entitlements; skipping the Elasticsearch trial license API");
+        return Ok(());
+    }
 
     if agent_builder_license_is_active(&current_license(client).await?) {
         return Ok(());
@@ -425,7 +478,10 @@ fn agent_builder_license_is_active(response: &Value) -> bool {
 }
 
 async fn kibana_assets(client: &Client, embedded_assets: &EmbeddedAssets) -> Result<()> {
-    let bundle = kibana_bundle(embedded_assets)?.read_all()?;
+    let mut bundle = kibana_bundle(embedded_assets)?.read_all()?;
+    if client.is_serverless().await? {
+        adapt_serverless_kibana_bundle(&mut bundle);
+    }
     let Client::Kibana(kibana) = client else {
         return Err(eyre!("expected Kibana client"));
     };
@@ -468,6 +524,16 @@ async fn kibana_assets(client: &Client, embedded_assets: &EmbeddedAssets) -> Res
 
     tracing::info!("completed setup for {client}");
     Ok(())
+}
+
+fn adapt_serverless_kibana_bundle(bundle: &mut SyncBundle) {
+    for space in &mut bundle.spaces {
+        if let Some(space) = space.as_object_mut() {
+            // Serverless fixes the solution and disallows space feature visibility controls.
+            space.remove("solution");
+            space.remove("disabledFeatures");
+        }
+    }
 }
 
 fn saved_objects_bundle(bundle: &SyncBundle) -> SyncBundle {
@@ -598,7 +664,12 @@ async fn attach_skills_to_default_agent(client: &Client, space_id: &str, skill_i
             response.text().await?
         ));
     }
-    let mut agent: Value = response.json().await?;
+    let agent: Value = response.json().await?;
+    let update = default_agent_skill_update(agent, skill_ids)?;
+    send_kibana_json_with_method(client, Method::PUT, &path, &update, false).await
+}
+
+fn default_agent_skill_update(mut agent: Value, skill_ids: &[String]) -> Result<Value> {
     let configuration = agent
         .get_mut("configuration")
         .and_then(Value::as_object_mut)
@@ -613,13 +684,9 @@ async fn attach_skills_to_default_agent(client: &Client, space_id: &str, skill_i
             configured_skills.push(Value::String(skill_id.clone()));
         }
     }
-    if let Some(agent) = agent.as_object_mut() {
-        agent.remove("id");
-        agent.remove("readonly");
-        agent.remove("type");
-        agent.remove("created_by");
-    }
-    send_kibana_json_with_method(client, Method::PUT, &path, &agent, false).await
+    // The update API accepts a partial body. Read responses also contain server-owned
+    // fields such as access_control.entries that must not be echoed into an update.
+    Ok(serde_json::json!({ "configuration": configuration }))
 }
 
 async fn send_kibana_json_with_method(
@@ -655,6 +722,10 @@ fn parse_assets_yml(application: Application, assets_store: &EmbeddedAssets) -> 
     let assets = yaml_serde::from_slice(&contents)?;
     Ok(assets)
 }
+
+#[cfg(test)]
+#[path = "setup/serverless_tests.rs"]
+mod serverless_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -246,10 +246,7 @@ async fn send_asset(client: &Client, asset: &Asset, path: &Path, contents: &[u8]
 
 /// Adapt only template settings. ILM fields in diagnostic mappings are source data.
 fn serverless_asset_contents(asset: &Asset, contents: &[u8]) -> Result<Vec<u8>> {
-    if !matches!(
-        asset.endpoint.trim_matches('/'),
-        "_component_template" | "_index_template"
-    ) {
+    if !is_template_asset(asset) {
         return Ok(contents.to_vec());
     }
     let mut body: Value = serde_json::from_slice(contents)?;
@@ -257,6 +254,13 @@ fn serverless_asset_contents(asset: &Asset, contents: &[u8]) -> Result<Vec<u8>> 
         remove_serverless_ilm_settings(settings, "");
     }
     Ok(serde_json::to_vec(&body)?)
+}
+
+fn is_template_asset(asset: &Asset) -> bool {
+    matches!(
+        asset.endpoint.trim_matches('/'),
+        "_component_template" | "_index_template"
+    )
 }
 
 fn remove_serverless_ilm_settings(value: &mut Value, prefix: &str) {
@@ -364,7 +368,7 @@ pub async fn assets(client: &Client) -> Result<()> {
         if !dir_files.is_empty() {
             // do something with the directory
             for (file_path, contents) in dir_files {
-                let contents = if serverless {
+                let contents = if serverless && is_template_asset(&asset) {
                     std::borrow::Cow::Owned(serverless_asset_contents(&asset, &contents)?)
                 } else {
                     contents
@@ -379,7 +383,7 @@ pub async fn assets(client: &Client) -> Result<()> {
                 }
             }
         } else if let Some(contents) = embedded_assets.get_file(&path) {
-            let contents = if serverless {
+            let contents = if serverless && is_template_asset(&asset) {
                 std::borrow::Cow::Owned(serverless_asset_contents(&asset, &contents)?)
             } else {
                 contents

--- a/src/setup/serverless_tests.rs
+++ b/src/setup/serverless_tests.rs
@@ -1,0 +1,361 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+use super::*;
+use std::collections::BTreeSet;
+
+#[test]
+fn default_agent_update_preserves_configuration_without_echoing_read_only_fields() {
+    let original = serde_json::json!({
+        "id": "elastic-ai-agent", "readonly": true,
+        "access_control": {"entries": [], "access_mode": "public"},
+        "configuration": {"instructions": "existing", "tools": [{"tool_ids": ["platform.core.*"]}], "skill_ids": ["existing-skill"]}
+    });
+    let skills = vec!["agentic-diagnostic-assistant".into()];
+    let update = default_agent_skill_update(original.clone(), &skills).unwrap();
+    assert_eq!(update.as_object().unwrap().len(), 1);
+    assert_eq!(
+        update["configuration"]["instructions"],
+        original["configuration"]["instructions"]
+    );
+    assert_eq!(update["configuration"]["tools"], original["configuration"]["tools"]);
+    assert_eq!(
+        update["configuration"]["skill_ids"],
+        serde_json::json!(["existing-skill", "agentic-diagnostic-assistant"])
+    );
+    assert_eq!(default_agent_skill_update(update.clone(), &skills).unwrap(), update);
+}
+
+fn visit_json(value: &Value, visitor: &mut impl FnMut(&Value)) {
+    visitor(value);
+    match value {
+        Value::Object(fields) => fields.values().for_each(|value| visit_json(value, visitor)),
+        Value::Array(values) => values.iter().for_each(|value| visit_json(value, visitor)),
+        Value::String(text) => {
+            if let Ok(decoded) = serde_json::from_str::<Value>(text) {
+                visit_json(&decoded, visitor);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn kibana_queries_do_not_use_serverless_unsupported_aggregations() {
+    let bundle = kibana_bundle(&EmbeddedAssets::new().unwrap())
+        .unwrap()
+        .read_all()
+        .unwrap();
+    for object in &bundle.by_space["esdiag"].saved_objects {
+        visit_json(object, &mut |value| {
+            assert!(
+                value.get("scripted_metric").is_none(),
+                "{} uses scripted_metric",
+                object["id"]
+            );
+            assert!(
+                !matches!(value.get("type").and_then(Value::as_str), Some("timelion")),
+                "{} needs a Serverless query review",
+                object["id"]
+            );
+        });
+    }
+}
+
+async fn live_json(client: &Client, method: Method, path: &str, body: Option<Value>) -> Result<Value> {
+    let body = body.map(|body| serde_json::to_vec(&body)).transpose()?;
+    let mut headers = default_headers();
+    headers.insert("X-Elastic-Internal-Origin".into(), "Kibana".into());
+    let response = client.request(method, &headers, path, body.as_deref()).await?;
+    let status = response.status();
+    let value: Value = response.json().await?;
+    eyre::ensure!(status.is_success(), "{path}: {status}: {value}");
+    Ok(value)
+}
+
+/// Read and simulate the assets installed by `esdiag setup`; never creates diagnostic data.
+#[tokio::test]
+#[ignore = "requires explicit Serverless saved hosts, an unlocked keystore, and installed assets"]
+async fn live_serverless_asset_audit() -> Result<()> {
+    use crate::data::Uri;
+    let es_host = std::env::var("ESDIAG_SERVERLESS_TEST_HOST")?;
+    let kb_host = std::env::var("ESDIAG_SERVERLESS_TEST_KIBANA_HOST")?;
+    let es = Client::try_from(Uri::try_from(es_host)?)?;
+    let kb = Client::try_from(Uri::try_from(kb_host)?)?;
+    assert!(es.is_serverless().await?);
+    assert!(kb.is_serverless().await?);
+    ensure_agent_builder_license(&es).await?;
+    let store = EmbeddedAssets::new()?;
+    let assets = parse_assets_yml(Application::Elasticsearch, &store)?;
+    let mut installed = 0;
+    let mut simulated = 0;
+    for asset in assets.iter().filter(|asset| !asset.requires_security) {
+        for (path, _) in store.get_dir_files(&PathBuf::from(format!("elasticsearch/{}", asset.name))) {
+            let stem = path.file_stem().unwrap().to_str().unwrap();
+            let name = format!("{stem}{}", asset.suffix.as_deref().unwrap_or(""));
+            let path = format!("/{}/{name}", asset.endpoint);
+            live_json(&es, Method::GET, &path, None).await?;
+            installed += 1;
+            if asset.name == "index_templates" {
+                let template =
+                    live_json(&es, Method::POST, &format!("/_index_template/_simulate/{name}"), None).await?;
+                let mut keys = BTreeSet::new();
+                settings_keys(&template["template"]["settings"], "", &mut keys);
+                assert!(!keys.contains("index.lifecycle.name"));
+                assert!(!keys.contains("index.lifecycle.prefer_ilm"));
+                simulated += 1;
+            }
+        }
+    }
+    eprintln!("Elasticsearch: read {installed} assets, simulated {simulated} composed index templates");
+    let simulation = live_json(
+        &es,
+        Method::POST,
+        "/_ingest/pipeline/esdiag/_simulate",
+        Some(serde_json::json!({"docs":[{
+            "_index":"metrics-diagnostic-esdiag", "_source": {
+                "@timestamp":"2026-09-04T00:00:00Z", "diagnostic":{"license":{"issued_to":"serverless-audit"}},
+                "data_stream":{"type":"metrics","dataset":"diagnostic","namespace":"esdiag"}
+            }
+        }]})),
+    )
+    .await?;
+    assert!(simulation["docs"][0].get("error").is_none(), "{simulation}");
+    assert!(simulation["docs"][0]["doc"]["_source"]["event"]["ingested"].is_string());
+    assert_eq!(
+        simulation["docs"][0]["doc"]["_source"]["diagnostic"]["account"],
+        "serverless-audit"
+    );
+    let bundle = kibana_bundle(&store)?.read_all()?;
+    let mut query_count = 0;
+    for (space_id, space) in &bundle.by_space {
+        let types: BTreeSet<_> = space
+            .saved_objects
+            .iter()
+            .map(|object| object["type"].as_str().unwrap())
+            .collect();
+        let mut imported = Vec::new();
+        for kind in types {
+            let mut page = 1;
+            loop {
+                let found = live_json(
+                    &kb,
+                    Method::GET,
+                    &format!("/s/{space_id}/api/saved_objects/_find?type={kind}&per_page=100&page={page}"),
+                    None,
+                )
+                .await?;
+                let objects = found["saved_objects"].as_array().unwrap();
+                imported.extend(objects.iter().cloned());
+                if page * 100 >= found["total"].as_u64().unwrap() {
+                    break;
+                }
+                page += 1;
+            }
+        }
+        for expected in &space.saved_objects {
+            // Kibana remaps globally occupied IDs on import into another space.
+            let actual = imported
+                .iter()
+                .find(|object| {
+                    object["type"] == expected["type"]
+                        && (object["id"] == expected["id"] || object["originId"] == expected["id"])
+                })
+                .unwrap_or_else(|| panic!("Missing imported {}/{}", expected["type"], expected["id"]));
+            for reference in actual["references"].as_array().unwrap() {
+                assert!(
+                    imported
+                        .iter()
+                        .any(|object| object["type"] == reference["type"] && object["id"] == reference["id"]),
+                    "{} has missing reference {reference}",
+                    actual["id"]
+                );
+            }
+        }
+        for (kind, values) in [
+            ("workflows/workflow", &space.workflows),
+            ("agent_builder/tools", &space.tools),
+            ("agent_builder/skills", &space.skills),
+        ] {
+            for value in values {
+                let id = value["id"].as_str().unwrap();
+                live_json(&kb, Method::GET, &format!("/s/{space_id}/api/{kind}/{id}"), None).await?;
+            }
+        }
+        let agent = live_json(
+            &kb,
+            Method::GET,
+            &format!("/s/{space_id}/api/agent_builder/agents/elastic-ai-agent"),
+            None,
+        )
+        .await?;
+        for skill in &space.skills {
+            assert!(
+                agent["configuration"]["skill_ids"]
+                    .as_array()
+                    .unwrap()
+                    .contains(&skill["id"])
+            );
+        }
+        let mut searches = Vec::new();
+        for object in &space.saved_objects {
+            visit_json(object, &mut |value| {
+                if let Some(url) = value.get("url")
+                    && let (Some(index), Some(body)) = (url.get("index").and_then(Value::as_str), url.get("body"))
+                {
+                    searches.push((index.to_string(), body.clone()));
+                }
+            });
+        }
+        for (index, body) in searches {
+            live_json(
+                &es,
+                Method::POST,
+                &format!("/{index}/_search?ignore_unavailable=true&allow_no_indices=true"),
+                Some(body),
+            )
+            .await?;
+            query_count += 1;
+        }
+        eprintln!(
+            "Kibana: read {} saved objects, {} workflow(s), {} tool(s), {} skill(s); verified default-agent attachment",
+            space.saved_objects.len(),
+            space.workflows.len(),
+            space.tools.len(),
+            space.skills.len()
+        );
+    }
+    eprintln!("Executed {query_count} embedded Vega searches and simulated the ingest pipeline");
+    Ok(())
+}
+
+fn settings_keys(value: &Value, prefix: &str, keys: &mut BTreeSet<String>) {
+    if let Some(object) = value.as_object() {
+        for (key, value) in object {
+            let path = if prefix.is_empty() {
+                key.clone()
+            } else {
+                format!("{prefix}.{key}")
+            };
+            settings_keys(value, &path, keys);
+        }
+    } else {
+        keys.insert(prefix.to_string());
+    }
+}
+
+#[test]
+fn diagnostic_reports_disable_retention_on_all_deployments() {
+    let source = Assets::get("elasticsearch/index_templates/metrics-diagnostic.json").unwrap();
+    let original: Value = serde_json::from_slice(&source.data).unwrap();
+    let store = EmbeddedAssets::new().unwrap();
+    let assets = parse_assets_yml(Application::Elasticsearch, &store).unwrap();
+    let asset = assets.iter().find(|asset| asset.name == "index_templates").unwrap();
+    let adapted: Value = serde_json::from_slice(&serverless_asset_contents(asset, &source.data).unwrap()).unwrap();
+    for template in [original, adapted] {
+        assert_eq!(
+            template["template"]["lifecycle"],
+            serde_json::json!({"enabled": false, "data_retention": null})
+        );
+    }
+}
+
+#[test]
+fn serverless_templates_only_use_audited_settings() {
+    // Reviewed against https://www.elastic.co/docs/reference/elasticsearch/index-settings/serverless.
+    // New settings should receive a compatibility review before extending this set.
+    let allowed = BTreeSet::from(
+        [
+            "index.codec",
+            "index.mapping.source.mode",
+            "index.mapping.ignore_malformed",
+            "index.mapping.total_fields.limit",
+            "index.mapping.total_fields.ignore_dynamic_beyond_limit",
+            "index.query.default_field",
+        ]
+        .map(str::to_string),
+    );
+    let store = EmbeddedAssets::new().unwrap();
+    let assets = parse_assets_yml(Application::Elasticsearch, &store).unwrap();
+    let mut count = 0;
+    for asset in assets
+        .iter()
+        .filter(|asset| matches!(asset.name.as_str(), "component_templates" | "index_templates"))
+    {
+        for (path, contents) in store.get_dir_files(&PathBuf::from(format!("elasticsearch/{}", asset.name))) {
+            let original: Value = serde_json::from_slice(&contents).unwrap();
+            let adapted: Value = serde_json::from_slice(&serverless_asset_contents(asset, &contents).unwrap()).unwrap();
+            let mut keys = BTreeSet::new();
+            if let Some(settings) = adapted.pointer("/template/settings") {
+                settings_keys(settings, "", &mut keys);
+            }
+            assert!(
+                keys.is_subset(&allowed),
+                "{}: unaudited settings {:?}",
+                path.display(),
+                keys.difference(&allowed).collect::<Vec<_>>()
+            );
+            assert_eq!(
+                original.pointer("/template/mappings"),
+                adapted.pointer("/template/mappings"),
+                "{} changed diagnostic fields",
+                path.display()
+            );
+            assert_eq!(
+                original.pointer("/template/lifecycle"),
+                adapted.pointer("/template/lifecycle")
+            );
+            count += 1;
+        }
+    }
+    assert_eq!(count, 33);
+}
+
+#[test]
+fn serverless_ilm_filter_handles_nested_and_flat_settings_without_removing_retention() {
+    for settings in [
+        serde_json::json!({"index":{"lifecycle":{"name":"metrics","prefer_ilm":false,"origination_date":123},"codec":"best_compression"}}),
+        serde_json::json!({"index.lifecycle.name":"metrics","index.lifecycle.prefer_ilm":false,"index.lifecycle.origination_date":123,"index.codec":"best_compression"}),
+        serde_json::json!({"index":{"lifecycle.name":"metrics","lifecycle.prefer_ilm":false,"lifecycle.origination_date":123,"codec":"best_compression"}}),
+    ] {
+        let mut settings = settings;
+        remove_serverless_ilm_settings(&mut settings, "");
+        let mut keys = BTreeSet::new();
+        settings_keys(&settings, "", &mut keys);
+        assert_eq!(
+            keys,
+            BTreeSet::from(["index.lifecycle.origination_date".into(), "index.codec".into()])
+        );
+    }
+    let source = Assets::get("elasticsearch/component_templates/esdiag@settings.json").unwrap();
+    let source: Value = serde_json::from_slice(&source.data).unwrap();
+    assert_eq!(
+        source.pointer("/template/settings/index/lifecycle/prefer_ilm"),
+        Some(&Value::Bool(false))
+    );
+    assert_eq!(source.pointer("/template/lifecycle/data_retention").unwrap(), "30d");
+}
+
+#[test]
+fn serverless_kibana_only_removes_stateful_space_controls() {
+    let store = EmbeddedAssets::new().unwrap();
+    let original = kibana_bundle(&store).unwrap().read_all().unwrap();
+    let mut adapted = original.clone();
+    adapt_serverless_kibana_bundle(&mut adapted);
+    assert_eq!(original.spaces[0]["solution"], "oblt");
+    assert!(original.spaces[0]["disabledFeatures"].as_array().unwrap().len() > 0);
+    for (before, after) in original.spaces.iter().zip(&adapted.spaces) {
+        let mut expected = before.clone();
+        expected.as_object_mut().unwrap().remove("solution");
+        expected.as_object_mut().unwrap().remove("disabledFeatures");
+        assert_eq!(&expected, after);
+    }
+    let before = &original.by_space["esdiag"];
+    let after = &adapted.by_space["esdiag"];
+    assert_eq!(before.saved_objects, after.saved_objects);
+    assert_eq!(before.workflows, after.workflows);
+    assert_eq!(before.tools, after.tools);
+    assert_eq!(before.skills, after.skills);
+    assert_eq!(before.agents, after.agents);
+}

--- a/tests/serverless_setup_tests.rs
+++ b/tests/serverless_setup_tests.rs
@@ -35,7 +35,16 @@ async fn deployment_metadata_handles_both_products_and_restricted_metadata() {
             (StatusCode::OK, "invalid", None),
         ] {
             let app = Router::new().fallback(move |request: Request<Body>| async move {
-                assert_eq!(request.uri().path(), if kibana { "/api/status" } else { "/" });
+                let expected_path = if kibana { "/api/status" } else { "/" };
+                assert!(
+                    request.uri().path() == expected_path
+                        || (!kibana
+                            && request.uri().path() == "/_xpack/usage"
+                            && matches!(
+                                status,
+                                StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN | StatusCode::NOT_FOUND
+                            ))
+                );
                 (
                     status,
                     [
@@ -58,6 +67,36 @@ async fn deployment_metadata_handles_both_products_and_restricted_metadata() {
             assert_eq!(actual.ok(), expected);
         }
     }
+}
+
+#[tokio::test]
+async fn restricted_elasticsearch_metadata_uses_serverless_security_fallback() {
+    let app = Router::new().fallback(|request: Request<Body>| async move {
+        let (status, body) = match request.uri().path() {
+            "/" => (StatusCode::FORBIDDEN, ""),
+            "/_xpack/usage" => (StatusCode::GONE, ""),
+            _ => (StatusCode::OK, "{}"),
+        };
+        (
+            status,
+            [
+                ("content-type", "application/json"),
+                ("x-elastic-product", "Elasticsearch"),
+            ],
+            body,
+        )
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap()).parse().unwrap();
+    let task = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let client = Client::Elasticsearch(
+        ElasticsearchBuilder::new(url)
+            .apikey("test-key".into())
+            .build()
+            .unwrap(),
+    );
+    assert!(client.is_serverless().await.unwrap());
+    task.abort();
 }
 
 impl Drop for MockCluster {

--- a/tests/serverless_setup_tests.rs
+++ b/tests/serverless_setup_tests.rs
@@ -1,0 +1,195 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+#![cfg(feature = "setup")]
+
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+    response::IntoResponse,
+};
+use esdiag::client::{Client, ElasticsearchBuilder};
+use std::sync::{Arc, Mutex};
+
+struct MockCluster {
+    client: Client,
+    paths: Arc<Mutex<Vec<String>>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+#[tokio::test]
+async fn deployment_metadata_handles_both_products_and_restricted_metadata() {
+    for kibana in [false, true] {
+        for (status, body, expected) in [
+            (
+                StatusCode::OK,
+                r#"{"version":{"build_flavor":"serverless"}}"#,
+                Some(true),
+            ),
+            (StatusCode::OK, r#"{"version":{"build_flavor":"default"}}"#, Some(false)),
+            (StatusCode::OK, r#"{"version":{"number":"8.19.0"}}"#, Some(false)),
+            (StatusCode::FORBIDDEN, "", Some(false)),
+            (StatusCode::INTERNAL_SERVER_ERROR, "", None),
+            (StatusCode::OK, "invalid", None),
+        ] {
+            let app = Router::new().fallback(move |request: Request<Body>| async move {
+                assert_eq!(request.uri().path(), if kibana { "/api/status" } else { "/" });
+                (
+                    status,
+                    [
+                        ("content-type", "application/json"),
+                        ("x-elastic-product", "Elasticsearch"),
+                    ],
+                    body,
+                )
+            });
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let url = format!("http://{}", listener.local_addr().unwrap()).parse().unwrap();
+            let task = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+            let client = if kibana {
+                Client::Kibana(esdiag::client::KibanaClient::try_new(url, esdiag::data::Auth::None).unwrap())
+            } else {
+                Client::Elasticsearch(ElasticsearchBuilder::new(url).build().unwrap())
+            };
+            let actual = client.is_serverless().await;
+            task.abort();
+            assert_eq!(actual.ok(), expected);
+        }
+    }
+}
+
+impl Drop for MockCluster {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn cluster(probe_status: StatusCode, probe_body: &'static str, asset_status: StatusCode) -> MockCluster {
+    cluster_with_flavor(probe_status, probe_body, asset_status, probe_status == StatusCode::GONE).await
+}
+
+async fn cluster_with_flavor(
+    probe_status: StatusCode,
+    probe_body: &'static str,
+    asset_status: StatusCode,
+    serverless: bool,
+) -> MockCluster {
+    let paths = Arc::new(Mutex::new(Vec::new()));
+    let requests = paths.clone();
+    let app = Router::new().fallback(move |request: Request<Body>| {
+        let requests = requests.clone();
+        async move {
+            assert_eq!(request.headers()["authorization"], "ApiKey test-key");
+            let path = request.uri().path().to_string();
+            requests.lock().unwrap().push(path.clone());
+            let (status, body) = if path == "/" {
+                (
+                    StatusCode::OK,
+                    if serverless {
+                        r#"{"version":{"build_flavor":"serverless"}}"#
+                    } else {
+                        r#"{"version":{"build_flavor":"default"}}"#
+                    },
+                )
+            } else if path == "/_xpack/usage" {
+                (probe_status, probe_body)
+            } else if path.ends_with("/_mapping") {
+                (StatusCode::OK, "{}")
+            } else if path.starts_with("/_security/") && probe_status == StatusCode::GONE {
+                (StatusCode::GONE, r#"{"error":"unsupported role"}"#)
+            } else {
+                (asset_status, r#"{"acknowledged":true}"#)
+            };
+            (
+                status,
+                [
+                    ("content-type", "application/json"),
+                    ("x-elastic-product", "Elasticsearch"),
+                ],
+                body,
+            )
+                .into_response()
+        }
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap()).parse().unwrap();
+    let task = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let client = Client::Elasticsearch(
+        ElasticsearchBuilder::new(url)
+            .apikey("test-key".into())
+            .build()
+            .unwrap(),
+    );
+    MockCluster { client, paths, task }
+}
+
+#[tokio::test]
+async fn security_probe_preserves_stateful_behavior_and_handles_gone() {
+    for (status, body, expected) in [
+        (StatusCode::OK, r#"{"security":{"enabled":true}}"#, true),
+        (StatusCode::OK, r#"{"security":{"enabled":false}}"#, false),
+        (StatusCode::OK, "{}", true),
+        (StatusCode::UNAUTHORIZED, "", true),
+        (StatusCode::FORBIDDEN, "", true),
+        (StatusCode::NOT_FOUND, "", false),
+        (StatusCode::GONE, "not JSON", true),
+    ] {
+        let mock = cluster(status, body, StatusCode::OK).await;
+        assert_eq!(mock.client.has_security_enabled().await.unwrap(), expected);
+    }
+    for (status, body) in [
+        (StatusCode::INTERNAL_SERVER_ERROR, ""),
+        (StatusCode::OK, "invalid JSON"),
+    ] {
+        let mock = cluster(status, body, StatusCode::OK).await;
+        assert!(mock.client.has_security_enabled().await.is_err());
+    }
+}
+
+#[tokio::test]
+async fn setup_installs_assets_and_skips_roles_only_when_needed() {
+    for (status, body, expects_roles) in [
+        (StatusCode::GONE, "", false),
+        (StatusCode::OK, r#"{"security":{"enabled":false}}"#, false),
+        (StatusCode::OK, r#"{"security":{"enabled":true}}"#, true),
+        (StatusCode::FORBIDDEN, "", true),
+    ] {
+        let mock = cluster(status, body, StatusCode::OK).await;
+        esdiag::setup::assets(&mock.client).await.unwrap();
+        let paths = mock.paths.lock().unwrap();
+        assert_eq!(
+            paths.iter().filter(|p| *p == "/_xpack/usage").count(),
+            usize::from(status != StatusCode::GONE)
+        );
+        for prefix in ["/_ingest/pipeline/", "/_component_template/", "/_index_template/"] {
+            assert!(paths.iter().any(|p| p.starts_with(prefix)), "missing {prefix}");
+        }
+        assert_eq!(paths.iter().any(|p| p.starts_with("/_security/role/")), expects_roles);
+    }
+}
+
+#[tokio::test]
+async fn setup_still_reports_probe_and_asset_failures() {
+    let mock = cluster(StatusCode::INTERNAL_SERVER_ERROR, "", StatusCode::OK).await;
+    assert!(esdiag::setup::assets(&mock.client).await.is_err());
+    assert_eq!(*mock.paths.lock().unwrap(), vec!["/", "/_xpack/usage"]);
+
+    let mock = cluster(StatusCode::GONE, "", StatusCode::FORBIDDEN).await;
+    assert!(esdiag::setup::assets(&mock.client).await.is_err());
+}
+
+#[tokio::test]
+async fn serverless_metadata_avoids_stateful_security_and_license_apis() {
+    let mock = cluster_with_flavor(StatusCode::INTERNAL_SERVER_ERROR, "", StatusCode::OK, true).await;
+    esdiag::setup::assets(&mock.client).await.unwrap();
+    esdiag::setup::ensure_agent_builder_license(&mock.client).await.unwrap();
+    let paths = mock.paths.lock().unwrap();
+    assert!(
+        !paths
+            .iter()
+            .any(|p| p.starts_with("/_security/") || p == "/_xpack/usage" || p.starts_with("/_license"))
+    );
+    assert!(paths.iter().any(|p| p.starts_with("/_index_template/")));
+}


### PR DESCRIPTION
## Summary

Fixes Serverless setup failures for issue #390.

- Detects Serverless deployments from product metadata and keeps security enabled when the security usage endpoint returns HTTP 410.
- Removes unsupported ILM settings from Serverless templates while preserving data stream lifecycle behavior.
- Keeps diagnostic report streams indefinitely by disabling inherited data stream retention for `metrics-diagnostic-esdiag`.
- Adapts Kibana spaces and default Agent Builder updates to omit Serverless-managed or read-only fields.
- Skips stateful role and trial-license setup on Serverless.
- Adds offline and live asset compatibility coverage.

## Validation

- `cargo test --lib setup::`
- `cargo test --test serverless_setup_tests`
- `cargo test --test elasticsearch_asset_templates_tests`
- Live Serverless setup and asset audit on `esdiag-less` / `esdiag-less-kb`
