### PR TITLE
Fix mixed-version provenance writes after rollover

### DIFF
--- a/.agents/skills/changelog/SKILL.md
+++ b/.agents/skills/changelog/SKILL.md
@@ -18,14 +18,12 @@ update changelog content.
 
 ## Project Rules
 
-- Changelog issue references must point only to the public `elastic/esdiag`
-  repository, using `https://github.com/elastic/esdiag/issues/<number>` or a
-  verified public issue number such as `#123`.
-- `elastic/esdiag-dev` is private. Never include its issue links, qualified
-  references, or bare issue numbers in the changelog. Do not transfer a private
-  issue number to a public URL; the repositories have separate issue numbering.
-- If no corresponding public `elastic/esdiag` issue is verified, keep the
-  changelog bullet without a reference. Do not substitute a PR link or number.
+- Follow the target repository's guidance on which issue trackers and references
+  are appropriate for its changelog.
+- Prefer issue numbers over PR numbers on bullets.
+- Use a PR number only when there is no explicit issue reference to cite.
+- Add `#123` references inline at the end of the bullet whenever they can be
+  verified from GitHub history or release notes.
 - Only include a `Fixed` bullet if the change clearly closed or resolved a GitHub
   issue, or if release notes explicitly frame it as a bug fix.
 
@@ -58,18 +56,20 @@ When updating changelog content:
 4. For each candidate bullet:
    - choose the correct section (`Added`, `Changed`, `Fixed`, etc.)
    - reduce it to a single user-facing item
-   - attach a reference only if the corresponding public `elastic/esdiag` issue is verified
-   - otherwise omit the reference
+   - attach an issue number if verified and allowed by the repository's guidance
+   - otherwise attach a verified PR number if allowed
+   - omit the reference if neither qualifies
 5. Remove or rewrite bullets that cannot be supported by the sources.
 
 ## GitHub Verification Guidance
 
-- Use release notes, PRs, and commit history to find the corresponding public
-  `elastic/esdiag` issue. Verify the repository as well as the issue number.
+- Use release notes, PRs, and commit history to find the corresponding issue.
+  Verify the repository as well as the issue number.
 - A PR's `Resolves #123` refers to its own repository unless explicitly qualified;
-  it does not establish that public `elastic/esdiag#123` is the same issue.
-- Private issues may substantiate a fix internally, but must not appear as
-  changelog references. A verified private fix can have an unreferenced `Fixed` bullet.
+  it does not establish that issue #123 in another repository is the same issue.
+- Private issue links are appropriate when the target repository's guidance and
+  intended audience permit them. If a verified source cannot be cited, keep the
+  supported changelog bullet without a reference.
 
 ## PR Review Use
 
@@ -77,7 +77,7 @@ During PR review workflows, check changelog updates for:
 
 - correct Keep a Changelog structure
 - one feature per `Added` bullet
-- references restricted to verified public `elastic/esdiag` issues, with no private references
+- verified references that follow the target repository's citation rules
 - `Fixed` bullets limited to verified fixes
 - no invented versions or unsupported claims
 - accurate `Unreleased` scope for the branch being reviewed

--- a/.agents/skills/changelog/SKILL.md
+++ b/.agents/skills/changelog/SKILL.md
@@ -20,6 +20,11 @@ update changelog content.
 
 - Follow the target repository's guidance on which issue trackers and references
   are appropriate for its changelog.
+- In this repository, the root `AGENTS.md` requires references only to verified
+  public `elastic/esdiag` issues. Do not include private repository issue links,
+  qualified references, or their bare issue numbers here. Never reuse a private
+  issue number in a public URL. In another repository, follow that repository's
+  own `AGENTS.md` or equivalent guidance instead.
 - Prefer issue numbers over PR numbers on bullets when the target repository's
   guidance permits references.
 - Use a PR number only when there is no explicit issue reference to cite and the
@@ -70,9 +75,9 @@ When updating changelog content:
   Verify the repository as well as the issue number.
 - A PR's `Resolves #123` refers to its own repository unless explicitly qualified;
   it does not establish that issue #123 in another repository is the same issue.
-- Private issue links are appropriate when the target repository's guidance and
-  intended audience permit them. If a verified source cannot be cited, keep the
-  supported changelog bullet without a reference.
+- In this repository, private issue links are not allowed in changelog entries.
+  In another repository, follow its citation rules. If a verified source cannot
+  be cited, keep the supported changelog bullet without a reference.
 
 ## PR Review Use
 

--- a/.agents/skills/changelog/SKILL.md
+++ b/.agents/skills/changelog/SKILL.md
@@ -20,10 +20,13 @@ update changelog content.
 
 - Follow the target repository's guidance on which issue trackers and references
   are appropriate for its changelog.
-- Prefer issue numbers over PR numbers on bullets.
-- Use a PR number only when there is no explicit issue reference to cite.
+- Prefer issue numbers over PR numbers on bullets when the target repository's
+  guidance permits references.
+- Use a PR number only when there is no explicit issue reference to cite and the
+  target repository's guidance permits PR references.
 - Add `#123` references inline at the end of the bullet whenever they can be
-  verified from GitHub history or release notes.
+  verified from GitHub history or release notes and the target repository allows
+  that reference.
 - Only include a `Fixed` bullet if the change clearly closed or resolved a GitHub
   issue, or if release notes explicitly frame it as a bug fix.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,13 @@ For deeper repository structure see `docs/repository/organization.md`
 
 Issues and PRDs live in GitHub Issues on `elastic/esdiag` (the `upstream` remote, not the `origin` fork). External PRs are also a triage surface. See `docs/agents/issue-tracker.md`.
 
+In this repository's changelog, documentation, and shipped assets, reference only
+verified public `elastic/esdiag` issues. Do not include private repository issue
+links, qualified references, or their bare issue numbers. Never reuse a private
+issue number in a public URL; issue numbering is repository-specific. If no
+corresponding public issue is verified, describe the change without an issue
+reference.
+
 ### Triage labels
 
 Five canonical roles; `wontfix` maps to the existing `Wontfix` label, the other four use their default strings. See `docs/agents/triage-labels.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ published release notes, maintenance branches, and tagged history.
 
 ### Fixed
 
+- Fixed legacy diagnostic writers being rejected after rollover by keeping both provenance field names writable and searchable; setup now warns about incompatible existing mappings.
 - Fixed searchable-snapshot documents being rejected by Elasticsearch by placing their stats mappings under `searchable_snapshot`.
 - Fixed `esdiag local` launcher execution and structured outcomes for help output and forwarded state directories (#382).
 - Fixed compilation of every `server`, `setup`, and `keystore` feature combination, including `--no-default-features` (#347).

--- a/assets/elasticsearch/component_templates/esdiag@ls-metadata.json
+++ b/assets/elasticsearch/component_templates/esdiag@ls-metadata.json
@@ -2,7 +2,7 @@
   "_meta": {
     "managed": false,
     "description": "ESDiag common Logstash metadata mappings",
-    "compatibility_debt": "Remove diagnostic.product/application and diagnostic.orchestration/platform aliases after dashboards migrate and old indices age out. Shipped dashboards are checked by shipped_saved_objects_only_query_provenance_names_the_templates_define; pre-rename indices carry the mirrored alias installed by setup."
+    "compatibility_debt": "Keep both provenance names writable with reciprocal copy_to until legacy writers and dashboards retire and old indices age out. Existing alias mappings require rollover after setup for mixed-version writes; historical aliases remain query-only. See ADR-0014."
   },
   "template": {
     "mappings": {
@@ -38,18 +38,20 @@
               "type": "keyword"
             },
             "platform": {
-              "type": "keyword"
+              "type": "keyword",
+              "copy_to": "diagnostic.orchestration"
             },
             "orchestration": {
-              "type": "alias",
-              "path": "diagnostic.platform"
+              "type": "keyword",
+              "copy_to": "diagnostic.platform"
             },
             "application": {
-              "type": "keyword"
+              "type": "keyword",
+              "copy_to": "diagnostic.product"
             },
             "product": {
-              "type": "alias",
-              "path": "diagnostic.application"
+              "type": "keyword",
+              "copy_to": "diagnostic.application"
             }
           }
         },
@@ -64,5 +66,5 @@
       }
     }
   },
-  "version": 2
+  "version": 3
 }

--- a/assets/elasticsearch/component_templates/esdiag@metadata.json
+++ b/assets/elasticsearch/component_templates/esdiag@metadata.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "description": "ESDiag common cluster and diagnostic metadata mappings",
-    "compatibility_debt": "Remove diagnostic.product/application and diagnostic.orchestration/platform aliases after dashboards migrate and old indices age out. Shipped dashboards are checked by shipped_saved_objects_only_query_provenance_names_the_templates_define; pre-rename indices carry the mirrored alias installed by setup."
+    "compatibility_debt": "Keep both provenance names writable with reciprocal copy_to until legacy writers and dashboards retire and old indices age out. Existing alias mappings require rollover after setup for mixed-version writes; historical aliases remain query-only. See ADR-0014."
   },
   "template": {
     "mappings": {
@@ -100,18 +100,20 @@
               "type": "keyword"
             },
             "platform": {
-              "type": "keyword"
+              "type": "keyword",
+              "copy_to": "diagnostic.orchestration"
             },
             "orchestration": {
-              "type": "alias",
-              "path": "diagnostic.platform"
+              "type": "keyword",
+              "copy_to": "diagnostic.platform"
             },
             "application": {
-              "type": "keyword"
+              "type": "keyword",
+              "copy_to": "diagnostic.product"
             },
             "product": {
-              "type": "alias",
-              "path": "diagnostic.application"
+              "type": "keyword",
+              "copy_to": "diagnostic.application"
             }
           }
         },
@@ -126,5 +128,5 @@
       }
     }
   },
-  "version": 2
+  "version": 3
 }

--- a/assets/elasticsearch/index_templates/metrics-diagnostic.json
+++ b/assets/elasticsearch/index_templates/metrics-diagnostic.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "description": "ESDiag processing stats",
-    "compatibility_debt": "Remove diagnostic.product/application and diagnostic.orchestration/platform aliases after dashboards migrate and old indices age out. Shipped dashboards are checked by shipped_saved_objects_only_query_provenance_names_the_templates_define; pre-rename indices carry the mirrored alias installed by setup."
+    "compatibility_debt": "Keep both provenance names writable with reciprocal copy_to until legacy writers and dashboards retire and old indices age out. Existing alias mappings require rollover after setup for mixed-version writes; historical aliases remain query-only. See ADR-0014."
   },
   "index_patterns": ["metrics-diagnostic-esdiag"],
   "composed_of": ["esdiag@metadata", "esdiag@mappings", "esdiag@settings"],
@@ -452,26 +452,28 @@
               }
             },
             "product": {
-              "type": "alias",
-              "path": "diagnostic.application"
+              "type": "keyword",
+              "copy_to": "diagnostic.application"
             },
             "parent_id": {
               "type": "keyword"
             },
             "platform": {
-              "type": "keyword"
+              "type": "keyword",
+              "copy_to": "diagnostic.orchestration"
             },
             "orchestration": {
-              "type": "alias",
-              "path": "diagnostic.platform"
+              "type": "keyword",
+              "copy_to": "diagnostic.platform"
             },
             "application": {
-              "type": "keyword"
+              "type": "keyword",
+              "copy_to": "diagnostic.product"
             }
           }
         }
       }
     }
   },
-  "version": 2
+  "version": 3
 }

--- a/docs/adr/0014-evolve-indexed-data-model-via-field-aliases.md
+++ b/docs/adr/0014-evolve-indexed-data-model-via-field-aliases.md
@@ -1,63 +1,65 @@
 ---
 type: Reference
-title: "Evolve the indexed data model via field aliases"
+title: "Evolve indexed provenance with writable fields and historical aliases"
 status: accepted
 tags: [repository, adr]
 ---
 
-# Evolve the indexed data model via field aliases
+# Evolve indexed provenance with writable fields and historical aliases
 
-ADR-0001's split lands in the indexed docs as `diagnostic.application` (replacing
-`diagnostic.product`) and `diagnostic.platform` (replacing
-`diagnostic.orchestration`). These provenance-field renames are bridged with
-**Elasticsearch field aliases** so old and new dashboards keep working across old and
-new indices during the transition; the aliases are removed later. This is the third
-compatibility strategy, distinct from owned-file rewrite (ADR-0009) and
-received-artifact tolerance (ADR-0010).
+ADR-0001 replaces `diagnostic.product` with `diagnostic.application` and
+`diagnostic.orchestration` with `diagnostic.platform`. Both writer generations
+must coexist on shared diagnostics clusters, including after rollover.
 
 ## Context
 
-Indexed data is *semi-owned*: ESDiag controls the templates going forward (installed
-by `setup`), but **cannot rewrite historical indices** produced by older versions. So
-neither rewrite-on-first-read nor pure read-tolerance fits — field aliases bridge the
-rename without touching stored documents. Adding an alias to a historical index is a
-mapping addition, not a rewrite: no document changes and no reindex, which is what
-makes the mirrored half of the bridge available at all.
+ESDiag controls templates installed by `setup`, but templates only affect new
+indices. The original alias migration preserved searches while rejecting writes
+from released 0.16.x writers on new indices. Elasticsearch field aliases cannot
+accept values.
 
 ## Decisions
 
-- **`diagnostic.application` replaces `diagnostic.product`.** Both names resolve to the
-  same underlying field via aliases in both directions, so dashboards querying either
-  name work on both old and new indices during the transition. "Both directions" is a
-  property of the *index pattern* a dashboard queries, not of one index: an alias must
-  point at a concrete field, so each index carries exactly one of the pair as an alias,
-  in whichever direction its own stored name dictates. The templates give every new
-  index the legacy name as an alias; `setup` installs the mirror image — the current
-  name as an alias to the stored legacy one — on indices that predate the rename. Both
-  halves are needed, because a pattern spanning both generations resolves a name only
-  if every index it touches does.
-- **`diagnostic.platform` replaces `diagnostic.orchestration`.** The old field name
-  resolves to the new one through a transitional alias while historical dashboards
-  and retained indices age out. The rename is not just the indexed field: the
-  `orchestration` term is retired everywhere, including the in-code identifier and
-  its derivation point (`Processor::start`, `mod.rs:420`, which derives it from the
-  product and propagates it to children) — all become `platform`, sourced from the
-  split `Platform` of ADR-0001.
-- **Aliases are transitional** and removed once dashboards are updated and old indices
-  age out of retention.
+- New indices map all four names as concrete keyword fields. Each pair uses
+  reciprocal `copy_to`, so documents written with either name are searchable and
+  aggregatable through both names. This covers report, Elasticsearch, and
+  Logstash metadata templates.
+- Writers keep emitting their own field names. No writer upgrade is required
+  before installing these templates. Copying happens in the mapping, including
+  for direct report writes and bulk requests without an ingest pipeline.
+- `copy_to` copies indexed values without changing ordinary `_source`. It does
+  not recurse. If a document supplies different values for both names, both
+  fields index both values. Writers should send one name per pair or agreeing
+  values. Synthetic source may expose the indexed copies.
+- Historical indices retain their concrete fields. `setup` still adds the
+  current name as a query-only alias when only the legacy name exists, preserving
+  searches over documents already stored there.
+- `setup` warns about existing aliases that reject writes and about two concrete
+  names without reciprocal copying, where historical searches may be split.
+  It does not rewrite historical documents or roll over streams automatically.
 
-## Consequences
+## Upgrade and recovery
 
-- No reindex and no clean break — historical indices remain queryable by both old and
-  new dashboards for the alias lifetime.
-- **`setup` acquires a bridging step over existing indices**, which is best-effort by
-  design: an index that cannot take a mapping update (closed, frozen, or write-blocked)
-  costs the legacy-name resolution for that one index and must not fail installing the
-  assets.
-- The removable aliases are the migration's only debt. Half the removal trigger is now
-  verifiable in the repository: the dashboards are shipped Kibana saved objects, so a
-  test reports which provenance names they still query and refuses to let an alias be
-  dropped while one depends on it. The other half — historical indices aging out of
-  retention — remains operational.
-- Confirms the compat trilogy: **owned files → rewrite** (0009), **received artifacts →
-  tolerate** (0010), **indexed data → field aliases** (this ADR).
+1. Install the corrected templates with `esdiag setup`.
+2. Before mixing writer versions, roll over each affected data stream whose
+   current write index has a provenance alias. For example, use
+   `POST /metrics-diagnostic-esdiag/_rollover` for reports. This applies to both
+   pre-rename indices with current-name aliases and indices created by the
+   earlier branch templates with legacy-name aliases. Installing templates alone
+   cannot change those existing field types. For standalone indices, write to a
+   replacement index created with the corrected mappings.
+3. Retry rejected diagnostics after rollover. Historical aliases remain useful
+   for searches. If both names already exist as unlinked concrete fields,
+   reindex into corrected mappings to make historical documents searchable under
+   either name. Rollover fixes future writes only.
+
+The copied values are indexed under both fields, increasing storage compared
+with an alias. Retire the legacy fields and copying only after legacy writers
+and dashboards are retired and old indices age out. The shipped saved-object
+regression test checks dashboard references; writer retirement remains an
+operational requirement.
+
+See Elasticsearch's [copy_to reference](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/copy-to)
+for indexing and source behavior. The opt-in test
+`tests/provenance_writers_tests.rs` verifies both writer generations through real
+Elasticsearch indexing, queries, aggregations, and rollover.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -127,10 +127,9 @@ const PROVENANCE_RENAMES: [(&str, &str); 2] = [("application", "product"), ("pla
 ///
 /// A field alias must point at a concrete field, so no single index can carry
 /// both names as aliases: the direction is fixed by which name that index stores.
-/// The templates give every *new* index the legacy name as an alias to the
-/// current one; this supplies the mirror image for indices that predate them, so
-/// a query over an index pattern spanning both generations resolves either name
-/// in every index it touches.
+/// New templates keep both names writable with reciprocal `copy_to`. Historical
+/// indices still need a query-only alias because adding a concrete field would
+/// leave previously indexed documents unsearchable through that name.
 ///
 /// Returns `None` when there is nothing to bridge — a new-generation index, one
 /// already carrying the alias, or a mapping with no provenance fields at all —
@@ -176,6 +175,36 @@ fn provenance_alias_patches(mappings: &Value) -> Vec<(String, Value)> {
         .collect()
 }
 
+/// Existing aliases cannot accept writes, and unlinked concrete fields can split
+/// search results. Neither can be repaired by installing a new template.
+fn provenance_mapping_warnings(properties: &Value) -> Vec<String> {
+    let mut warnings = Vec::new();
+    for (current, legacy) in PROVENANCE_RENAMES {
+        for name in [current, legacy] {
+            if properties[name]["type"] == "alias" {
+                warnings.push(format!(
+                    "diagnostic.{name} is a query-only alias and rejects writers using that name; \
+                     roll over the data stream after setup before mixing writer versions"
+                ));
+            }
+        }
+        let concrete = |name: &str| properties[name]["type"].as_str().is_some_and(|kind| kind != "alias");
+        let copies_to = |from: &str, to: &str| {
+            let target = Value::String(format!("diagnostic.{to}"));
+            let copy = &properties[from]["copy_to"];
+            copy == &target || copy.as_array().is_some_and(|targets| targets.contains(&target))
+        };
+        if concrete(current) && concrete(legacy) && !(copies_to(current, legacy) && copies_to(legacy, current)) {
+            warnings.push(format!(
+                "diagnostic.{current} and diagnostic.{legacy} are unlinked concrete fields; \
+                 historical search results may be split. Roll over for future writes and \
+                 reindex historical documents if both names must find them"
+            ));
+        }
+    }
+    warnings
+}
+
 /// Bridge the provenance rename on indices that predate it (ADR-0014).
 ///
 /// Templates only govern indices created after they are installed, so this is the
@@ -197,6 +226,16 @@ async fn install_provenance_aliases(client: &Client) -> Result<()> {
     }
 
     let mappings: Value = response.json().await?;
+    if let Some(indices) = mappings.as_object() {
+        for (index, mapping) in indices {
+            let properties = mapping
+                .pointer("/mappings/properties/diagnostic/properties")
+                .unwrap_or(&Value::Null);
+            for warning in provenance_mapping_warnings(properties) {
+                tracing::warn!("{index}: {warning}");
+            }
+        }
+    }
     let patches = provenance_alias_patches(&mappings);
     if patches.is_empty() {
         tracing::debug!("No pre-rename ESDiag indices need a provenance alias");
@@ -212,6 +251,9 @@ async fn install_provenance_aliases(client: &Client) -> Result<()> {
         match result {
             Ok(response) if response.status().is_success() => {
                 tracing::info!("Aliased the current provenance names onto {index}");
+                tracing::warn!(
+                    "{index}: added query-only provenance aliases; roll over the data stream after setup before mixing writer versions"
+                );
             }
             Ok(response) => {
                 failures += 1;
@@ -705,15 +747,11 @@ mod tests {
     #[test]
     fn both_provenance_names_resolve_in_either_index_generation() {
         let new_index = template_diagnostic_properties();
-        assert_eq!(
-            resolves_to(&new_index, "product"),
-            resolves_to(&new_index, "application"),
-            "a new index stores `application` and aliases `product` to it"
-        );
-        assert_eq!(
-            resolves_to(&new_index, "orchestration"),
-            resolves_to(&new_index, "platform")
-        );
+        for (current, legacy) in PROVENANCE_RENAMES {
+            assert_eq!(new_index[current]["type"], "keyword");
+            assert_eq!(new_index[legacy]["type"], "keyword");
+        }
+        assert!(provenance_mapping_warnings(&new_index).is_empty());
         assert!(
             provenance_alias_patch(&new_index).is_none(),
             "a new index needs no patch, so setup is idempotent"
@@ -741,6 +779,26 @@ mod tests {
             provenance_alias_patch(&old_index).is_none(),
             "re-running setup over a patched index is a no-op"
         );
+    }
+
+    #[test]
+    fn provenance_warnings_identify_aliases_and_unlinked_fields() {
+        let old = pre_rename_diagnostic_properties();
+        assert!(provenance_mapping_warnings(&old).is_empty());
+        let patch = provenance_alias_patch(&old).unwrap();
+        assert_eq!(provenance_mapping_warnings(&patched(&old, &patch)).len(), 2);
+        let split = serde_json::json!({
+            "application": {"type": "keyword"},
+            "product": {"type": "keyword"}
+        });
+        assert!(provenance_mapping_warnings(&split)[0].contains("unlinked concrete fields"));
+        assert!(provenance_alias_patch(&split).is_none());
+        let alias = serde_json::json!({
+            "application": {"type": "keyword"},
+            "product": {"type": "alias", "path": "diagnostic.application"}
+        });
+        assert!(provenance_mapping_warnings(&alias)[0].contains("diagnostic.product is a query-only alias"));
+        assert!(provenance_mapping_warnings(&Value::Null).is_empty());
     }
 
     #[test]

--- a/tests/README.md
+++ b/tests/README.md
@@ -150,3 +150,20 @@ The script requires `cargo`, `curl`, and `docker` by default. Set
 `CONTAINER_RUNTIME=podman` to use Podman instead. It starts temporary Elastic
 Stack containers and uses a temporary directory for the Logstash pipeline
 configuration.
+
+## Mixed-version provenance writes
+
+`tests/provenance_writers_tests.rs` installs the checkout's Elasticsearch assets
+and tests legacy, current, and dual-name payloads against report, Elasticsearch
+node, and Logstash node streams. It checks direct and bulk writes, term queries,
+aggregations, and a subsequent rollover.
+
+Run only against a disposable Elasticsearch cluster with security disabled.
+The test replaces ESDiag templates and rolls over its test streams.
+
+```sh
+ESDIAG_TEST_ES_URL=http://localhost:19278 cargo test --test provenance_writers_tests -- --ignored --nocapture
+```
+
+The test is ignored by default. Elasticsearch 9.4.2 on
+Ironhide is the regression environment for mixed-version provenance writes.

--- a/tests/elasticsearch_asset_templates_tests.rs
+++ b/tests/elasticsearch_asset_templates_tests.rs
@@ -48,15 +48,6 @@ fn diagnostic_properties(template: &Value) -> &Value {
     &template["template"]["mappings"]["properties"]["diagnostic"]["properties"]
 }
 
-fn canonical_diagnostic_field(properties: &Value, field: &str) -> String {
-    let mapping = &properties[field];
-    if mapping["type"].as_str() == Some("alias") {
-        mapping["path"].as_str().expect("alias path").to_string()
-    } else {
-        format!("diagnostic.{field}")
-    }
-}
-
 fn collect_rs_files(root: &Path, files: &mut Vec<std::path::PathBuf>) {
     for entry in fs::read_dir(root).unwrap_or_else(|err| panic!("read dir {}: {}", root.display(), err)) {
         let entry = entry.expect("read directory entry");
@@ -191,23 +182,19 @@ fn logstash_templates_allow_concrete_logstash_datasets() {
 }
 
 #[test]
-fn metadata_templates_map_new_provenance_fields_and_transitional_aliases() {
+fn metadata_templates_accept_both_writer_generations() {
     let templates = [
         diagnostic_properties(&component_template("esdiag@metadata.json")).clone(),
         diagnostic_properties(&component_template("esdiag@ls-metadata.json")).clone(),
         diagnostic_properties(&index_template("metrics-diagnostic.json")).clone(),
     ];
-
     for properties in templates {
-        assert_eq!(properties["platform"]["type"].as_str(), Some("keyword"));
-        assert_eq!(properties["application"]["type"].as_str(), Some("keyword"));
-        assert_eq!(properties["product"]["type"].as_str(), Some("alias"));
-        assert_eq!(properties["product"]["path"].as_str(), Some("diagnostic.application"));
-        assert_eq!(properties["orchestration"]["type"].as_str(), Some("alias"));
-        assert_eq!(
-            properties["orchestration"]["path"].as_str(),
-            Some("diagnostic.platform")
-        );
+        for (current, legacy) in [("application", "product"), ("platform", "orchestration")] {
+            for (from, to) in [(current, legacy), (legacy, current)] {
+                assert_eq!(properties[from]["type"], "keyword", "{from} must accept writes");
+                assert_eq!(properties[from]["copy_to"], format!("diagnostic.{to}"));
+            }
+        }
     }
 }
 
@@ -270,22 +257,6 @@ fn saved_data_view_patterns() -> Vec<(String, String)> {
     patterns
 }
 
-#[test]
-fn new_index_templates_resolve_both_provenance_names() {
-    // The mirrored half of the bridge — the alias a pre-rename index needs — is
-    // installed by `setup`, and covered by
-    // `setup::tests::both_provenance_names_resolve_in_either_index_generation`.
-    let properties = diagnostic_properties(&component_template("esdiag@metadata.json")).clone();
-    assert_eq!(
-        canonical_diagnostic_field(&properties, "application"),
-        canonical_diagnostic_field(&properties, "product")
-    );
-    assert_eq!(
-        canonical_diagnostic_field(&properties, "platform"),
-        canonical_diagnostic_field(&properties, "orchestration")
-    );
-}
-
 /// The dashboard layer used to be unverifiable, so ADR-0015 left it to review
 /// discipline. The saved objects now live in the repository, so the convention is
 /// checkable: a title that does not pin `-esdiag` also matches indices ESDiag does
@@ -308,10 +279,7 @@ fn shipped_data_views_follow_the_stream_naming_contract() {
     );
 }
 
-/// Keeps the transitional aliases and their consumers honest in both directions:
-/// an alias may not be dropped while a shipped saved object still queries the
-/// legacy name, and once none do, this test is what reports that the debt is
-/// collectable (ADR-0014).
+/// Keep legacy fields searchable while shipped saved objects still use them.
 #[test]
 fn shipped_saved_objects_only_query_provenance_names_the_templates_define() {
     let properties = diagnostic_properties(&component_template("esdiag@metadata.json")).clone();
@@ -331,10 +299,10 @@ fn shipped_saved_objects_only_query_provenance_names_the_templates_define() {
         .map(|(_, field)| field.as_str())
         .collect();
     for legacy in legacy_names {
-        let alias_installed = properties[legacy]["type"].as_str() == Some("alias");
+        let field_installed = properties.get(legacy).is_some();
         assert!(
-            !still_legacy.contains(legacy) || alias_installed,
-            "saved objects still query diagnostic.{legacy}, so its alias must stay installed"
+            !still_legacy.contains(legacy) || field_installed,
+            "saved objects still query diagnostic.{legacy}, so its field must stay installed"
         );
     }
 }

--- a/tests/provenance_writers_tests.rs
+++ b/tests/provenance_writers_tests.rs
@@ -1,0 +1,135 @@
+//! Opt-in regression test for a disposable, unauthenticated Elasticsearch cluster.
+//! Installs repository assets and rolls over test streams. Never run on a shared cluster.
+
+use reqwest::{Method, blocking::Client};
+use serde_json::{Value, json};
+use std::{path::Path, time::Duration};
+
+struct Cluster {
+    client: Client,
+    url: String,
+}
+
+impl Cluster {
+    fn request(&self, method: Method, path: &str, body: Option<Value>) -> Value {
+        let mut request = self.client.request(method, format!("{}{path}", self.url));
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+        let response = request.send().expect("Elasticsearch request");
+        let status = response.status();
+        let result: Value = response.json().expect("Elasticsearch JSON response");
+        assert!(status.is_success(), "{path}: {status} {result}");
+        result
+    }
+}
+
+#[test]
+#[ignore = "requires ESDIAG_TEST_ES_URL pointing to a disposable Elasticsearch cluster"]
+fn mixed_version_provenance_writes_survive_rollover() {
+    let cluster = Cluster {
+        client: Client::builder().timeout(Duration::from_secs(60)).build().unwrap(),
+        url: std::env::var("ESDIAG_TEST_ES_URL")
+            .expect("set ESDIAG_TEST_ES_URL to a disposable cluster")
+            .trim_end_matches('/')
+            .to_owned(),
+    };
+    let assets = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/elasticsearch");
+    let run = uuid::Uuid::new_v4().to_string();
+    for (folder, endpoint, suffix) in [
+        ("ingest_pipelines", "_ingest/pipeline", ""),
+        ("component_templates", "_component_template", ""),
+        ("index_templates", "_index_template", "-esdiag"),
+    ] {
+        let mut paths: Vec<_> = std::fs::read_dir(assets.join(folder))
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| path.extension().is_some_and(|extension| extension == "json"))
+            .collect();
+        paths.sort();
+        for path in paths {
+            let name = path.file_stem().unwrap().to_str().unwrap();
+            let body = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+            cluster.request(Method::PUT, &format!("/{endpoint}/{name}{suffix}"), Some(body));
+        }
+    }
+    for (stream, application) in [
+        ("metrics-diagnostic-esdiag", "elasticsearch"),
+        ("metrics-node-esdiag", "elasticsearch"),
+        ("metrics-logstash.node-esdiag", "logstash"),
+    ] {
+        let response = cluster
+            .client
+            .get(format!("{}/_data_stream/{stream}", cluster.url))
+            .send()
+            .unwrap();
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            cluster.request(Method::PUT, &format!("/_data_stream/{stream}"), None);
+        } else {
+            assert!(
+                response.status().is_success(),
+                "reading {stream}: {}",
+                response.status()
+            );
+            cluster.request(Method::POST, &format!("/{stream}/_rollover"), Some(json!({})));
+        }
+        for generation in 0..2 {
+            if generation > 0 {
+                cluster.request(Method::POST, &format!("/{stream}/_rollover"), Some(json!({})));
+            }
+            let mut bulk = String::new();
+            for mut diagnostic in [
+                json!({"product": application, "orchestration": "eck"}),
+                json!({"application": application, "platform": "eck"}),
+                json!({"product": application, "application": application, "orchestration": "eck", "platform": "eck"}),
+            ] {
+                diagnostic["id"] = json!(run);
+                let document = json!({"@timestamp": chrono::Utc::now().to_rfc3339(), "diagnostic": diagnostic});
+                cluster.request(Method::POST, &format!("/{stream}/_doc"), Some(document.clone()));
+                bulk.push_str(&json!({"create": {"_index": stream}}).to_string());
+                bulk.push('\n');
+                bulk.push_str(&document.to_string());
+                bulk.push('\n');
+            }
+            let response = cluster
+                .client
+                .post(format!("{}/_bulk", cluster.url))
+                .header("Content-Type", "application/x-ndjson")
+                .body(bulk)
+                .send()
+                .unwrap();
+            let status = response.status();
+            let result: Value = response.json().unwrap();
+            assert!(status.is_success(), "bulk: {status} {result}");
+            assert_eq!(result["errors"], false, "{result}");
+            cluster.request(Method::POST, &format!("/{stream}/_refresh"), None);
+            for (field, value) in [
+                ("product", application),
+                ("application", application),
+                ("orchestration", "eck"),
+                ("platform", "eck"),
+            ] {
+                let field = format!("diagnostic.{field}");
+                let result = cluster.request(
+                    Method::POST,
+                    &format!("/{stream}/_search"),
+                    Some(json!({
+                        "size": 0,
+                        "query": {"bool": {"filter": [
+                            {"term": {"diagnostic.id": run}}, {"term": {&field: value}}
+                        ]}},
+                        "aggs": {"values": {"terms": {"field": field}}}
+                    })),
+                );
+                let count = 6 * (generation + 1);
+                assert_eq!(result["hits"]["total"]["value"], count, "{stream} {field}: {result}");
+                assert_eq!(
+                    result["aggregations"]["values"]["buckets"],
+                    json!([{"key": value, "doc_count": count}]),
+                    "{stream} {field}: {result}"
+                );
+            }
+        }
+        println!("PASS {stream}: legacy/current/dual writes, bulk, search, aggregations, rollover");
+    }
+}


### PR DESCRIPTION
## Problem

The provenance migration made `diagnostic.product` and
`diagnostic.orchestration` field aliases. Existing writers still send those
names, so report documents fail after rollover with `Cannot write to a field
alias`.

## Fix

- Map both provenance names as writable keyword fields with reciprocal `copy_to`.
- Warn during setup when existing indices contain query-only aliases or split
  concrete fields, and document the rollover and recovery path.
- Add Rust coverage for legacy, current, and bulk writes across report,
  Elasticsearch node, and Logstash streams, including rollover behavior.
- Update the repository guidance to keep issue references scoped to verified
  public `elastic/esdiag` issues.

## Validation

- `cargo test --test elasticsearch_asset_templates_tests`
- `cargo test --lib setup::tests`
- Rust mixed-version integration test passed against Elasticsearch 9.4.2 on
  Ironhide.
