### PR TITLE
Improve init onboarding and recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ published release notes, maintenance branches, and tagged history.
 
 ### Changed
 
-- Changed onboarding to show workflow changes, offer only available credential sources, and prompt for a diagnostic user without defaulting to the shell username.
-- Added credential-update guidance to keystore errors and listed local-stack commands in `esdiag local --help`.
-
+- Changed onboarding to show workflow changes when resuming and changing a saved workflow.
+- Changed onboarding to offer only available credential sources.
+- Changed onboarding to prompt for a diagnostic user without defaulting to the shell username.
+- Changed keystore replacement errors to suggest the `update` command.
+- Changed `esdiag local --help` to list the local-stack commands.
 - Changed diagnostic platform fields to serialize stable hyphenated platform keys (#347).
 - Changed platform detection to identify Elastic Cloud Hosted bundles from a cluster license issued to `Elastic Cloud`, so API-only hosted bundles no longer report an unknown platform (#347).
 - Changed collection and processing source selection to use canonical registry keys and added a maintainer reconciliation utility for upstream support-diagnostics sources (#348).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ published release notes, maintenance branches, and tagged history.
 
 ### Changed
 
+- Changed onboarding to show workflow changes, offer only available credential sources, and prompt for a diagnostic user without defaulting to the shell username.
+- Added credential-update guidance to keystore errors and listed local-stack commands in `esdiag local --help`.
+
 - Changed diagnostic platform fields to serialize stable hyphenated platform keys (#347).
 - Changed platform detection to identify Elastic Cloud Hosted bundles from a cluster license issued to `Elastic Cloud`, so API-only hosted bundles no longer report an unknown platform (#347).
 - Changed collection and processing source selection to use canonical registry keys and added a maintainer reconciliation utility for upstream support-diagnostics sources (#348).
@@ -50,6 +53,13 @@ published release notes, maintenance branches, and tagged history.
   container; full mode preserves the containerized runtime.
 
 ### Fixed
+
+- Fixed first-run output validation trying to read a pasted API key from the keystore before it had been saved.
+- Fixed onboarding accepting invalid confirmations and aborting on invalid URLs or default-job host selections; output validation now identifies endpoint failures and offers a retry.
+- Fixed local-stack startup failures deleting the files needed to retrieve credentials, retry startup, or stop running containers.
+- Fixed local-stack readiness checks panicking inside the async runtime and rejecting reachable ESDiag services that require authentication.
+- Fixed processing results omitting rejected-document counts and affected indices.
+- Fixed setup results reporting incomplete mapping updates without a partial outcome and recovery guidance.
 
 - Fixed legacy diagnostic writers being rejected after rollover by keeping both provenance field names writable and searchable; setup now warns about incompatible existing mappings.
 - Fixed Serverless setup failures caused by security and license probes (#390).

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -37,6 +37,11 @@ esdiag <command> --help
 finite commands. YAML is the default.
 
 Finite commands write one result to stdout. Progress and errors go to stderr.
+Processing results include `outcome`, `documents_failed`, and `indexing_failures`
+with affected index names and rejection counts. `output` identifies the resolved
+destination, including a saved default deployment. A `setup_completed` result
+has an `outcome` of `complete` or `partial`; partial mapping updates include
+`failed_indices` and recovery advice in `warnings`.
 When a command fails after it starts, stdout contains a `command_failed` result
 and the command exits non-zero.
 
@@ -148,6 +153,21 @@ legacy plaintext host credentials into the keystore.
 
 It stores credentials in `secrets.yml`, not `esdiag.yml`.
 
+Enter an email address or another diagnostic user identifier. `EMAIL`, when
+set to an email address, supplies the default; the shell username does not.
+Invalid yes/no answers, endpoint URLs, and default-job host selections prompt
+again. The default job requires a saved collection host name, not a URL.
+Resuming displays the saved workflow, and changing it displays both choices.
+
+Pasted keys are hidden and used to validate Elasticsearch and Kibana before
+saving the output. Validation identifies the failing application and reports
+authentication, TLS, DNS, connection, or response failures. You can retry the
+output step without restarting onboarding. The local API key source appears
+only when a usable local key is detected.
+
+To replace a referenced API key later, run `esdiag keystore update <name> --apikey`
+at a terminal. It prompts for the key without putting it in shell history.
+
 When you select local processing and no stack exists, `init` can start a
 binary-owned core stack. Its approval includes that new stack's required
 assets; declining returns to remote output setup.
@@ -157,6 +177,12 @@ See [Configure ESDiag](setup/configuration.md) for the prompts and paths.
 ## `local`
 
 `esdiag local <command>` runs the binary's Rust-owned local-stack lifecycle:
+
+`esdiag local --help` lists the available commands. If startup fails, the
+generated `.env` and `compose.yml` remain in the state directory. Use `logs`
+to inspect the failure, retry `up`, or stop the stack with `down`. Include
+the same `--state-dir` when using a custom directory. `secrets password`
+continues to read the retained password.
 
 ```sh
 esdiag local up

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -136,7 +136,9 @@ pub enum CliOutcome {
     SetupCompleted {
         targets: Vec<String>,
         outcome: String,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
         failed_indices: Vec<String>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
         warnings: Vec<String>,
     },
     LocalStack {

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -135,6 +135,9 @@ pub enum CliOutcome {
     },
     SetupCompleted {
         targets: Vec<String>,
+        outcome: String,
+        failed_indices: Vec<String>,
+        warnings: Vec<String>,
     },
     LocalStack {
         command: String,
@@ -218,11 +221,22 @@ pub struct DiagnosticResult {
     pub id: String,
     pub product: String,
     pub documents: u32,
+    pub documents_failed: u32,
+    pub outcome: crate::processor::DiagnosticOutcome,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub indexing_failures: Vec<IndexingFailure>,
     pub duration_ms: u128,
     pub source: String,
     pub output: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kibana_url: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IndexingFailure {
+    pub index: String,
+    pub documents_failed: u32,
+    pub category: &'static str,
 }
 
 #[derive(Debug, Serialize)]
@@ -516,6 +530,9 @@ mod tests {
             id: "prod-es@2026-08-10~a1b2".to_string(),
             product: "Elasticsearch".to_string(),
             documents: 42,
+            documents_failed: 0,
+            outcome: crate::processor::DiagnosticOutcome::Complete,
+            indexing_failures: vec![],
             duration_ms: 125,
             source: "primary".to_string(),
             output: "stdio://stdout".to_string(),
@@ -607,6 +624,9 @@ mod tests {
                         id: "prod-es@2026-08-10~a1b2".to_string(),
                         product: "Elasticsearch".to_string(),
                         documents: 42,
+                        documents_failed: 0,
+                        outcome: crate::processor::DiagnosticOutcome::Complete,
+                        indexing_failures: vec![],
                         duration_ms: 125,
                         source: "primary".to_string(),
                         output: "file:///tmp/report.ndjson".to_string(),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -121,6 +121,9 @@ impl Client {
                     .map_err(|e| format!("{e}"))?;
 
                 let status = response.status_code();
+                if !status.is_success() {
+                    return Err(format!("HTTP {status}"));
+                }
                 let json: serde_json::Value = response
                     .json::<serde_json::Value>()
                     .await
@@ -136,6 +139,9 @@ impl Client {
             Client::Kibana(client) => {
                 let response = client.test_connection().await.map_err(|e| format!("{e}"))?;
                 let status = response.status();
+                if !status.is_success() {
+                    return Err(format!("HTTP {status}"));
+                }
                 let json: serde_json::Value = response
                     .json::<serde_json::Value>()
                     .await
@@ -149,6 +155,9 @@ impl Client {
             Client::Logstash(client) => {
                 let response = client.test_connection().await.map_err(|e| format!("{e}"))?;
                 let status = response.status();
+                if !status.is_success() {
+                    return Err(format!("HTTP {status}"));
+                }
                 let json: serde_json::Value = response
                     .json::<serde_json::Value>()
                     .await

--- a/src/data/keystore.rs
+++ b/src/data/keystore.rs
@@ -703,7 +703,9 @@ pub fn add_secret(
     let auth = parse_secret_auth(username, password, apikey)?;
     let mut store = read_store(keystore_password)?;
     if store.secrets.contains_key(secret_id) {
-        return Err(eyre!("Secret '{secret_id}' already exists"));
+        return Err(eyre!(
+            "Secret '{secret_id}' already exists. Replace its credential with `esdiag keystore update {secret_id} --apikey` or `--user <username> --password`."
+        ));
     }
     store
         .secrets
@@ -794,7 +796,7 @@ fn ensure_secret_is_unreferenced(secret_id: &str) -> Result<()> {
     }
 
     Err(eyre!(
-        "Cannot remove secret '{secret_id}' because it is still referenced by {}",
+        "Cannot remove secret '{secret_id}' because it is still referenced by {}. To replace its credential, use `esdiag keystore update {secret_id} --apikey` or `--user <username> --password`.",
         parts.join("; ")
     ))
 }

--- a/src/data/known_host.rs
+++ b/src/data/known_host.rs
@@ -1443,7 +1443,7 @@ impl KnownHost {
                 Ok(hosts)
             }
             false => {
-                tracing::info!("No hosts file found at {:?}", path);
+                tracing::debug!("No hosts file found at {:?}", path);
                 Ok(BTreeMap::new())
             }
         }

--- a/src/local.rs
+++ b/src/local.rs
@@ -5,16 +5,17 @@ use std::{
     fs,
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    thread,
     time::Duration,
 };
 
+use esdiag::cli_output::CliOutcome;
+#[cfg(feature = "setup")]
 use esdiag::{
-    cli_output::CliOutcome,
     client::Client,
     data::{Application, KnownHostBuilder, Uri},
     setup,
 };
+#[cfg(feature = "setup")]
 use url::Url;
 
 const STATE_SCHEMA_VERSION: &str = "3";
@@ -48,7 +49,7 @@ impl StackMode {
 
 pub async fn run(args: &[OsString]) -> Result<CliOutcome> {
     let command = args.first().and_then(|argument| argument.to_str()).unwrap_or("help");
-    let options = LocalOptions::parse(&args[1..])?;
+    let options = LocalOptions::parse(args.get(1..).unwrap_or_default())?;
     let mut state = LocalState::load(options.state_dir.clone())?;
     state.open_browser = options.open_browser;
     state.copy_password = options.copy_password;
@@ -71,7 +72,7 @@ pub async fn run(args: &[OsString]) -> Result<CliOutcome> {
             state.setup().await?;
         }
         "open" => state.open_browser()?,
-        "auth" => state.auth()?,
+        "auth" => state.auth().await?,
         "reset" => state.reset(options.force)?,
         "secrets" => state.secret(options.remaining.first().map(String::as_str))?,
         "update" => {
@@ -215,15 +216,13 @@ impl LocalState {
     }
 
     async fn up(&mut self, options: LocalOptions) -> Result<()> {
-        let previous_env = fs::read_to_string(self.dir.join(".env")).ok();
-        let previous_compose = fs::read_to_string(self.dir.join("compose.yml")).ok();
-        match self.up_inner(options).await {
-            Ok(()) => Ok(()),
-            Err(error) => {
-                self.restore_startup_state(previous_env, previous_compose)?;
-                Err(error)
-            }
-        }
+        self.up_inner(options).await.map_err(|error| {
+            let message = format!(
+                "Local startup did not complete: {error}. Generated state is retained at {}. Inspect `esdiag local logs --state-dir {}`, then retry `esdiag local up --state-dir {}` or stop with `esdiag local down --state-dir {}`.",
+                self.dir.display(), self.dir.display(), self.dir.display(), self.dir.display()
+            );
+            error.wrap_err(message)
+        })
     }
 
     async fn up_inner(&mut self, options: LocalOptions) -> Result<()> {
@@ -244,12 +243,11 @@ impl LocalState {
             self.compose(&["down", "--remove-orphans"])?;
         }
         self.compose(&["pull", "elasticsearch", "kibana"])?;
-        self.compose(&["up", "-d", "elasticsearch"])?;
-        self.wait_elasticsearch()?;
-        self.configure_security()?;
+        self.compose(&["up", "-d", "elasticsearch", "kibana"])?;
+        self.wait_elasticsearch().await?;
+        self.configure_security().await?;
         self.write()?;
-        self.compose(&["up", "-d", "kibana"])?;
-        self.wait_kibana()?;
+        self.wait_kibana().await?;
         self.setup_mode(mode).await?;
         if mode == StackMode::Full {
             self.stop_native_service()?;
@@ -257,27 +255,11 @@ impl LocalState {
         } else {
             self.start_native_service()?;
         }
-        self.wait_url(&self.esdiag_url(), None)?;
+        self.wait_url(&self.esdiag_url(), None).await?;
         self.values.insert("STACK_MODE".to_string(), mode.as_str().to_string());
         self.write()?;
         if self.open_browser {
             self.open_browser()?;
-        }
-        Ok(())
-    }
-
-    fn restore_startup_state(&self, env: Option<String>, compose: Option<String>) -> Result<()> {
-        match env {
-            Some(env) => write_private(self.dir.join(".env"), &env)?,
-            None => {
-                let _ = fs::remove_file(self.dir.join(".env"));
-            }
-        }
-        match compose {
-            Some(compose) => write_private(self.dir.join("compose.yml"), &compose)?,
-            None => {
-                let _ = fs::remove_file(self.dir.join("compose.yml"));
-            }
         }
         Ok(())
     }
@@ -410,8 +392,8 @@ impl LocalState {
         write_private(self.dir.join("compose.yml"), &compose)
     }
 
-    fn configure_security(&mut self) -> Result<()> {
-        let client = reqwest::blocking::Client::new();
+    async fn configure_security(&mut self) -> Result<()> {
+        let client = reqwest::Client::builder().timeout(Duration::from_secs(5)).build()?;
         let response = client
             .post(format!(
                 "{}/_security/user/kibana_system/_password",
@@ -419,7 +401,8 @@ impl LocalState {
             ))
             .basic_auth("elastic", Some(self.required("ELASTIC_PASSWORD")?))
             .json(&serde_json::json!({"password": self.required("KIBANA_SYSTEM_PASSWORD")?}))
-            .send()?
+            .send()
+            .await?
             .error_for_status()?;
         drop(response);
         if self.required("ESDIAG_OUTPUT_APIKEY")? == "pending" {
@@ -427,9 +410,11 @@ impl LocalState {
                 .post(format!("{}/_security/api_key", self.elasticsearch_url()))
                 .basic_auth("elastic", Some(self.required("ELASTIC_PASSWORD")?))
                 .json(&serde_json::json!({"name": "esdiag-local"}))
-                .send()?
+                .send()
+                .await?
                 .error_for_status()?
-                .json()?;
+                .json()
+                .await?;
             let key = response["encoded"]
                 .as_str()
                 .ok_or_else(|| eyre!("Elasticsearch did not return an API key"))?;
@@ -450,6 +435,14 @@ impl LocalState {
         }
     }
 
+    #[cfg(not(feature = "setup"))]
+    async fn native_setup(&self) -> Result<()> {
+        Err(eyre!(
+            "Native local-stack setup requires an ESDiag binary built with the setup feature."
+        ))
+    }
+
+    #[cfg(feature = "setup")]
     async fn native_setup(&self) -> Result<()> {
         let apikey = self.required("ESDIAG_OUTPUT_APIKEY")?.to_string();
         let elasticsearch = KnownHostBuilder::new(Url::parse(&self.elasticsearch_url())?)
@@ -605,9 +598,9 @@ impl LocalState {
         }
     }
 
-    fn auth(&self) -> Result<()> {
-        self.wait_elasticsearch()?;
-        self.wait_kibana()
+    async fn auth(&self) -> Result<()> {
+        self.wait_elasticsearch().await?;
+        self.wait_kibana().await
     }
 
     fn reset(&mut self, force: bool) -> Result<()> {
@@ -706,46 +699,52 @@ impl LocalState {
             .ok_or_else(|| eyre!("{runtime} compose command failed"))
     }
 
-    fn wait_elasticsearch(&self) -> Result<()> {
+    async fn wait_elasticsearch(&self) -> Result<()> {
         self.wait_url(
             &self.elasticsearch_url(),
             Some(("elastic", self.required("ELASTIC_PASSWORD")?)),
         )
+        .await
     }
 
-    fn wait_kibana(&self) -> Result<()> {
+    async fn wait_kibana(&self) -> Result<()> {
         let url = format!("{}/api/status", self.kibana_url());
-        let client = reqwest::blocking::Client::new();
+        let client = reqwest::Client::builder().timeout(Duration::from_secs(5)).build()?;
         for _ in 0..60 {
-            if let Ok(response) = client.get(&url).send()
+            if let Ok(response) = client.get(&url).send().await
                 && response.status().is_success()
                 && response
                     .json::<serde_json::Value>()
+                    .await
                     .is_ok_and(|response| kibana_is_available(&response))
             {
                 return Ok(());
             }
-            thread::sleep(Duration::from_secs(2));
+            tokio::time::sleep(Duration::from_secs(2)).await;
         }
         Err(eyre!("Timed out waiting for Kibana to become available at {url}"))
     }
 
-    fn wait_url(&self, url: &str, auth: Option<(&str, &str)>) -> Result<()> {
-        let client = reqwest::blocking::Client::new();
+    async fn wait_url(&self, url: &str, auth: Option<(&str, &str)>) -> Result<()> {
+        let client = reqwest::Client::builder().timeout(Duration::from_secs(5)).build()?;
         for _ in 0..60 {
             let request = client.get(url);
             let request = match auth {
                 Some((username, password)) => request.basic_auth(username, Some(password)),
                 None => request,
             };
-            if request
-                .send()
-                .and_then(reqwest::blocking::Response::error_for_status)
-                .is_ok()
-            {
-                return Ok(());
+            if let Ok(response) = request.send().await {
+                let status = response.status();
+                if local_endpoint_ready(status, auth.is_some()) {
+                    return Ok(());
+                }
+                if auth.is_some() && matches!(status.as_u16(), 401 | 403) {
+                    return Err(eyre!(
+                        "Authentication failed at {url} (HTTP {status}); check the retained local credentials."
+                    ));
+                }
             }
-            thread::sleep(Duration::from_secs(2));
+            tokio::time::sleep(Duration::from_secs(2)).await;
         }
         Err(eyre!("Timed out waiting for {url}"))
     }
@@ -1011,5 +1010,71 @@ mod tests {
         assert!(kibana_is_available(&serde_json::json!({
             "status": {"overall": {"level": "available"}}
         })));
+    }
+}
+
+fn local_endpoint_ready(status: reqwest::StatusCode, authenticated: bool) -> bool {
+    status.is_success() || (!authenticated && status == reqwest::StatusCode::UNAUTHORIZED)
+}
+
+#[cfg(test)]
+mod onboarding_recovery_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn readiness_requests_run_inside_the_async_lifecycle() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            for _ in 0..2 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut buffer = [0; 4096];
+                socket.read(&mut buffer).await.unwrap();
+                socket
+                    .write_all(b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                    .await
+                    .unwrap();
+            }
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let state = LocalState::load(dir.path().into()).unwrap();
+        assert!(state.wait_url(&url, None).await.is_ok());
+        let error = state
+            .wait_url(&url, Some(("elastic", "bad-test-password")))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("Authentication failed"));
+        server.await.unwrap();
+    }
+
+    #[test]
+    fn service_reachability_does_not_mask_bad_elasticsearch_credentials() {
+        assert!(local_endpoint_ready(reqwest::StatusCode::OK, true));
+        assert!(local_endpoint_ready(reqwest::StatusCode::UNAUTHORIZED, false));
+        assert!(!local_endpoint_ready(reqwest::StatusCode::UNAUTHORIZED, true));
+        assert!(!local_endpoint_ready(reqwest::StatusCode::SERVICE_UNAVAILABLE, false));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn failed_startup_retains_recovery_files() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = dir.path().join("runtime");
+        fs::write(
+            &runtime,
+            "#!/bin/sh\ncase \"$*\" in\n  'compose version') exit 0;;\n  *) exit 1;;\nesac\n",
+        )
+        .unwrap();
+        fs::set_permissions(&runtime, fs::Permissions::from_mode(0o700)).unwrap();
+        let state_dir = dir.path().join("state");
+        let mut state = LocalState::load(state_dir.clone()).unwrap();
+        let mut options = LocalOptions::parse(&[]).unwrap();
+        options.runtime = Some(runtime.to_string_lossy().into_owned());
+        assert!(state.up(options).await.is_err());
+        let env = fs::read_to_string(state_dir.join(".env")).unwrap();
+        assert!(parse_env(&env).unwrap().contains_key("ELASTIC_PASSWORD"));
+        assert!(state_dir.join("compose.yml").exists());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4675,7 +4675,7 @@ fn safe_output_display(uri: &Uri) -> String {
         | Uri::ElasticGovCloudAdmin(host) => host
             .concrete_url()
             .map(|url| safe_output_display(&Uri::Url(url.clone())))
-            .unwrap_or_default(),
+            .unwrap_or_else(|| host.transport_display()),
         Uri::Url(url) | Uri::ServiceLink(url) | Uri::ServiceLinkNoAuth(url) => {
             let mut url = url.clone();
             let _ = url.set_username("");

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,6 +177,9 @@ enum Commands {
     /// Interactively configure a repeatable local diagnostic workflow
     Init,
     /// Manage a local Elasticsearch, Kibana, and ESDiag deployment
+    #[command(
+        after_help = "Commands: up, down, restart, status, logs, setup, open, auth, secrets, reset.\nRun esdiag local help for usage."
+    )]
     Local {
         /// Local-stack command and options
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -946,6 +949,17 @@ fn execution_process_result(outcome: &esdiag::job::outcome::ExecutionOutcome) ->
                     id: report.diagnostic.metadata.id.clone(),
                     product: report.diagnostic.display_label(),
                     documents: report.diagnostic.docs.created,
+                    documents_failed: report.diagnostic.docs.errors,
+                    outcome: report.outcome(),
+                    indexing_failures: report
+                        .rejected_indices()
+                        .into_iter()
+                        .map(|(index, documents_failed)| esdiag::cli_output::IndexingFailure {
+                            index,
+                            documents_failed,
+                            category: "document_rejected",
+                        })
+                        .collect(),
                     duration_ms: child.runtime.unwrap_or_default(),
                     source: child.path.clone(),
                     output: String::new(),
@@ -967,6 +981,17 @@ fn execution_process_result(outcome: &esdiag::job::outcome::ExecutionOutcome) ->
             id: report.diagnostic.metadata.id.clone(),
             product: report.diagnostic.display_label(),
             documents: report.diagnostic.docs.created,
+            documents_failed: report.diagnostic.docs.errors,
+            outcome: report.outcome(),
+            indexing_failures: report
+                .rejected_indices()
+                .into_iter()
+                .map(|(index, documents_failed)| esdiag::cli_output::IndexingFailure {
+                    index,
+                    documents_failed,
+                    category: "document_rejected",
+                })
+                .collect(),
             duration_ms: report.diagnostic.processing_duration,
             source: "primary".to_string(),
             output: String::new(),
@@ -1459,6 +1484,14 @@ async fn run(cli: Cli, format: OutputFormat) -> Result<CommandResult> {
                 }
                 let input_uri = Uri::try_from(input)?;
                 let output_uri = Uri::try_from(output.clone())?;
+                let output_display = match output.as_deref() {
+                    Some(name) if KnownHost::get_known(&name.to_string()).is_some() => name.to_string(),
+                    None if std::env::var_os("ESDIAG_OUTPUT_URL").is_none() => esdiag::data::ApplicationConfig::load()?
+                        .output
+                        .default
+                        .unwrap_or_else(|| safe_output_display(&output_uri)),
+                    _ => safe_output_display(&output_uri),
+                };
                 let stdout_owned = matches!(output_uri, Uri::Stream);
                 if has_explicit_output {
                     ensure_uri_role(&output_uri, HostRole::Send, "process output")?;
@@ -1531,9 +1564,10 @@ async fn run(cli: Cli, format: OutputFormat) -> Result<CommandResult> {
                 if stdout_owned {
                     Ok(CommandResult::stream())
                 } else {
-                    let diagnostic = process
+                    let mut diagnostic = process
                         .map(|result| result.diagnostic)
                         .ok_or_else(|| eyre!("Process completed without a diagnostic report"))?;
+                    diagnostic.output = output_display;
                     #[cfg(feature = "agent")]
                     if let Some(prompt) = ask {
                         return run_agent_ask_for_output(
@@ -1570,17 +1604,15 @@ async fn run(cli: Cli, format: OutputFormat) -> Result<CommandResult> {
                     let uri = Uri::try_from(host)?;
                     let client = Client::try_from(uri)?;
                     tracing::info!("Setting up assets in {client}");
-                    setup::assets(&client).await?;
-                    Ok(CommandResult::outcome(CliOutcome::SetupCompleted {
-                        targets: vec![client.to_string()],
-                    }))
+                    let report = setup::assets_report(&client).await?;
+                    Ok(CommandResult::outcome(setup_outcome(vec![client.to_string()], report)))
                 } else {
                     tracing::debug!("Setting up assets with the resolved output deployment");
                     let deployment = OutputDeployment::resolve(None, true)?;
                     let es_uri = Uri::try_from(deployment.elasticsearch)?;
                     let es_client = Client::try_from(es_uri)?;
                     tracing::info!("Setting up assets in {es_client}");
-                    setup::assets(&es_client).await?;
+                    let mut report = setup::assets_report(&es_client).await?;
                     setup::ensure_agent_builder_license(&es_client).await?;
                     let kibana = deployment
                         .kibana
@@ -1588,10 +1620,13 @@ async fn run(cli: Cli, format: OutputFormat) -> Result<CommandResult> {
                     let kb_uri = Uri::try_from(kibana)?;
                     let kb_client = Client::try_from(kb_uri)?;
                     tracing::info!("Setting up Kibana assets in {kb_client}");
-                    setup::assets(&kb_client).await?;
-                    Ok(CommandResult::outcome(CliOutcome::SetupCompleted {
-                        targets: vec![es_client.to_string(), kb_client.to_string()],
-                    }))
+                    let kb_report = setup::assets_report(&kb_client).await?;
+                    report.failed_indices.extend(kb_report.failed_indices);
+                    report.warnings.extend(kb_report.warnings);
+                    Ok(CommandResult::outcome(setup_outcome(
+                        vec![es_client.to_string(), kb_client.to_string()],
+                        report,
+                    )))
                 }
             }
             #[cfg(feature = "keystore")]
@@ -2022,28 +2057,39 @@ fn prompt_missing_secret_value(prompt: &str) -> Result<String> {
     Ok(value)
 }
 
-fn prompt_confirm(message: &str) -> Result<bool> {
+fn parse_confirmation(answer: &str, default: bool) -> Option<bool> {
+    match answer.trim().to_ascii_lowercase().as_str() {
+        "" => Some(default),
+        "y" | "yes" => Some(true),
+        "n" | "no" => Some(false),
+        _ => None,
+    }
+}
+
+fn prompt_confirmation(message: &str, default: bool) -> Result<bool> {
     if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
         return Ok(false);
     }
-    print!("{message}");
-    std::io::stdout().flush()?;
-    let mut line = String::new();
-    std::io::stdin().read_line(&mut line)?;
-    let answer = line.trim().to_ascii_lowercase();
-    Ok(matches!(answer.as_str(), "y" | "yes"))
+    loop {
+        print!("{message}");
+        std::io::stdout().flush()?;
+        let mut line = String::new();
+        if std::io::stdin().read_line(&mut line)? == 0 {
+            return Err(eyre!("Input closed; run `esdiag init` again to resume."));
+        }
+        if let Some(answer) = parse_confirmation(&line, default) {
+            return Ok(answer);
+        }
+        println!("Enter y or n, or press Enter to accept the default.");
+    }
+}
+
+fn prompt_confirm(message: &str) -> Result<bool> {
+    prompt_confirmation(message, false)
 }
 
 fn prompt_confirm_default_yes(message: &str) -> Result<bool> {
-    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
-        return Ok(false);
-    }
-    print!("{message}");
-    std::io::stdout().flush()?;
-    let mut line = String::new();
-    std::io::stdin().read_line(&mut line)?;
-    let answer = line.trim().to_ascii_lowercase();
-    Ok(!matches!(answer.as_str(), "n" | "no"))
+    prompt_confirmation(message, true)
 }
 
 fn prompt_new_keystore_password() -> Result<String> {
@@ -2110,7 +2156,7 @@ async fn run_init_wizard() -> Result<CommandResult> {
     };
     if replace_user {
         save_user(prompt_with_default(
-            "Default diagnostic user",
+            "Diagnostic user, preferably your email address",
             &default_diagnostic_user(),
         )?)?;
     }
@@ -2121,6 +2167,12 @@ async fn run_init_wizard() -> Result<CommandResult> {
         }
         _ => prompt_onboarding_workflow()?,
     };
+    println!("Selected workflow: {}", workflow.as_str());
+    if let Some(previous) = config.workflow
+        && previous != workflow
+    {
+        println!("Workflow changed from {} to {}.", previous.as_str(), workflow.as_str());
+    }
     if config.workflow != Some(workflow) {
         save_workflow(workflow)?;
     }
@@ -2147,59 +2199,82 @@ async fn run_init_wizard() -> Result<CommandResult> {
         if !reuse_output {
             unlock_keystore(default_unlock_ttl())?;
             let keystore_password = get_password_for_secret_commands()?;
-            let (output_name, output_url, viewer_url, viewer_api_url, secret_id, auth) = match prompt_output_location()?
-            {
-                OutputLocation::Local => {
-                    let local_output = |preset: EsdiagLocalPreset| -> Result<_> {
-                        let apikey = preset.apikey.ok_or_else(|| {
+            let (output_name, output_url, viewer_url, viewer_name, secret_id, auth, output_client, viewer_client) = loop {
+                let (output_name, output_url, viewer_url, viewer_api_url, secret_id, auth) =
+                    match prompt_output_location()? {
+                        OutputLocation::Local => {
+                            let local_output = |preset: EsdiagLocalPreset| -> Result<_> {
+                                let apikey = preset.apikey.ok_or_else(|| {
                         eyre!(
                             "The local ESDiag deployment has no usable output API key. Run `esdiag local up` first, or select remote processing."
                         )
                     })?;
-                        Ok((
-                            "localhost".to_string(),
-                            Url::parse(&preset.elasticsearch_url)?,
-                            Url::parse(&preset.kibana_url)?,
-                            Url::parse(&preset.kibana_api_url)?,
-                            "localhost".to_string(),
-                            SecretAuth::apikey(apikey),
-                        ))
-                    };
-                    let existing = detected_esdiag_local_preset();
-                    let runtime_available = if existing.is_none() {
-                        match local::detected_runtime() {
-                            Some(runtime) => {
-                                println!("Detected container runtime: {runtime}");
+                                Ok((
+                                    "localhost".to_string(),
+                                    Url::parse(&preset.elasticsearch_url)?,
+                                    Url::parse(&preset.kibana_url)?,
+                                    Url::parse(&preset.kibana_api_url)?,
+                                    "localhost".to_string(),
+                                    SecretAuth::apikey(apikey),
+                                ))
+                            };
+                            let existing = detected_esdiag_local_preset();
+                            let runtime_available = if existing.is_none() {
+                                match local::detected_runtime() {
+                                    Some(runtime) => {
+                                        println!("Detected container runtime: {runtime}");
+                                        true
+                                    }
+                                    None => {
+                                        println!("No container runtime detected; cannot configure a local stack.");
+                                        false
+                                    }
+                                }
+                            } else {
                                 true
-                            }
-                            None => {
-                                println!("No container runtime detected; cannot configure a local stack.");
-                                false
+                            };
+                            let start_core = should_start_local_core_stack(
+                                existing.is_none(),
+                                runtime_available,
+                                || {
+                                    prompt_confirm(
+                                        "No local ESDiag deployment was detected. Start a local core stack now? [y/N]: ",
+                                    )
+                                },
+                            )?;
+                            let local_preset = match existing {
+                                Some(preset) => Some(preset),
+                                None if start_core => {
+                                    run_local_lifecycle(local_core_stack_start_args()).await?;
+                                    started_local_stack = true;
+                                    detected_esdiag_local_preset()
+                                }
+                                None => None,
+                            };
+                            match local_preset {
+                                Some(preset) => local_output(preset)?,
+                                None => {
+                                    if !prompt_confirm_default_yes(
+                                        "Configure a remote output deployment instead? [Y/n]: ",
+                                    )? {
+                                        return Err(eyre!(
+                                            "Local stack startup was declined. Select local output again to start it, or configure a remote output."
+                                        ));
+                                    }
+                                    let output_name = prompt_with_default("Remote output host name", "diagnostics")?;
+                                    let output_url = prompt_url_with_default(
+                                        "Remote output Elasticsearch URL",
+                                        "https://localhost:9200",
+                                    )?;
+                                    let viewer_url =
+                                        prompt_url_with_default("Remote output Kibana URL", "https://localhost:5601")?;
+                                    let secret_id = prompt_with_default("Remote output credential name", &output_name)?;
+                                    let auth = prompt_api_key("Remote output", None)?;
+                                    (output_name, output_url, viewer_url.clone(), viewer_url, secret_id, auth)
+                                }
                             }
                         }
-                    } else {
-                        true
-                    };
-                    let start_core = should_start_local_core_stack(existing.is_none(), runtime_available, || {
-                        prompt_confirm("No local ESDiag deployment was detected. Start a local core stack now? [y/N]: ")
-                    })?;
-                    let local_preset = match existing {
-                        Some(preset) => Some(preset),
-                        None if start_core => {
-                            run_local_lifecycle(local_core_stack_start_args()).await?;
-                            started_local_stack = true;
-                            detected_esdiag_local_preset()
-                        }
-                        None => None,
-                    };
-                    match local_preset {
-                        Some(preset) => local_output(preset)?,
-                        None => {
-                            if !prompt_confirm_default_yes("Configure a remote output deployment instead? [Y/n]: ")? {
-                                return Err(eyre!(
-                                    "Local stack startup was declined. Select local output again to start it, or configure a remote output."
-                                ));
-                            }
+                        OutputLocation::Remote => {
                             let output_name = prompt_with_default("Remote output host name", "diagnostics")?;
                             let output_url =
                                 prompt_url_with_default("Remote output Elasticsearch URL", "https://localhost:9200")?;
@@ -2209,35 +2284,43 @@ async fn run_init_wizard() -> Result<CommandResult> {
                             let auth = prompt_api_key("Remote output", None)?;
                             (output_name, output_url, viewer_url.clone(), viewer_url, secret_id, auth)
                         }
+                    };
+                let viewer_name = format!("{output_name}-kb");
+                let output_client = Client::try_from(Uri::try_from(esdiag::onboarding::output_validation_host(
+                    output_url.clone(),
+                    Application::Elasticsearch,
+                    auth.clone(),
+                )?)?)?;
+                let viewer_client = Client::try_from(Uri::try_from(esdiag::onboarding::output_validation_host(
+                    viewer_api_url,
+                    Application::Kibana,
+                    auth.clone(),
+                )?)?)?;
+                let output_result = validate_onboarding_endpoint(&output_client).await;
+                let viewer_result = validate_onboarding_endpoint(&viewer_client).await;
+                for (name, result) in [("Elasticsearch", &output_result), ("Kibana", &viewer_result)] {
+                    if let Err(error) = result {
+                        eprintln!("{name} output validation failed: {}.", endpoint_failure_reason(error));
                     }
                 }
-                OutputLocation::Remote => {
-                    let output_name = prompt_with_default("Remote output host name", "diagnostics")?;
-                    let output_url =
-                        prompt_url_with_default("Remote output Elasticsearch URL", "https://localhost:9200")?;
-                    let viewer_url = prompt_url_with_default("Remote output Kibana URL", "https://localhost:5601")?;
-                    let secret_id = prompt_with_default("Remote output credential name", &output_name)?;
-                    let auth = prompt_api_key("Remote output", None)?;
-                    (output_name, output_url, viewer_url.clone(), viewer_url, secret_id, auth)
+                if ensure_output_deployment_valid(output_result.is_ok(), viewer_result.is_ok()).is_err() {
+                    eprintln!("Existing output configuration was not changed.");
+                    if prompt_confirm_default_yes("Re-enter output endpoints and credentials? [Y/n]: ")? {
+                        continue;
+                    }
+                    return Err(eyre!("Output validation failed. Run `esdiag init` again to resume."));
                 }
+                break (
+                    output_name,
+                    output_url,
+                    viewer_url,
+                    viewer_name,
+                    secret_id,
+                    auth,
+                    output_client,
+                    viewer_client,
+                );
             };
-            let viewer_name = format!("{output_name}-kb");
-            let output_candidate = KnownHostBuilder::new(output_url.clone())
-                .application(Application::Elasticsearch)
-                .roles(vec![HostRole::Send])
-                .viewer(Some(viewer_name.clone()))
-                .secret(Some(secret_id.clone()))
-                .build_with_secret_auth(auth.clone())?;
-            let viewer_candidate = KnownHostBuilder::new(viewer_api_url)
-                .application(Application::Kibana)
-                .roles(vec![HostRole::View])
-                .secret(Some(secret_id.clone()))
-                .build_with_secret_auth(auth.clone())?;
-            let output_client = Client::try_from(Uri::try_from(output_candidate)?)?;
-            let output_valid = output_client.test_connection().await.is_ok();
-            let viewer_client = Client::try_from(Uri::try_from(viewer_candidate)?)?;
-            let viewer_valid = viewer_client.test_connection().await.is_ok();
-            ensure_output_deployment_valid(output_valid, viewer_valid)?;
             confirm_output_replacement(&output_name, &viewer_name, &secret_id, &keystore_password)?;
             output_name_for_defaults = Some(output_name.clone());
             output_url_for_defaults = Some(output_url.to_string());
@@ -2334,7 +2417,7 @@ async fn run_init_wizard() -> Result<CommandResult> {
     if workflow.collects_diagnostics() {
         let collect_host_default =
             most_recent_collect_host.ok_or_else(|| eyre!("Add a collect host before creating the default job"))?;
-        let collect_host = prompt_with_default("Collect host for the default job", &collect_host_default)?;
+        let collect_host = prompt_collect_host(&collect_host_default)?;
         let collect_job_name = format!("{collect_host}-collect");
         let collect_job = esdiag::data::Job::builder()
             .collect_from(collect_host.clone())?
@@ -2387,6 +2470,46 @@ fn ensure_output_deployment_valid(elasticsearch_valid: bool, kibana_valid: bool)
         (true, false) => Err(eyre!(
             "The selected Kibana output endpoint could not be validated. Existing output configuration was not changed."
         )),
+    }
+}
+
+fn endpoint_failure_reason(error: &str) -> &'static str {
+    let error = error.to_ascii_lowercase();
+    if error.contains("401") || error.contains("403") {
+        "authentication or permission denied; check the API key and its privileges"
+    } else if error.contains("certificate") || error.contains("tls") || error.contains("ssl") {
+        "TLS verification failed; check the certificate and URL"
+    } else if error.contains("dns") || error.contains("resolve") {
+        "DNS lookup failed; check the hostname"
+    } else if error.contains("timed out") || error.contains("timeout") {
+        "connection timed out; check the hostname, port, and network access"
+    } else if error.contains("connect") || error.contains("sending request") {
+        "connection failed; check the hostname, port, and network access"
+    } else {
+        "unexpected response; check that the URL points to the correct Elastic application"
+    }
+}
+
+async fn validate_onboarding_endpoint(client: &Client) -> std::result::Result<String, String> {
+    tokio::time::timeout(Duration::from_secs(20), client.test_connection())
+        .await
+        .unwrap_or_else(|_| Err("connection timed out".to_string()))
+}
+
+fn prompt_collect_host(default: &str) -> Result<String> {
+    let hosts = KnownHost::parse_hosts_yml()?;
+    let names = hosts
+        .iter()
+        .filter(|(_, host)| host.has_role(HostRole::Collect) && !host.is_template())
+        .map(|(name, _)| name.as_str())
+        .collect::<Vec<_>>();
+    println!("Saved collection hosts: {}", names.join(", "));
+    loop {
+        let name = prompt_with_default("Saved host name for the default job", default)?;
+        if names.contains(&name.as_str()) {
+            return Ok(name);
+        }
+        println!("Choose a saved collection host name from the list above. A URL cannot be used here.");
     }
 }
 
@@ -2499,7 +2622,7 @@ fn run_optional_agent_skill_stage() -> Result<AgentSkillsResult> {
     let prompt = if detected_names.is_empty() {
         "No supported coding-agent home was detected. Install the embedded ESDiag skill now? [y/N]: ".to_string()
     } else {
-        format!("Install the embedded ESDiag skill for detected targets ({detected_names})? [y/N]: ")
+        format!("Detected coding agents: {detected_names}. Install the embedded ESDiag skill? [y/N]: ")
     };
     if !prompt_confirm(&prompt)? {
         return Ok(AgentSkillsResult {
@@ -2542,7 +2665,9 @@ fn prompt_agent_skill_targets(detected: &[SkillTarget]) -> Result<Vec<SkillTarge
     );
     std::io::stdout().flush()?;
     let mut line = String::new();
-    std::io::stdin().read_line(&mut line)?;
+    if std::io::stdin().read_line(&mut line)? == 0 {
+        return Err(eyre!("Input closed; run `esdiag init` again to resume."));
+    }
     let targets = if line.trim().is_empty() {
         detected.to_vec()
     } else {
@@ -2565,23 +2690,32 @@ fn prompt_agent_skill_targets(detected: &[SkillTarget]) -> Result<Vec<SkillTarge
 }
 
 fn prompt_required(message: &str) -> Result<String> {
-    print!("{message}");
-    std::io::stdout().flush()?;
-    let mut line = String::new();
-    std::io::stdin().read_line(&mut line)?;
-    let value = line.trim().to_string();
-    if value.is_empty() {
-        return Err(eyre!("A value is required."));
+    loop {
+        print!("{message}");
+        std::io::stdout().flush()?;
+        let mut line = String::new();
+        if std::io::stdin().read_line(&mut line)? == 0 {
+            return Err(eyre!("Input closed; run `esdiag init` again to resume."));
+        }
+        let value = line.trim();
+        if !value.is_empty() {
+            return Ok(value.to_string());
+        }
+        println!("A value is required. Please try again.");
     }
-    Ok(value)
 }
 
 fn prompt_with_default(message: &str, default: &str) -> Result<String> {
     print!("{message} [{default}]: ");
     std::io::stdout().flush()?;
     let mut line = String::new();
-    std::io::stdin().read_line(&mut line)?;
+    if std::io::stdin().read_line(&mut line)? == 0 {
+        return Err(eyre!("Input closed; run `esdiag init` again to resume."));
+    }
     let value = line.trim();
+    if value.is_empty() && default.is_empty() {
+        return prompt_required(&format!("{message}: "));
+    }
     Ok(if value.is_empty() {
         default.to_string()
     } else {
@@ -2590,7 +2724,20 @@ fn prompt_with_default(message: &str, default: &str) -> Result<String> {
 }
 
 fn prompt_url_with_default(message: &str, default: &str) -> Result<Url> {
-    Url::parse(&prompt_with_default(message, default)?).map_err(Into::into)
+    loop {
+        let value = prompt_with_default(message, default)?;
+        match Url::parse(&value) {
+            Ok(url)
+                if matches!(url.scheme(), "http" | "https")
+                    && url.host_str().is_some()
+                    && url.username().is_empty()
+                    && url.password().is_none() =>
+            {
+                return Ok(url);
+            }
+            _ => println!("Enter an HTTP or HTTPS URL without embedded credentials."),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -2715,7 +2862,9 @@ fn prompt_api_key(label: &str, local_preset: Option<&EsdiagLocalPreset>) -> Resu
         println!("{label} API key source:");
         println!("  1. Read from a file");
         println!("  2. Read from an environment variable");
-        println!("  3. Read from detected esdiag-local configuration");
+        if default == "3" {
+            println!("  3. Read from detected esdiag-local configuration");
+        }
         println!("  4. Paste securely");
         let source = prompt_with_default("Selection", default)?;
         let apikey = match source.as_str() {
@@ -2728,7 +2877,7 @@ fn prompt_api_key(label: &str, local_preset: Option<&EsdiagLocalPreset>) -> Resu
                 .and_then(|preset| preset.apikey.clone())
                 .ok_or_else(|| eyre!("No usable ESDiag local API key was detected")),
             "4" | "paste" => prompt_missing_secret_value(&format!("Enter {label} API key: ")),
-            _ => Err(eyre!("Choose API key source 1, 2, 3, or 4")),
+            _ => Err(eyre!("Choose one of the listed API key sources")),
         };
         let apikey = match apikey {
             Ok(apikey) => apikey.trim().to_string(),
@@ -3028,9 +3177,7 @@ where
 {
     get_environment("EMAIL")
         .filter(|email| email.contains('@'))
-        .or_else(|| get_environment("USER"))
-        .or_else(|| get_environment("USERNAME"))
-        .unwrap_or_else(|| "user".to_string())
+        .unwrap_or_default()
 }
 
 fn format_epoch(epoch_seconds: i64) -> String {
@@ -3213,6 +3360,59 @@ fn resolve_serve_exporter(output: Option<String>) -> Result<Exporter> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn output_display_redacts_direct_and_resolved_url_credentials() {
+        let url = Url::parse("https://user:password@example.test:9200/path?token=secret#fragment").unwrap();
+        let direct = super::safe_output_display(&Uri::Url(url.clone()));
+        let host = super::KnownHostBuilder::new(url)
+            .application(Application::Elasticsearch)
+            .build()
+            .unwrap();
+        let resolved = super::safe_output_display(&Uri::KnownHost(host));
+        assert_eq!(direct, "https://example.test:9200/path");
+        assert_eq!(resolved, direct);
+    }
+    #[test]
+    fn confirmations_require_yes_or_no() {
+        assert_eq!(super::parse_confirmation("claude", false), None);
+        assert_eq!(super::parse_confirmation("typo", true), None);
+        assert_eq!(super::parse_confirmation("", false), Some(false));
+        assert_eq!(super::parse_confirmation("", true), Some(true));
+        assert_eq!(super::parse_confirmation(" YES ", false), Some(true));
+        assert_eq!(super::parse_confirmation("No", true), Some(false));
+    }
+
+    #[test]
+    fn endpoint_errors_are_actionable_without_echoing_response_secrets() {
+        for (error, expected) in [
+            ("HTTP 401 secret-value", "authentication"),
+            ("HTTP 403", "permission"),
+            ("TLS certificate error", "TLS"),
+            ("DNS lookup failed", "DNS"),
+            ("connection timed out", "timed out"),
+            ("connection refused", "connection failed"),
+            ("bad body secret-value", "unexpected response"),
+        ] {
+            let message = super::endpoint_failure_reason(error);
+            assert!(message.contains(expected));
+            assert!(!message.contains("secret-value"));
+        }
+    }
+
+    #[cfg(feature = "setup")]
+    #[test]
+    fn setup_outcome_reports_partial_mapping_updates() {
+        let outcome = super::setup_outcome(
+            vec!["elasticsearch".into()],
+            esdiag::setup::SetupReport {
+                failed_indices: vec!["metrics-test-esdiag".into()],
+                warnings: vec!["Raise index.mapping.total_fields.limit".into()],
+            },
+        );
+        let value = serde_json::to_value(outcome).unwrap();
+        assert_eq!(value["outcome"], "partial");
+        assert_eq!(value["failed_indices"][0], "metrics-test-esdiag");
+    }
     #[cfg(feature = "agent")]
     use super::{
         AgentCommands, AgentSkillTarget, SkillInstallationFailure, agent_builder_space, install_skill_targets,
@@ -3537,7 +3737,7 @@ mod tests {
         });
 
         assert_eq!(email, "operator@example.com");
-        assert_eq!(user, "shell-user");
+        assert_eq!(user, "");
     }
 
     #[test]
@@ -4454,5 +4654,36 @@ mod desktop_startup_tests {
 
         server.shutdown().await;
         drop(occupied_listener);
+    }
+}
+
+#[cfg(feature = "setup")]
+fn setup_outcome(targets: Vec<String>, report: setup::SetupReport) -> CliOutcome {
+    CliOutcome::SetupCompleted {
+        targets,
+        outcome: if report.is_complete() { "complete" } else { "partial" }.to_string(),
+        failed_indices: report.failed_indices,
+        warnings: report.warnings,
+    }
+}
+
+fn safe_output_display(uri: &Uri) -> String {
+    match uri {
+        Uri::KnownHost(host)
+        | Uri::ElasticCloud(host)
+        | Uri::ElasticCloudAdmin(host)
+        | Uri::ElasticGovCloudAdmin(host) => host
+            .concrete_url()
+            .map(|url| safe_output_display(&Uri::Url(url.clone())))
+            .unwrap_or_default(),
+        Uri::Url(url) | Uri::ServiceLink(url) | Uri::ServiceLinkNoAuth(url) => {
+            let mut url = url.clone();
+            let _ = url.set_username("");
+            let _ = url.set_password(None);
+            url.set_query(None);
+            url.set_fragment(None);
+            url.to_string()
+        }
+        _ => uri.to_string(),
     }
 }

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -58,6 +58,20 @@ pub struct CollectHostInput {
     pub auth: Option<SecretAuth>,
 }
 
+/// Build a transient validation target without resolving an unsaved secret.
+/// Persisted hosts are built separately and contain only a keystore reference.
+pub fn output_validation_host(url: Url, app: Application, auth: SecretAuth) -> Result<KnownHost> {
+    let mut host = KnownHostBuilder::new(url).application(app).build()?;
+    match auth {
+        SecretAuth::ApiKey { apikey } => host.legacy_apikey = Some(apikey),
+        SecretAuth::Basic { username, password } => {
+            host.legacy_username = Some(username);
+            host.legacy_password = Some(password);
+        }
+    }
+    Ok(host)
+}
+
 pub fn inspect() -> Result<OnboardingReadiness> {
     let config = ApplicationConfig::load()?;
     let hosts = KnownHost::parse_hosts_yml()?;
@@ -243,6 +257,28 @@ fn validate_name(name: &str, kind: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    #[tokio::test]
+    async fn validation_uses_unsaved_credentials_without_reading_or_writing_keystore() {
+        let _env = crate::TestEnv::new();
+        for app in [
+            crate::data::Application::Elasticsearch,
+            crate::data::Application::Kibana,
+        ] {
+            let host = super::output_validation_host(
+                url::Url::parse("http://127.0.0.1:9200").unwrap(),
+                app,
+                crate::data::SecretAuth::apikey("new-unsaved-key"),
+            )
+            .unwrap();
+            assert!(host.secret.is_none());
+            let serialized = yaml_serde::to_string(&host).unwrap();
+            assert!(!serialized.contains("new-unsaved-key"));
+            let uri = crate::data::Uri::try_from(host).unwrap();
+            assert!(crate::client::Client::try_from(uri).is_ok());
+            assert!(!crate::data::keystore_exists().unwrap());
+        }
+    }
+
     use super::{
         CollectHostInput, OnboardingReadiness, OutputDeploymentInput, inspect, save_collect_host, save_default_job,
         save_default_processing_job, save_output_deployment, save_user, save_workflow,

--- a/src/processor/diagnostic/report.rs
+++ b/src/processor/diagnostic/report.rs
@@ -456,6 +456,19 @@ impl DiagnosticReport {
         &self.diagnostic.events
     }
 
+    pub fn rejected_indices(&self) -> Vec<(String, u32)> {
+        let mut indices = self
+            .diagnostic
+            .processor
+            .stats
+            .values()
+            .filter(|summary| summary.doc_errors > 0)
+            .map(|summary| (summary.index.clone(), summary.doc_errors))
+            .collect::<Vec<_>>();
+        indices.sort();
+        indices
+    }
+
     pub fn add_identifiers(&mut self, identifiers: Identifiers) {
         self.diagnostic.identifiers = identifiers;
     }
@@ -1200,6 +1213,27 @@ user: ada
         assert_eq!(summary.events.len(), 2);
         assert!(summary.events.iter().all(|e| e.severity == EventSeverity::Error));
         assert!(summary.events.iter().any(|e| e.reason.contains("boom")));
+    }
+
+    #[test]
+    fn rejected_documents_retain_index_counts_and_partial_outcome() {
+        let metadata = DiagnosticMetadata {
+            id: "test".into(),
+            collection_date: 0,
+            runner: "test".into(),
+            uuid: "test".into(),
+        };
+        let mut report =
+            DiagnosticReport::try_from(DiagnosticReportBuilder::from(metadata).receiver("file path".into())).unwrap();
+        let mut summary = ProcessorSummary::new("metrics-test-esdiag".into());
+        let mut batch = BatchResponse::new(10);
+        batch.errors = 3;
+        batch.status_code = 200;
+        summary.add_batch(batch);
+        report.add_processor_summary(summary.was_parsed());
+        assert_eq!(report.outcome(), DiagnosticOutcome::Partial);
+        assert_eq!(report.diagnostic.docs.errors, 3);
+        assert_eq!(report.rejected_indices(), vec![("metrics-test-esdiag".into(), 3)]);
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -386,11 +386,20 @@ impl SetupReport {
 pub async fn assets(client: &Client) -> Result<()> {
     let report = assets_report(client).await?;
     if !report.is_complete() {
-        return Err(eyre!(
-            "Asset installation was partial. These indices could not be updated: {}. {}",
-            report.failed_indices.join(", "),
-            report.warnings.join(" ")
-        ));
+        let failed_indices = if report.failed_indices.is_empty() {
+            String::new()
+        } else {
+            format!(
+                " These indices could not be updated: {}.",
+                report.failed_indices.join(", ")
+            )
+        };
+        let warnings = if report.warnings.is_empty() {
+            String::new()
+        } else {
+            format!(" {}", report.warnings.join(" "))
+        };
+        return Err(eyre!("Asset installation was partial.{}{}", failed_indices, warnings));
     }
     Ok(())
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -387,8 +387,8 @@ pub async fn assets(client: &Client) -> Result<()> {
     let report = assets_report(client).await?;
     if !report.is_complete() {
         return Err(eyre!(
-            "Asset installation was partial. {} indices could not be updated. {}",
-            report.failed_indices.len(),
+            "Asset installation was partial. These indices could not be updated: {}. {}",
+            report.failed_indices.join(", "),
             report.warnings.join(" ")
         ));
     }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -210,10 +210,9 @@ fn provenance_mapping_warnings(properties: &Value) -> Vec<String> {
 /// Templates only govern indices created after they are installed, so this is the
 /// other half of the bridge: without it a dashboard querying the current field
 /// name silently matches nothing in historical indices. Failures are reported and
-/// not fatal — an index that cannot take a mapping update (closed, frozen, or
-/// write-blocked) costs one index's worth of legacy-name resolution, which is no
-/// reason to fail installing the assets.
-async fn install_provenance_aliases(client: &Client) -> Result<()> {
+/// returned to the caller so the CLI can report partial installation while
+/// allowing the remaining assets to be installed.
+async fn install_provenance_aliases(client: &Client) -> Result<Vec<String>> {
     let headers = default_headers();
     let path = format!("/{ESDIAG_INDEX_PATTERN}/_mapping?ignore_unavailable=true&allow_no_indices=true");
     let response = client.request(Method::GET, &headers, &path, None).await?;
@@ -239,10 +238,10 @@ async fn install_provenance_aliases(client: &Client) -> Result<()> {
     let patches = provenance_alias_patches(&mappings);
     if patches.is_empty() {
         tracing::debug!("No pre-rename ESDiag indices need a provenance alias");
-        return Ok(());
+        return Ok(vec![]);
     }
 
-    let mut failures = 0;
+    let mut failures = Vec::new();
     for (index, patch) in &patches {
         let body = serde_json::to_vec(patch)?;
         let result = client
@@ -250,13 +249,10 @@ async fn install_provenance_aliases(client: &Client) -> Result<()> {
             .await;
         match result {
             Ok(response) if response.status().is_success() => {
-                tracing::info!("Aliased the current provenance names onto {index}");
-                tracing::warn!(
-                    "{index}: added query-only provenance aliases; roll over the data stream after setup before mixing writer versions"
-                );
+                tracing::debug!("Aliased the current provenance names onto {index}");
             }
             Ok(response) => {
-                failures += 1;
+                failures.push(index.clone());
                 tracing::warn!(
                     "Could not add the provenance alias to {index}: {} {}",
                     response.status(),
@@ -264,7 +260,7 @@ async fn install_provenance_aliases(client: &Client) -> Result<()> {
                 );
             }
             Err(err) => {
-                failures += 1;
+                failures.push(index.clone());
                 tracing::warn!("Could not add the provenance alias to {index}: {err}");
             }
         }
@@ -272,10 +268,15 @@ async fn install_provenance_aliases(client: &Client) -> Result<()> {
 
     tracing::info!(
         "Bridged provenance field names on {} of {} pre-rename indices",
-        patches.len() - failures,
+        patches.len() - failures.len(),
         patches.len()
     );
-    Ok(())
+    if patches.len() > failures.len() {
+        tracing::warn!(
+            "Added query-only provenance aliases. Roll over the affected data streams after setup before mixing writer versions."
+        );
+    }
+    Ok(failures)
 }
 
 fn should_skip_asset(asset: &Asset, security_assets_supported: bool) -> bool {
@@ -368,11 +369,38 @@ async fn send_asset_with_allowed_statuses(
     }
 }
 
-/// Submit saved assets to the client APIs
+/// Mapping updates that could not be completed after asset installation.
+#[derive(Default)]
+pub struct SetupReport {
+    pub failed_indices: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+impl SetupReport {
+    pub fn is_complete(&self) -> bool {
+        self.failed_indices.is_empty() && self.warnings.is_empty()
+    }
+}
+
+/// Install assets, requiring complete mapping updates before returning success.
 pub async fn assets(client: &Client) -> Result<()> {
+    let report = assets_report(client).await?;
+    if !report.is_complete() {
+        return Err(eyre!(
+            "Asset installation was partial. {} indices could not be updated. {}",
+            report.failed_indices.len(),
+            report.warnings.join(" ")
+        ));
+    }
+    Ok(())
+}
+
+pub async fn assets_report(client: &Client) -> Result<SetupReport> {
+    let mut report = SetupReport::default();
     let embedded_assets = EmbeddedAssets::new()?;
     if Application::from(client) == Application::Kibana {
-        return kibana_assets(client, &embedded_assets).await;
+        kibana_assets(client, &embedded_assets).await?;
+        return Ok(report);
     }
 
     // load asset list from ./assets/{product}/assets.yml
@@ -446,15 +474,22 @@ pub async fn assets(client: &Client) -> Result<()> {
     // with (ADR-0014). Elasticsearch owns those indices, so the bridge is only
     // meaningful there — asking any other product for its mappings would warn
     // about a call that never made sense.
-    if matches!(client, Client::Elasticsearch(_))
-        && let Err(err) = install_provenance_aliases(client).await
-    {
-        tracing::warn!("Could not bridge provenance field names on existing ESDiag indices: {err}");
+    if matches!(client, Client::Elasticsearch(_)) {
+        match install_provenance_aliases(client).await {
+            Ok(indices) => report.failed_indices = indices,
+            Err(err) => {
+                tracing::warn!("Could not bridge provenance field names on existing ESDiag indices: {err}");
+                report.warnings.push("Could not inspect or update existing index mappings. Check connectivity and mapping privileges, then rerun setup.".to_string());
+            }
+        }
+        if !report.failed_indices.is_empty() {
+            report.warnings.push("Check the failed indices for mapping limits or write blocks. For a total-fields-limit error, raise index.mapping.total_fields.limit, then rerun setup.".to_string());
+        }
     }
 
     if error_count == 0 {
-        tracing::info!("completed setup for {client}");
-        Ok(())
+        tracing::info!("finished asset installation for {client}");
+        Ok(report)
     } else {
         tracing::error!("{error_count} errors in setup for {client}");
         Err(eyre!("{error_count} errors in setup for {client}"))


### PR DESCRIPTION
## Summary

- Fix `init` secure paste so a new credential is validated in memory before it is saved.
- Retry invalid confirmations, URLs, endpoint credentials, and saved-host selections with actionable errors.
- Preserve local-stack state after startup failures and keep readiness checks async-safe.
- Report partial processing and setup outcomes, including rejected documents, affected indices, and recovery guidance.

Addresses elastic/esdiag-dev#75.

## Validation

- Ironhide: 560 library tests, 77 CLI tests, and the keystore, host, agent, and Serverless setup integration suites passed.
- Ironhide: minimal-feature build passed.
- Ironhide: interactive onboarding, invalid-input recovery, secure paste, retained-state retry, partial processing, and partial setup checks passed.
