### PR TITLE
Fix remaining init onboarding startup failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ published release notes, maintenance branches, and tagged history.
 
 ### Changed
 
+- Changed local startup to retry transient Elasticsearch authentication failures while security initializes.
+- Changed the managed native server to use local output credentials and report early exits with a log path.
+- Changed onboarding to return to output selection when replacement is declined.
+- Changed API key source menus to use consecutive numbering when local credentials are unavailable.
+- Changed endpoint validation to distinguish network failures using the underlying error chain.
+- Changed duplicate keystore-secret failures to report the `conflict` outcome category.
 - Changed onboarding to show workflow changes when resuming and changing a saved workflow.
 - Changed onboarding to offer only available credential sources.
 - Changed onboarding to prompt for a diagnostic user without defaulting to the shell username.

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -184,6 +184,14 @@ to inspect the failure, retry `up`, or stop the stack with `down`. Include
 the same `--state-dir` when using a custom directory. `secrets password`
 continues to read the retained password.
 
+During startup, Elasticsearch authentication failures are retried while its
+security index initializes. If authentication still fails when readiness times
+out, check the retained credentials. `local auth` reports rejected credentials
+immediately. The managed native server uses the local deployment's output and
+Kibana settings, overriding ambient `ESDIAG_OUTPUT_*` and `ESDIAG_KIBANA_*`
+variables. If that child exits during startup, `up` reports its exit status and
+log path without waiting for the readiness timeout.
+
 ```sh
 esdiag local up
 esdiag local status

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -84,6 +84,11 @@ Choose processing, then choose **remote**. The initializer saves the output
 host, linked Kibana viewer, and encrypted credentials. It also offers to
 install output assets.
 
+If validation fails, `init` identifies the endpoint and lets you re-enter its
+settings. Declining to replace an existing output returns to output selection
+without changing the saved deployment. API key source numbers depend on which
+sources are available; use the displayed number or type `paste`, `file`, or `env`.
+
 To configure the destination yourself:
 
 ```sh

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -415,6 +415,7 @@ pub struct AgentRecovery {
 #[serde(rename_all = "snake_case")]
 pub enum CliFailureCategory {
     InvalidInput,
+    Conflict,
     NotFound,
     AuthenticationFailed,
     CollectionFailed,
@@ -429,6 +430,7 @@ impl CliFailureCategory {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::InvalidInput => "invalid_input",
+            Self::Conflict => "conflict",
             Self::NotFound => "not_found",
             Self::AuthenticationFailed => "authentication_failed",
             Self::CollectionFailed => "collection_failed",

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -20,6 +20,46 @@ use eyre::{Result, eyre};
 use reqwest::Method;
 use std::collections::HashMap;
 
+// Inspect the whole transport error chain, but never expose URLs or credentials.
+fn connection_failure(error: &(dyn std::error::Error + 'static)) -> String {
+    let mut messages = Vec::new();
+    let mut cause = Some(error);
+    while let Some(error) = cause {
+        messages.push(error.to_string().to_ascii_lowercase());
+        cause = error.source();
+    }
+    let details = messages.join(" ");
+    if details.contains("dns") || details.contains("resolve") || details.contains("name or service not known") {
+        "DNS lookup failed"
+    } else if details.contains("certificate") || details.contains("tls") || details.contains("ssl") {
+        "TLS verification failed"
+    } else if details.contains("timed out") || details.contains("timeout") {
+        "connection timed out"
+    } else {
+        "connection failed"
+    }
+    .to_string()
+}
+
+#[cfg(test)]
+mod connection_failure_tests {
+    use super::connection_failure;
+
+    #[test]
+    fn classifies_nested_transport_errors_without_exposing_their_contents() {
+        for (cause, expected) in [
+            ("dns error: failed to lookup address", "DNS lookup failed"),
+            ("invalid peer certificate", "TLS verification failed"),
+            ("operation timed out", "connection timed out"),
+            ("tcp connect error", "connection failed"),
+        ] {
+            let error = eyre::Report::new(std::io::Error::other(format!("{cause}: api_key=secret")))
+                .wrap_err("Failed to send request");
+            assert_eq!(connection_failure(error.as_ref()), expected);
+        }
+    }
+}
+
 /// A standardized client for interacting with Elastic Stack APIs
 pub enum Client {
     Elasticsearch(ElasticsearchClient),
@@ -118,7 +158,7 @@ impl Client {
                         None,
                     )
                     .await
-                    .map_err(|e| format!("{e}"))?;
+                    .map_err(|e| connection_failure(&e))?;
 
                 let status = response.status_code();
                 if !status.is_success() {
@@ -137,7 +177,10 @@ impl Client {
                 }
             }
             Client::Kibana(client) => {
-                let response = client.test_connection().await.map_err(|e| format!("{e}"))?;
+                let response = client
+                    .test_connection()
+                    .await
+                    .map_err(|e| connection_failure(e.as_ref()))?;
                 let status = response.status();
                 if !status.is_success() {
                     return Err(format!("HTTP {status}"));
@@ -153,7 +196,10 @@ impl Client {
                 }
             }
             Client::Logstash(client) => {
-                let response = client.test_connection().await.map_err(|e| format!("{e}"))?;
+                let response = client
+                    .test_connection()
+                    .await
+                    .map_err(|e| connection_failure(e.as_ref()))?;
                 let status = response.status();
                 if !status.is_success() {
                     return Err(format!("HTTP {status}"));

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -29,7 +29,18 @@ fn connection_failure(error: &(dyn std::error::Error + 'static)) -> String {
         cause = error.source();
     }
     let details = messages.join(" ");
-    if details.contains("dns") || details.contains("resolve") || details.contains("name or service not known") {
+    if [
+        "dns error",
+        "dns lookup",
+        "failed to lookup address",
+        "name or service not known",
+        "could not resolve host",
+        "nodename nor servname",
+        "getaddrinfo",
+    ]
+    .iter()
+    .any(|marker| details.contains(marker))
+    {
         "DNS lookup failed"
     } else if details.contains("certificate") || details.contains("tls") || details.contains("ssl") {
         "TLS verification failed"
@@ -49,6 +60,7 @@ mod connection_failure_tests {
     fn classifies_nested_transport_errors_without_exposing_their_contents() {
         for (cause, expected) in [
             ("dns error: failed to lookup address", "DNS lookup failed"),
+            ("windows connection failure", "connection failed"),
             ("invalid peer certificate", "TLS verification failed"),
             ("operation timed out", "connection timed out"),
             ("tcp connect error", "connection failed"),

--- a/src/data/keystore.rs
+++ b/src/data/keystore.rs
@@ -693,6 +693,23 @@ pub fn get_password_for_secret_commands() -> Result<String> {
     )
 }
 
+#[derive(Debug)]
+pub struct SecretAlreadyExists {
+    pub secret_id: String,
+}
+
+impl std::fmt::Display for SecretAlreadyExists {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let id = &self.secret_id;
+        write!(
+            f,
+            "Secret '{id}' already exists. Replace its credential with `esdiag keystore update {id} --apikey` or `--user <username> --password`."
+        )
+    }
+}
+
+impl std::error::Error for SecretAlreadyExists {}
+
 pub fn add_secret(
     secret_id: &str,
     username: Option<String>,
@@ -703,9 +720,10 @@ pub fn add_secret(
     let auth = parse_secret_auth(username, password, apikey)?;
     let mut store = read_store(keystore_password)?;
     if store.secrets.contains_key(secret_id) {
-        return Err(eyre!(
-            "Secret '{secret_id}' already exists. Replace its credential with `esdiag keystore update {secret_id} --apikey` or `--user <username> --password`."
-        ));
+        return Err(SecretAlreadyExists {
+            secret_id: secret_id.to_string(),
+        }
+        .into());
     }
     store
         .secrets

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -31,11 +31,12 @@ pub(crate) use keystore::get_active_unlock_keystore_password;
 #[cfg(all(feature = "server", feature = "keystore"))]
 pub(crate) use keystore::list_secret_entries;
 pub use keystore::{
-    BasicSecret, SecretAuth, SecretEntry, UnlockLease, UnlockStatus, add_secret, authenticate, clear_unlock_lease,
-    create_keystore, default_unlock_ttl, get_keystore_password, get_keystore_path, get_password_for_secret_commands,
-    get_secret, get_unlock_path, get_unlock_status, keystore_exists, list_secret_names, parse_unlock_ttl,
-    read_unlock_lease, remove_secret, resolve_secret_auth, rotate_keystore_password, update_secret, upsert_secret_auth,
-    validate_existing_keystore_password, with_scoped_keystore_password, write_unlock_lease,
+    BasicSecret, SecretAlreadyExists, SecretAuth, SecretEntry, UnlockLease, UnlockStatus, add_secret, authenticate,
+    clear_unlock_lease, create_keystore, default_unlock_ttl, get_keystore_password, get_keystore_path,
+    get_password_for_secret_commands, get_secret, get_unlock_path, get_unlock_status, keystore_exists,
+    list_secret_names, parse_unlock_ttl, read_unlock_lease, remove_secret, resolve_secret_auth,
+    rotate_keystore_password, update_secret, upsert_secret_auth, validate_existing_keystore_password,
+    with_scoped_keystore_password, write_unlock_lease,
 };
 #[cfg(all(test, feature = "server"))]
 pub(crate) use known_host::write_hosts_yml_for_tests;

--- a/src/local.rs
+++ b/src/local.rs
@@ -4,7 +4,7 @@ use std::{
     ffi::OsString,
     fs,
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::{Child, Command, Stdio},
     time::Duration,
 };
 
@@ -244,18 +244,26 @@ impl LocalState {
         }
         self.compose(&["pull", "elasticsearch", "kibana"])?;
         self.compose(&["up", "-d", "elasticsearch", "kibana"])?;
-        self.wait_elasticsearch().await?;
+        self.wait_url_for_startup(
+            &self.elasticsearch_url(),
+            Some(("elastic", self.required("ELASTIC_PASSWORD")?)),
+            None,
+            true,
+        )
+        .await?;
         self.configure_security().await?;
         self.write()?;
         self.wait_kibana().await?;
         self.setup_mode(mode).await?;
-        if mode == StackMode::Full {
+        let mut native_child = if mode == StackMode::Full {
             self.stop_native_service()?;
             self.compose(&["up", "-d", "esdiag"])?;
+            None
         } else {
-            self.start_native_service()?;
-        }
-        self.wait_url(&self.esdiag_url(), None).await?;
+            Some(self.start_native_service()?)
+        };
+        self.wait_url_for_startup(&self.esdiag_url(), None, native_child.as_mut(), false)
+            .await?;
         self.values.insert("STACK_MODE".to_string(), mode.as_str().to_string());
         self.write()?;
         if self.open_browser {
@@ -461,11 +469,20 @@ impl LocalState {
         setup::assets(&kibana).await
     }
 
-    fn start_native_service(&self) -> Result<()> {
+    fn start_native_service(&self) -> Result<Child> {
         self.stop_native_service()?;
         let log = self.dir.join("logs/native-serve.log");
         let stdout = fs::File::create(&log)?;
-        let child = Command::new(std::env::current_exe()?)
+        let mut command = Command::new(std::env::current_exe()?);
+        // The managed deployment owns its output and viewer configuration.
+        // Other environment entries (PATH, HOME, proxy settings) remain available.
+        for (key, _) in std::env::vars_os() {
+            let name = key.to_string_lossy();
+            if name.starts_with("ESDIAG_OUTPUT_") || name.starts_with("ESDIAG_KIBANA_") {
+                command.env_remove(key);
+            }
+        }
+        let mut child = command
             .arg("serve")
             .arg("--mode")
             .arg("user")
@@ -480,6 +497,7 @@ impl LocalState {
             .stdout(Stdio::from(stdout.try_clone()?))
             .stderr(Stdio::from(stdout))
             .spawn()?;
+        self.check_native_child(&mut child)?;
         write_private(self.dir.join(".native-serve.pid"), &child.id().to_string())?;
         write_private(
             self.dir.join(".native-serve.binary"),
@@ -490,6 +508,17 @@ impl LocalState {
             &process_start_time(child.id() as i32)?
                 .ok_or_else(|| eyre!("Could not identify managed native ESDiag service"))?,
         )?;
+        Ok(child)
+    }
+
+    fn check_native_child(&self, child: &mut Child) -> Result<()> {
+        if let Some(status) = child.try_wait()? {
+            return Err(eyre!(
+                "Native ESDiag server exited ({status}) before becoming ready. Read {} with `esdiag local logs --state-dir {} esdiag`.",
+                self.dir.join("logs/native-serve.log").display(),
+                self.dir.display()
+            ));
+        }
         Ok(())
     }
 
@@ -726,8 +755,22 @@ impl LocalState {
     }
 
     async fn wait_url(&self, url: &str, auth: Option<(&str, &str)>) -> Result<()> {
+        self.wait_url_for_startup(url, auth, None, false).await
+    }
+
+    async fn wait_url_for_startup(
+        &self,
+        url: &str,
+        auth: Option<(&str, &str)>,
+        mut child: Option<&mut Child>,
+        retry_auth: bool,
+    ) -> Result<()> {
         let client = reqwest::Client::builder().timeout(Duration::from_secs(5)).build()?;
+        let mut last_status = None;
         for _ in 0..60 {
+            if let Some(child) = child.as_deref_mut() {
+                self.check_native_child(child)?;
+            }
             let request = client.get(url);
             let request = match auth {
                 Some((username, password)) => request.basic_auth(username, Some(password)),
@@ -735,16 +778,29 @@ impl LocalState {
             };
             if let Ok(response) = request.send().await {
                 let status = response.status();
+                last_status = Some(status);
+                if let Some(child) = child.as_deref_mut() {
+                    self.check_native_child(child)?;
+                }
                 if local_endpoint_ready(status, auth.is_some()) {
                     return Ok(());
                 }
-                if auth.is_some() && matches!(status.as_u16(), 401 | 403) {
+                if !retry_auth && auth.is_some() && matches!(status.as_u16(), 401 | 403) {
                     return Err(eyre!(
                         "Authentication failed at {url} (HTTP {status}); check the retained local credentials."
                     ));
                 }
             }
             tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+        if let Some(child) = child {
+            self.check_native_child(child)?;
+        }
+        if auth.is_some() && last_status.is_some_and(|status| matches!(status.as_u16(), 401 | 403)) {
+            return Err(eyre!(
+                "Timed out waiting for {url}: authentication was still rejected (HTTP {}); check the retained local credentials.",
+                last_status.unwrap()
+            ));
         }
         Err(eyre!("Timed out waiting for {url}"))
     }
@@ -1020,6 +1076,56 @@ fn local_endpoint_ready(status: reqwest::StatusCode, authenticated: bool) -> boo
 #[cfg(test)]
 mod onboarding_recovery_tests {
     use super::*;
+
+    #[tokio::test]
+    async fn startup_retries_authentication_until_security_is_ready() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            for status in ["401 Unauthorized", "200 OK"] {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut buffer = [0; 4096];
+                socket.read(&mut buffer).await.unwrap();
+                socket
+                    .write_all(
+                        format!("HTTP/1.1 {status}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n").as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+            }
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let state = LocalState::load(dir.path().into()).unwrap();
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            state.wait_url_for_startup(&url, Some(("elastic", "test-password")), None, true),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        server.await.unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn startup_reports_native_child_exit_without_waiting_for_http_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = LocalState::load(dir.path().into()).unwrap();
+        let mut child = Command::new("sh").args(["-c", "exit 7"]).spawn().unwrap();
+        child.wait().unwrap();
+        let error = tokio::time::timeout(
+            Duration::from_secs(1),
+            state.wait_url_for_startup("http://127.0.0.1:1", None, Some(&mut child), false),
+        )
+        .await
+        .unwrap()
+        .unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("exit status: 7"));
+        assert!(message.contains("native-serve.log"));
+        assert!(message.contains("local logs --state-dir"));
+    }
 
     #[tokio::test]
     async fn readiness_requests_run_inside_the_async_lifecycle() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -717,6 +717,9 @@ async fn run_local_lifecycle(args: Vec<OsString>) -> Result<CommandResult> {
 }
 
 fn classify_failure(error: &eyre::Report) -> CliFailureCategory {
+    if error.downcast_ref::<esdiag::data::SecretAlreadyExists>().is_some() {
+        return CliFailureCategory::Conflict;
+    }
     if let Some(response) = http_response_details(error) {
         return match response.status {
             401 | 403 => CliFailureCategory::AuthenticationFailed,
@@ -757,6 +760,7 @@ fn safe_failure_message(error: &eyre::Report) -> String {
         };
     }
     match classify_failure(error) {
+        CliFailureCategory::Conflict => "requested resource already exists",
         CliFailureCategory::NotFound => "requested resource was not found",
         CliFailureCategory::AuthenticationFailed => "authentication failed",
         CliFailureCategory::CollectionFailed => "diagnostic collection failed",
@@ -2310,6 +2314,10 @@ async fn run_init_wizard() -> Result<CommandResult> {
                     }
                     return Err(eyre!("Output validation failed. Run `esdiag init` again to resume."));
                 }
+                if !confirm_output_replacement(&output_name, &viewer_name, &secret_id, &keystore_password)? {
+                    println!("Existing output configuration was not changed. Choose an output deployment.");
+                    continue;
+                }
                 break (
                     output_name,
                     output_url,
@@ -2321,7 +2329,6 @@ async fn run_init_wizard() -> Result<CommandResult> {
                     viewer_client,
                 );
             };
-            confirm_output_replacement(&output_name, &viewer_name, &secret_id, &keystore_password)?;
             output_name_for_defaults = Some(output_name.clone());
             output_url_for_defaults = Some(output_url.to_string());
             save_output_deployment(
@@ -2518,7 +2525,7 @@ fn confirm_output_replacement(
     viewer_name: &str,
     secret_id: &str,
     keystore_password: &str,
-) -> Result<()> {
+) -> Result<bool> {
     let hosts = KnownHost::parse_hosts_yml()?;
     let replaces_output = hosts.contains_key(output_name);
     let replaces_viewer = hosts.contains_key(viewer_name);
@@ -2543,11 +2550,9 @@ fn confirm_output_replacement(
         if replaces_default {
             replaced.push("the configured default output".to_string());
         }
-        if !prompt_confirm(&format!("Replace {}? [y/N]: ", replaced.join(", ")))? {
-            return Err(eyre!("Output deployment replacement was declined."));
-        }
+        return prompt_confirm(&format!("Replace {}? [y/N]: ", replaced.join(", ")));
     }
-    Ok(())
+    Ok(true)
 }
 
 fn default_collect_host_name() -> Option<String> {
@@ -2853,30 +2858,29 @@ fn default_esdiag_local_state_dir() -> Option<PathBuf> {
 }
 
 fn prompt_api_key(label: &str, local_preset: Option<&EsdiagLocalPreset>) -> Result<SecretAuth> {
-    let default = if local_preset.and_then(|preset| preset.apikey.as_ref()).is_some() {
-        "3"
-    } else {
-        "4"
-    };
+    let has_local_key = local_preset.and_then(|preset| preset.apikey.as_ref()).is_some();
+    let paste_selection = if has_local_key { "4" } else { "3" };
     loop {
         println!("{label} API key source:");
         println!("  1. Read from a file");
         println!("  2. Read from an environment variable");
-        if default == "3" {
+        if has_local_key {
             println!("  3. Read from detected esdiag-local configuration");
         }
-        println!("  4. Paste securely");
-        let source = prompt_with_default("Selection", default)?;
+        println!("  {paste_selection}. Paste securely");
+        let source = prompt_with_default("Selection", "3")?;
         let apikey = match source.as_str() {
             "1" | "file" => prompt_required("API key file path: ").and_then(|path| read_api_key_file(&path)),
             "2" | "environment" | "env" => {
                 let name = prompt_with_default("API key environment variable", "ESDIAG_OUTPUT_APIKEY")?;
                 std::env::var(&name).map_err(|_| eyre!("{name} is not set"))
             }
+            value if value == paste_selection || value == "paste" => {
+                prompt_missing_secret_value(&format!("Enter {label} API key: "))
+            }
             "3" | "esdiag-local" | "local" => local_preset
                 .and_then(|preset| preset.apikey.clone())
                 .ok_or_else(|| eyre!("No usable ESDiag local API key was detected")),
-            "4" | "paste" => prompt_missing_secret_value(&format!("Enter {label} API key: ")),
             _ => Err(eyre!("Choose one of the listed API key sources")),
         };
         let apikey = match apikey {

--- a/tests/keystore_cli_tests.rs
+++ b/tests/keystore_cli_tests.rs
@@ -196,6 +196,8 @@ fn keystore_add_rejects_duplicate_secret() {
         String::from_utf8_lossy(&second_add.stderr).contains("already exists"),
         "expected duplicate-secret error"
     );
+    let outcome: serde_json::Value = yaml_serde::from_slice(&second_add.stdout).expect("structured failure");
+    assert_eq!(outcome["category"], "conflict");
 
     let secret = get_secret("prod-es", "pw")
         .expect("read secret")


### PR DESCRIPTION
Fixes the remaining onboarding issues from the follow-up validation of issue #75. The local lifecycle now retries transient Elasticsearch authentication failures, isolates managed native-server credentials from ambient ESDIAG variables, and reports early child exits. Endpoint errors, API-key menus, replacement declines, and duplicate keystore conflicts now produce actionable results. Adds Ironhide-verified regression coverage and updates the onboarding documentation.