### PR TITLE
Support installing Kibana assets in the default space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ published release notes, maintenance branches, and tagged history.
 - Changed onboarding to prompt for a diagnostic user without defaulting to the shell username.
 - Changed keystore replacement errors to suggest the `update` command.
 - Changed `esdiag local --help` to list the local-stack commands.
+- Changed Kibana asset setup to honor `ESDIAG_KIBANA_SPACE`, with `_default` selecting the default space and unprefixed API and dashboard URLs.
 - Changed diagnostic platform fields to serialize stable hyphenated platform keys (#347).
 - Changed platform detection to identify Elastic Cloud Hosted bundles from a cluster license issued to `Elastic Cloud`, so API-only hosted bundles no longer report an unknown platform (#347).
 - Changed collection and processing source selection to use canonical registry keys and added a maintainer reconciliation utility for upstream support-diagnostics sources (#348).

--- a/docs/setup/existing-cluster.md
+++ b/docs/setup/existing-cluster.md
@@ -63,6 +63,20 @@ validate the role and resolve its credentials.
 
 ## Install assets
 
+Kibana assets install into the `esdiag` space unless `ESDIAG_KIBANA_SPACE`
+selects another destination. To install into Kibana's default space:
+
+```sh
+ESDIAG_KIBANA_SPACE=_default esdiag setup esdiag-less
+```
+
+Replace `esdiag-less` with your configured deployment or Kibana host name.
+`_default` skips space creation and omits `/s/{space}` from asset requests and
+links. An empty value or Kibana's `default` ID also selects the default space. A named value such as
+`support` installs into that space. An explicit selection overrides a space
+prefix in the configured Kibana URL. Keep the same environment setting when
+running `process`, `serve`, or `agent ask` so their links use that destination.
+
 The output needs ESDiag templates and ingest pipelines:
 
 ```sh

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -51,7 +51,9 @@ impl AgentBuilderLocation {
 
         Self {
             viewer,
-            space: space.or(url_space),
+            space: space
+                .or(url_space)
+                .filter(|s| !s.is_empty() && s != "_default" && s != "default"),
         }
     }
 
@@ -520,6 +522,21 @@ mod tests {
         let location = AgentBuilderLocation::new(Url::parse("https://kb.example").expect("url"), None);
 
         assert_eq!(location.api_path(CONVERSE_PATH), "/api/agent_builder/converse/async");
+    }
+
+    #[test]
+    fn explicit_default_overrides_viewer_space() {
+        for space in ["_default", "", "default"] {
+            let location = AgentBuilderLocation::new(
+                Url::parse("https://kb.example/proxy/s/ops").unwrap(),
+                Some(space.to_string()),
+            );
+            assert_eq!(location.space(), None);
+            assert_eq!(
+                location.api_path("api/agent_builder/agents"),
+                "/proxy/api/agent_builder/agents"
+            );
+        }
     }
 
     #[test]

--- a/src/client/kibana.rs
+++ b/src/client/kibana.rs
@@ -240,6 +240,23 @@ mod tests {
         assert!(!request.contains("/s/marketing/s/marketing/"));
     }
 
+    #[cfg(feature = "setup")]
+    #[tokio::test]
+    async fn default_setup_space_sends_unprefixed_requests_despite_viewer_space() {
+        let request = capture_single_request(|mut url| async move {
+            url.set_path("/s/old-space");
+            let client = KibanaClient::try_new(url, Auth::None).unwrap();
+            let sync = client.sync_client(Vec::new()).unwrap();
+            let default = sync.space("default").unwrap();
+            default
+                .request(Method::GET, &HashMap::new(), "/api/saved_objects/_find", None)
+                .await
+                .unwrap();
+        })
+        .await;
+        assert!(request.starts_with("GET /api/saved_objects/_find HTTP/1.1"));
+    }
+
     #[tokio::test]
     async fn multipart_request_uses_shared_client_form_upload_shape() {
         let request = capture_single_request(|url| async move {

--- a/src/env.rs
+++ b/src/env.rs
@@ -77,12 +77,8 @@ pub fn kibana_url_with_space(kibana_url: &str, space: Option<&str>) -> String {
                     .filter(|segment| !segment.is_empty())
                     .map(str::to_string)
                     .collect::<Vec<_>>();
-                if segments.first().map(String::as_str) == Some("s") {
-                    if let Some(current_space) = segments.get_mut(1) {
-                        *current_space = space.to_string();
-                    } else {
-                        segments.push(space.to_string());
-                    }
+                if let Some(index) = segments.windows(2).rposition(|pair| pair[0] == "s") {
+                    segments[index + 1] = space.to_string();
                 } else {
                     segments.insert(0, space.to_string());
                     segments.insert(0, "s".to_string());
@@ -94,14 +90,18 @@ pub fn kibana_url_with_space(kibana_url: &str, space: Option<&str>) -> String {
         }
         None => {
             if let Ok(mut url) = url::Url::parse(kibana_url) {
-                let path = url.path();
-                if let Some(index) = path.find("/s/") {
-                    let rest = &path[index + 3..];
-                    let path = format!(
-                        "{}{}",
-                        &path[..index],
-                        rest.find('/').map(|i| &rest[i..]).unwrap_or("/")
-                    );
+                let mut segments = url
+                    .path_segments()
+                    .map(|segments| {
+                        segments
+                            .filter(|segment| !segment.is_empty())
+                            .map(str::to_string)
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                if let Some(index) = segments.windows(2).rposition(|pair| pair[0] == "s") {
+                    segments.drain(index..=index + 1);
+                    let path = format!("/{}", segments.join("/"));
                     url.set_path(&path);
                     return url.to_string();
                 }
@@ -167,6 +167,10 @@ mod tests {
         assert_eq!(
             append_kibana_space("https://kb:5601/s/foo/app/home"),
             "https://kb:5601/s/support/app/home"
+        );
+        assert_eq!(
+            append_kibana_space("https://kb:5601/proxy/s/foo/app/home"),
+            "https://kb:5601/proxy/s/support/app/home"
         );
     }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -79,6 +79,8 @@ pub fn kibana_url_with_space(kibana_url: &str, space: Option<&str>) -> String {
                     .collect::<Vec<_>>();
                 if let Some(index) = segments.windows(2).rposition(|pair| pair[0] == "s") {
                     segments[index + 1] = space.to_string();
+                } else if segments.last().map(String::as_str) == Some("s") {
+                    segments.push(space.to_string());
                 } else {
                     let insert_at = segments
                         .iter()
@@ -105,6 +107,11 @@ pub fn kibana_url_with_space(kibana_url: &str, space: Option<&str>) -> String {
                     .unwrap_or_default();
                 if let Some(index) = segments.windows(2).rposition(|pair| pair[0] == "s") {
                     segments.drain(index..=index + 1);
+                    let path = format!("/{}", segments.join("/"));
+                    url.set_path(&path);
+                    return url.to_string();
+                } else if segments.last().map(String::as_str) == Some("s") {
+                    segments.pop();
                     let path = format!("/{}", segments.join("/"));
                     url.set_path(&path);
                     return url.to_string();
@@ -180,6 +187,10 @@ mod tests {
             append_kibana_space("https://kb:5601/proxy/app/home"),
             "https://kb:5601/proxy/s/support/app/home"
         );
+        assert_eq!(
+            append_kibana_space("https://kb:5601/proxy/s"),
+            "https://kb:5601/proxy/s/support"
+        );
     }
 
     #[test]
@@ -206,5 +217,6 @@ mod tests {
             append_kibana_space("https://kb:5601/app/home"),
             "https://kb:5601/app/home"
         );
+        assert_eq!(append_kibana_space("https://kb:5601/proxy/s"), "https://kb:5601/proxy");
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -80,8 +80,12 @@ pub fn kibana_url_with_space(kibana_url: &str, space: Option<&str>) -> String {
                 if let Some(index) = segments.windows(2).rposition(|pair| pair[0] == "s") {
                     segments[index + 1] = space.to_string();
                 } else {
-                    segments.insert(0, space.to_string());
-                    segments.insert(0, "s".to_string());
+                    let insert_at = segments
+                        .iter()
+                        .position(|segment| matches!(segment.as_str(), "app" | "api" | "internal"))
+                        .unwrap_or(segments.len());
+                    segments.insert(insert_at, space.to_string());
+                    segments.insert(insert_at, "s".to_string());
                 }
                 url.set_path(&format!("/{}", segments.join("/")));
                 return url.to_string();
@@ -170,6 +174,10 @@ mod tests {
         );
         assert_eq!(
             append_kibana_space("https://kb:5601/proxy/s/foo/app/home"),
+            "https://kb:5601/proxy/s/support/app/home"
+        );
+        assert_eq!(
+            append_kibana_space("https://kb:5601/proxy/app/home"),
             "https://kb:5601/proxy/s/support/app/home"
         );
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -49,7 +49,7 @@ pub fn get_kibana_space() -> Option<String> {
     match std::env::var("ESDIAG_KIBANA_SPACE") {
         Ok(space) => {
             let trimmed = space.trim();
-            if trimmed.is_empty() {
+            if trimmed.is_empty() || trimmed == "_default" || trimmed == "default" {
                 None
             } else {
                 Some(trimmed.to_string())
@@ -60,8 +60,15 @@ pub fn get_kibana_space() -> Option<String> {
 }
 
 pub fn append_kibana_space(kibana_url: &str) -> String {
+    kibana_url_with_space(kibana_url, get_kibana_space().as_deref())
+}
+
+pub fn kibana_url_with_space(kibana_url: &str, space: Option<&str>) -> String {
     let kibana_url = kibana_url.trim_end_matches('/');
-    match get_kibana_space() {
+    let space = space
+        .map(str::trim)
+        .filter(|s| !s.is_empty() && *s != "_default" && *s != "default");
+    match space {
         Some(space) => {
             if let Ok(mut url) = url::Url::parse(kibana_url)
                 && let Some(existing_segments) = url.path_segments()
@@ -72,12 +79,12 @@ pub fn append_kibana_space(kibana_url: &str) -> String {
                     .collect::<Vec<_>>();
                 if segments.first().map(String::as_str) == Some("s") {
                     if let Some(current_space) = segments.get_mut(1) {
-                        *current_space = space;
+                        *current_space = space.to_string();
                     } else {
-                        segments.push(space);
+                        segments.push(space.to_string());
                     }
                 } else {
-                    segments.insert(0, space);
+                    segments.insert(0, space.to_string());
                     segments.insert(0, "s".to_string());
                 }
                 url.set_path(&format!("/{}", segments.join("/")));
@@ -85,7 +92,22 @@ pub fn append_kibana_space(kibana_url: &str) -> String {
             }
             format!("{kibana_url}/s/{space}")
         }
-        None => kibana_url.to_string(),
+        None => {
+            if let Ok(mut url) = url::Url::parse(kibana_url) {
+                let path = url.path();
+                if let Some(index) = path.find("/s/") {
+                    let rest = &path[index + 3..];
+                    let path = format!(
+                        "{}{}",
+                        &path[..index],
+                        rest.find('/').map(|i| &rest[i..]).unwrap_or("/")
+                    );
+                    url.set_path(&path);
+                    return url.to_string();
+                }
+            }
+            kibana_url.to_string()
+        }
     }
 }
 
@@ -96,6 +118,33 @@ mod tests {
 
     fn env_lock() -> &'static Mutex<()> {
         crate::test_env_lock()
+    }
+
+    #[test]
+    fn explicit_default_space_removes_existing_prefix() {
+        let _guard = env_lock().lock().expect("env lock");
+        let previous = std::env::var_os("ESDIAG_KIBANA_SPACE");
+        for value in ["_default", "", "  _default  ", "default"] {
+            unsafe {
+                std::env::set_var("ESDIAG_KIBANA_SPACE", value);
+            }
+            assert_eq!(get_kibana_space(), None);
+            assert_eq!(
+                append_kibana_space("https://kb/s/ops/app/home?x=1#hash"),
+                "https://kb/app/home?x=1#hash"
+            );
+            assert_eq!(append_kibana_space("https://kb/s/ops"), "https://kb/");
+            assert_eq!(
+                append_kibana_space("https://kb/proxy/s/ops/app/home"),
+                "https://kb/proxy/app/home"
+            );
+        }
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("ESDIAG_KIBANA_SPACE", value),
+                None => std::env::remove_var("ESDIAG_KIBANA_SPACE"),
+            }
+        }
     }
 
     #[test]

--- a/src/local.rs
+++ b/src/local.rs
@@ -356,7 +356,7 @@ impl LocalState {
         let kibana_space = self.required("ESDIAG_KIBANA_SPACE")?;
         self.value(
             "ESDIAG_KIBANA_PUBLIC_URL",
-            &format!("http://127.0.0.1:{kibana_port}/s/{kibana_space}"),
+            &esdiag::env::kibana_url_with_space(&format!("http://127.0.0.1:{kibana_port}"), Some(kibana_space)),
         );
         self.value("LOG_LEVEL", "info");
         self.write_compose(mode)
@@ -383,7 +383,7 @@ impl LocalState {
         let compose = format!(
             "name: esdiag-local\nservices:\n  elasticsearch:\n    image: ${{ELASTICSEARCH_IMAGE}}\n    environment:\n      discovery.type: single-node\n      xpack.security.enabled: \"true\"\n      xpack.security.http.ssl.enabled: \"false\"\n      ELASTIC_PASSWORD: ${{ELASTIC_PASSWORD}}\n    ports: [\"127.0.0.1:${{ESDIAG_ELASTICSEARCH_PORT}}:9200\"]\n    volumes: [\"elasticsearch-data:/usr/share/elasticsearch/data\"]\n  kibana:\n    image: ${{KIBANA_IMAGE}}\n    environment:\n      ELASTICSEARCH_HOSTS: http://elasticsearch:9200\n      ELASTICSEARCH_USERNAME: kibana_system\n      ELASTICSEARCH_PASSWORD: ${{KIBANA_SYSTEM_PASSWORD}}\n      XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY: ${{KIBANA_ENCRYPTION_KEY}}\n    ports: [\"127.0.0.1:${{ESDIAG_KIBANA_PORT}}:5601\"]\n    volumes: [\"kibana-data:/usr/share/kibana/data\"]\n{full_services}volumes:\n  elasticsearch-data:\n  kibana-data:\n{full_volume}",
             full_services = if full {
-                "  setup:\n    image: ${ESDIAG_IMAGE}\n    profiles: [\"setup\"]\n    environment:\n      ESDIAG_OUTPUT_URL: http://elasticsearch:9200\n      ESDIAG_OUTPUT_APIKEY: ${ESDIAG_OUTPUT_APIKEY}\n      ESDIAG_KIBANA_URL: http://kibana:5601/s/${ESDIAG_KIBANA_SPACE}\n    command: [\"setup\"]\n  esdiag:\n    image: ${ESDIAG_IMAGE}\n    environment:\n      ESDIAG_MODE: user\n      ESDIAG_CONTAINER_LOCAL_STACK: full\n      ESDIAG_OUTPUT_URL: http://elasticsearch:9200\n      ESDIAG_OUTPUT_APIKEY: ${ESDIAG_OUTPUT_APIKEY}\n      ESDIAG_KIBANA_URL: http://kibana:5601/s/${ESDIAG_KIBANA_SPACE}\n      ESDIAG_KIBANA_INTERNAL_URL: http://kibana:5601/s/${ESDIAG_KIBANA_SPACE}\n      ESDIAG_KIBANA_PUBLIC_URL: ${ESDIAG_KIBANA_PUBLIC_URL}\n    command: [\"serve\"]\n    ports: [\"127.0.0.1:${ESDIAG_PORT}:2501\"]\n    volumes: [\"esdiag-data:/root/.esdiag\"]\n"
+                "  setup:\n    image: ${ESDIAG_IMAGE}\n    profiles: [\"setup\"]\n    environment:\n      ESDIAG_OUTPUT_URL: http://elasticsearch:9200\n      ESDIAG_OUTPUT_APIKEY: ${ESDIAG_OUTPUT_APIKEY}\n      ESDIAG_KIBANA_SPACE: ${ESDIAG_KIBANA_SPACE}\n      ESDIAG_KIBANA_URL: http://kibana:5601\n    command: [\"setup\"]\n  esdiag:\n    image: ${ESDIAG_IMAGE}\n    environment:\n      ESDIAG_MODE: user\n      ESDIAG_CONTAINER_LOCAL_STACK: full\n      ESDIAG_OUTPUT_URL: http://elasticsearch:9200\n      ESDIAG_OUTPUT_APIKEY: ${ESDIAG_OUTPUT_APIKEY}\n      ESDIAG_KIBANA_SPACE: ${ESDIAG_KIBANA_SPACE}\n      ESDIAG_KIBANA_URL: http://kibana:5601\n      ESDIAG_KIBANA_INTERNAL_URL: http://kibana:5601\n      ESDIAG_KIBANA_PUBLIC_URL: ${ESDIAG_KIBANA_PUBLIC_URL}\n    command: [\"serve\"]\n    ports: [\"127.0.0.1:${ESDIAG_PORT}:2501\"]\n    volumes: [\"esdiag-data:/root/.esdiag\"]\n"
             } else {
                 ""
             },
@@ -763,10 +763,12 @@ impl LocalState {
         )
     }
     fn kibana_url(&self) -> String {
-        format!(
-            "http://127.0.0.1:{}/s/{}",
-            self.required("ESDIAG_KIBANA_PORT").unwrap_or("5601"),
-            self.required("ESDIAG_KIBANA_SPACE").unwrap_or("esdiag")
+        esdiag::env::kibana_url_with_space(
+            &format!(
+                "http://127.0.0.1:{}",
+                self.required("ESDIAG_KIBANA_PORT").unwrap_or("5601")
+            ),
+            Some(self.required("ESDIAG_KIBANA_SPACE").unwrap_or("esdiag")),
         )
     }
     fn esdiag_url(&self) -> String {
@@ -943,6 +945,20 @@ mod tests {
             state.resolve_mode(StackMode::Auto).expect("resolve mode"),
             StackMode::Core
         );
+    }
+
+    #[test]
+    fn default_space_local_urls_and_containers_use_explicit_selection() {
+        let (directory, mut state) = state();
+        state.values.insert("ESDIAG_KIBANA_SPACE".into(), "_default".into());
+        assert_eq!(state.kibana_url(), "http://127.0.0.1:5601");
+        state.write_compose(StackMode::Full).unwrap();
+        let compose = fs::read_to_string(directory.path().join("compose.yml")).unwrap();
+        assert_eq!(
+            compose.matches("ESDIAG_KIBANA_SPACE: ${ESDIAG_KIBANA_SPACE}").count(),
+            2
+        );
+        assert!(!compose.contains("/s/${ESDIAG_KIBANA_SPACE}"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3042,7 +3042,7 @@ fn agent_builder_space(viewer: &Url) -> Option<String> {
     match std::env::var("ESDIAG_KIBANA_SPACE") {
         Ok(space) => {
             let space = space.trim();
-            (!space.is_empty()).then(|| space.to_string())
+            Some(if space.is_empty() { "_default" } else { space }.to_string())
         }
         Err(std::env::VarError::NotPresent) => {
             let viewer_has_space = viewer.path_segments().is_some_and(|mut segments| {
@@ -3621,6 +3621,28 @@ mod tests {
             agent_builder_space(&Url::parse("https://kb.example/app/s/support").expect("url")),
             None
         );
+    }
+
+    #[cfg(feature = "agent")]
+    #[test]
+    fn agent_builder_space_explicit_default_overrides_url() {
+        let _guard = env_lock().lock().expect("env lock");
+        let previous = std::env::var_os("ESDIAG_KIBANA_SPACE");
+        let viewer = Url::parse("https://kb.example/s/support").unwrap();
+        for value in ["_default", "", "  _default  "] {
+            unsafe {
+                std::env::set_var("ESDIAG_KIBANA_SPACE", value);
+            }
+            let location =
+                esdiag::agent::builder::AgentBuilderLocation::new(viewer.clone(), agent_builder_space(&viewer));
+            assert_eq!(location.space(), None);
+        }
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("ESDIAG_KIBANA_SPACE", value),
+                None => std::env::remove_var("ESDIAG_KIBANA_SPACE"),
+            }
+        }
     }
 
     #[cfg(feature = "agent")]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -569,6 +569,7 @@ fn agent_builder_license_is_active(response: &Value) -> bool {
 
 async fn kibana_assets(client: &Client, embedded_assets: &EmbeddedAssets) -> Result<()> {
     let mut bundle = kibana_bundle(embedded_assets)?.read_all()?;
+    target_kibana_bundle(&mut bundle, crate::env::get_kibana_space().as_deref())?;
     if client.is_serverless().await? {
         adapt_serverless_kibana_bundle(&mut bundle);
     }
@@ -614,6 +615,51 @@ async fn kibana_assets(client: &Client, embedded_assets: &EmbeddedAssets) -> Res
 
     tracing::info!("completed setup for {client}");
     Ok(())
+}
+
+fn target_kibana_bundle(bundle: &mut SyncBundle, space: Option<&str>) -> Result<()> {
+    let target = space.unwrap_or("default");
+    if target == "esdiag" {
+        return Ok(());
+    }
+    if bundle.by_space.len() != 1 || !bundle.by_space.contains_key("esdiag") {
+        return Err(eyre!(
+            "Expected a single esdiag asset space before selecting a destination"
+        ));
+    }
+    let mut assets = bundle.by_space.remove("esdiag").expect("checked asset space");
+    let prefix = space
+        .map(|s| format!("/s/{}", urlencoding::encode(s)))
+        .unwrap_or_default();
+    for value in assets
+        .saved_objects
+        .iter_mut()
+        .chain(&mut assets.workflows)
+        .chain(&mut assets.agents)
+        .chain(&mut assets.tools)
+        .chain(&mut assets.skills)
+    {
+        rewrite_kibana_asset_links(value, &prefix);
+    }
+    bundle.by_space.insert(target.to_string(), assets);
+    if space.is_none() {
+        bundle.spaces.clear();
+    } else {
+        for definition in &mut bundle.spaces {
+            definition["id"] = Value::String(target.to_string());
+            definition["name"] = Value::String(target.to_string());
+        }
+    }
+    Ok(())
+}
+
+fn rewrite_kibana_asset_links(value: &mut Value, prefix: &str) {
+    match value {
+        Value::String(text) => *text = text.replace("/s/esdiag/", &format!("{prefix}/")),
+        Value::Array(values) => values.iter_mut().for_each(|v| rewrite_kibana_asset_links(v, prefix)),
+        Value::Object(values) => values.values_mut().for_each(|v| rewrite_kibana_asset_links(v, prefix)),
+        _ => {}
+    }
 }
 
 fn adapt_serverless_kibana_bundle(bundle: &mut SyncBundle) {
@@ -745,7 +791,7 @@ async fn attach_skills_to_default_agent(client: &Client, space_id: &str, skill_i
     if skill_ids.is_empty() {
         return Ok(());
     }
-    let path = format!("s/{space_id}/api/agent_builder/agents/elastic-ai-agent");
+    let path = default_agent_path(space_id);
     let response = client.request(Method::GET, &HashMap::new(), &path, None).await?;
     let status = response.status();
     if !status.is_success() {
@@ -757,6 +803,15 @@ async fn attach_skills_to_default_agent(client: &Client, space_id: &str, skill_i
     let agent: Value = response.json().await?;
     let update = default_agent_skill_update(agent, skill_ids)?;
     send_kibana_json_with_method(client, Method::PUT, &path, &update, false).await
+}
+
+fn default_agent_path(space_id: &str) -> String {
+    let endpoint = "api/agent_builder/agents/elastic-ai-agent";
+    if space_id == "default" {
+        endpoint.to_string()
+    } else {
+        format!("s/{}/{endpoint}", urlencoding::encode(space_id))
+    }
 }
 
 fn default_agent_skill_update(mut agent: Value, skill_ids: &[String]) -> Result<Value> {

--- a/src/setup/serverless_tests.rs
+++ b/src/setup/serverless_tests.rs
@@ -6,6 +6,59 @@ use super::*;
 use std::collections::BTreeSet;
 
 #[test]
+fn kibana_setup_targets_default_and_named_spaces_without_losing_assets() {
+    let original = kibana_bundle(&EmbeddedAssets::new().unwrap())
+        .unwrap()
+        .read_all()
+        .unwrap();
+    for target in [None, Some("support"), Some("esdiag")] {
+        let mut bundle = original.clone();
+        target_kibana_bundle(&mut bundle, target).unwrap();
+        let destination = target.unwrap_or("default");
+        assert_eq!(bundle.by_space.len(), 1);
+        let assets = &bundle.by_space[destination];
+        let source = &original.by_space["esdiag"];
+        assert_eq!(assets.saved_objects.len(), source.saved_objects.len());
+        assert_eq!(assets.workflows.len(), source.workflows.len());
+        assert_eq!(assets.agents.len(), source.agents.len());
+        assert_eq!(assets.tools.len(), source.tools.len());
+        assert_eq!(assets.skills.len(), source.skills.len());
+        if target.is_none() {
+            assert!(bundle.spaces.is_empty());
+            assert_eq!(
+                default_agent_path(destination),
+                "api/agent_builder/agents/elastic-ai-agent"
+            );
+        } else {
+            assert_eq!(bundle.spaces[0]["id"], destination);
+            assert_eq!(
+                default_agent_path(destination),
+                format!("s/{destination}/api/agent_builder/agents/elastic-ai-agent")
+            );
+        }
+        if destination != "esdiag" {
+            for value in assets
+                .saved_objects
+                .iter()
+                .chain(&assets.workflows)
+                .chain(&assets.agents)
+                .chain(&assets.tools)
+                .chain(&assets.skills)
+            {
+                assert!(!value.to_string().contains("/s/esdiag/"));
+            }
+            let skill_text = serde_json::to_string(&assets.skills).unwrap();
+            let expected = target
+                .map(|space| format!("/s/{space}/app/dashboards"))
+                .unwrap_or_else(|| "/app/dashboards".to_string());
+            assert!(skill_text.contains(&expected));
+        } else {
+            assert_eq!(bundle, original);
+        }
+    }
+}
+
+#[test]
 fn default_agent_update_preserves_configuration_without_echoing_read_only_fields() {
     let original = serde_json::json!({
         "id": "elastic-ai-agent", "readonly": true,


### PR DESCRIPTION
Problem: Kibana setup could not install bundled assets into Kibana's default space. It always targeted `esdiag`, and generated links retained the `/s/esdiag` prefix.

Change: Add explicit `_default` handling for `ESDIAG_KIBANA_SPACE`. Setup now remaps bundled assets to the default space, omits space URL prefixes, preserves named-space behavior, and updates local-stack URLs and Agent Builder links.

Validation:
- `cargo fmt --check`
- `cargo test --lib`
- `cargo test --bin esdiag`
- `git diff --check`
